### PR TITLE
Fix Pages deploy: run puppeteer installer directly + verify chrome

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,9 +37,11 @@ jobs:
         run: npm ci
       - name: Install Puppeteer Browsers
         run: |
-          # clear any partial download left by npm postinstall, then fetch a clean copy
+          # clear any partial download, then run puppeteer's own installer and
+          # fail fast here (not in prerender) if chrome still isn't usable
           rm -rf ~/.cache/puppeteer
-          npm exec -- puppeteer browsers install chrome
+          node node_modules/puppeteer/install.mjs
+          node -e "console.log('chrome at:', require('puppeteer').executablePath())"
       - name: Build
         run: npm run build
         env:


### PR DESCRIPTION
Follow-up to #64 — the `npm exec -- puppeteer browsers install chrome` step exits 0 in ~1.4s **without downloading anything** (see run logs), so prerender still fails with *Could not find Chrome (ver. 146.0.7680.31)*.

This change:
1. Runs `node node_modules/puppeteer/install.mjs` (puppeteer's own postinstall) — deterministic download of the pinned browser into the cache
2. Asserts `require('puppeteer').executablePath()` resolves, so any future install problem fails **this step** with a clear error instead of surfacing later in prerender

Unblocks deploying #63 (Aaria's Block Craft 3D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)