### PR TITLE
Fix Pages deploy: clear partial puppeteer cache before install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Install Puppeteer Browsers
-        run: npm exec -- puppeteer browsers install chrome
+        run: |
+          # clear any partial download left by npm postinstall, then fetch a clean copy
+          rm -rf ~/.cache/puppeteer
+          npm exec -- puppeteer browsers install chrome
       - name: Build
         run: npm run build
         env:


### PR DESCRIPTION
Pages deploys have been failing since May 27 with:

```
Error: All providers failed for chrome …: The browser folder exists but the executable is missing
```

npm's postinstall leaves a partial chrome download; the explicit `puppeteer browsers install chrome` step then sees the folder and refuses to re-download. Clearing `~/.cache/puppeteer` first forces a clean fetch.

This also unblocks deploying #63 (Aaria's Block Craft 3D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)