### PR TITLE
Use runner's preinstalled Chrome for prerender (fixes deploys)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,16 +35,17 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
-      - name: Install Puppeteer Browsers
+        env:
+          # prerender uses the runner's preinstalled Chrome — skip puppeteer's flaky download
+          PUPPETEER_SKIP_DOWNLOAD: 'true'
+      - name: Verify system Chrome for prerender
         run: |
-          # clear any partial download, then run puppeteer's own installer and
-          # fail fast here (not in prerender) if chrome still isn't usable
-          rm -rf ~/.cache/puppeteer
-          node node_modules/puppeteer/install.mjs
-          node -e "console.log('chrome at:', require('puppeteer').executablePath())"
+          which google-chrome
+          google-chrome --version
       - name: Build
         run: npm run build
         env:
+          PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL || secrets.NEXT_PUBLIC_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY || secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || secrets.VITE_SUPABASE_URL }}


### PR DESCRIPTION
Third time's the charm. #64/#65 showed puppeteer's downloader silently fails to materialize the chrome binary on the Pages runner (`executablePath()` resolves a path, but `launch()` finds nothing there).

This removes the download from the equation entirely:
- `PUPPETEER_SKIP_DOWNLOAD=true` during `npm ci` (faster, no partial caches)
- New step asserts `google-chrome` exists on the runner (fails fast with a clear message if GitHub ever removes it)
- `PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome` on the Build step — puppeteer 24 honors this env var (verified locally)

Unblocks #63 (Aaria's Block Craft 3D) and all future deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)