### PR TITLE
Block Craft: daily quests, animal requests, sentence builder, show & tell

### DIFF
--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -47,9 +47,9 @@
   #scoreBar { position:absolute; top:12px; left:12px; display:flex; gap:10px; }
   .scoreChip { background:rgba(255,255,255,.88); border-radius:20px; padding:8px 16px; font-size:20px;
     box-shadow:0 3px 8px rgba(0,0,0,.18); color:#333; }
-  #portalChip { pointer-events:auto; cursor:pointer; }
-  #portalChip:hover { transform:scale(1.07); }
-  #portalChip.portalReady { background:linear-gradient(90deg,#d0bfff,#a5d8ff); animation:pulseChip 1.2s infinite; }
+  #portalChip, #questChip { pointer-events:auto; cursor:pointer; }
+  #portalChip:hover, #questChip:hover { transform:scale(1.07); }
+  #portalChip.portalReady, #questChip.portalReady { background:linear-gradient(90deg,#d0bfff,#a5d8ff); animation:pulseChip 1.2s infinite; }
   @keyframes pulseChip { 0%,100%{transform:scale(1)} 50%{transform:scale(1.1)} }
   #flash { position:fixed; inset:0; z-index:90; background:#fff; display:none; pointer-events:none; }
   #menuBar { position:absolute; top:12px; right:12px; display:flex; gap:8px; pointer-events:auto; }
@@ -173,6 +173,7 @@
     <div class="scoreChip" id="starChip">⭐ 0</div>
     <div class="scoreChip" id="heartChip">💖 0</div>
     <div class="scoreChip" id="portalChip" title="Word power opens the wormhole!">🌀 0/5</div>
+    <div class="scoreChip" id="questChip" title="Today's Adventures">📋 0/3</div>
   </div>
   <div id="menuBar">
     <button class="menuBtn" id="buildMenuBtn">🏗️ Build</button>

--- a/public/blockcraft/js/activities.js
+++ b/public/blockcraft/js/activities.js
@@ -117,6 +117,7 @@ ABC.activities = (function () {
     const p = prompts.stages[a.stageIdx];
     setTimeout(() => {
       ui().askExpressive(p, () => {
+        ABC.quests.mark('build');
         if (a.stageIdx === a.bp.stages.length - 1) nextStage();   // triggers complete
         else nextStage();
       }, { stars: 2 });
@@ -218,11 +219,13 @@ ABC.activities = (function () {
   function talkToAnimal(a) {
     if (a.isGuide) { bellaChat(a); return; }
     if (!a.emotion) {
-      // friendly hello + describing prompt about the animal itself
+      // half the time the animal has a treasure — practice ASKING for it!
+      if (Math.random() < 0.5) { animalRequest(a); return; }
+      // otherwise: friendly hello + describing prompt about the animal
       const d = a.def;
       ui().askExpressive({
         emoji: d.emoji,
-        scene: `You walked up to ${a.name} the ${d.label}! ${a.name} looks at you with friendly eyes. What can you tell me about ${a.name}?`,
+        scene: `${a.name} the ${d.label} looks at you with friendly eyes. What can you tell me about ${a.name}?`,
         options: [
           { t: describeAnimal(a), q: 'best' },
           { t: d.label + '.', q: 'name' },
@@ -251,10 +254,29 @@ ABC.activities = (function () {
             ABC.audio.sfx.munch();
             ui().confetti(16);
             ui().addHearts(1);
+            ABC.quests.mark('animal');
             ui().toast('💖 ' + fillTpl(k.say, a), 5000, true);
           }, '💖');
       }, 400);
     }, { stars: 1 });
+  }
+
+  /* the animal found something — asking nicely gets it! (requesting practice) */
+  function animalRequest(a) {
+    const want = ui().pick(ABC.ANIMAL_WANTS);
+    ui().askExpressive({
+      emoji: a.def.emoji + want.ico,
+      scene: `${a.name} the ${a.def.label} found ${want.word}! ${want.ico} How do we ask for it nicely?`,
+      options: [
+        { t: `Can I have ${want.word}, please?`, q: 'best' },
+        { t: 'Give.', q: 'name' },
+        { t: 'The door is open.', q: 'off' } ],
+    }, () => {
+      ABC.animals.celebrate(a, performance.now() / 1000);
+      ui().confetti(14);
+      ui().addStars(1);   // bonus on top of the expressive star
+      ui().toast(`${want.ico} ${a.name} happily shares ${want.word} with you! Asking nicely is magic! 💖`, 4600, true);
+    });
   }
 
   function describeAnimal(a) {
@@ -332,6 +354,7 @@ ABC.activities = (function () {
             ui().unlockBlock(color.key);
             const p = spotInFront(3);
             ABC.squishy.spawn({ kind:'slime', color: color.key, mixin: mixin.label, x: p.x, z: p.z });
+            ABC.quests.mark('words');
             ABC.saveSoon && ABC.saveSoon();
             ui().bellaSays(`Your pet slime is wiggling right there! Poke it to squish it! 🫧`, 5000);
           }, { stars: 2 });
@@ -397,12 +420,88 @@ ABC.activities = (function () {
             ui().unlockBlock(blockId);
             const p = spotInFront(3);
             ABC.squishy.spawn({ kind:'oreo', cream: cream.label, topping: topping.label, x: p.x, z: p.z });
+            ABC.quests.mark('words');
             ABC.saveSoon && ABC.saveSoon();
             ui().bellaSays('Your giant Oreo is on the ground! Poke it, squish it, or carry it home! 🍪', 5000);
           }, { stars: 2 });
         }, 600);
       }
     };
+  }
+
+  /* =====================================================
+     TODAY'S ADVENTURES 📋 — 3 focus quests per day
+     ===================================================== */
+  ABC.quests = (function () {
+    const todayKey = () => new Date().toISOString().slice(0, 10);
+    function state() {
+      let q = ABC.state.quests;
+      if (!q || q.date !== todayKey()) {
+        q = ABC.state.quests = { date: todayKey(), done: {}, celebrated: false };
+      }
+      return q;
+    }
+    function allDone() { return ABC.QUEST_DEFS.every(d => state().done[d.key]); }
+    function refreshChip() {
+      const chip = document.getElementById('questChip');
+      if (!chip) return;
+      const n = ABC.QUEST_DEFS.filter(d => state().done[d.key]).length;
+      chip.textContent = '📋 ' + n + '/' + ABC.QUEST_DEFS.length;
+      chip.classList.toggle('portalReady', allDone());
+    }
+    function mark(key) {
+      const q = state();
+      if (q.done[key]) return;
+      q.done[key] = true;
+      refreshChip();
+      ABC.saveSoon && ABC.saveSoon();
+      const def = ABC.QUEST_DEFS.find(d => d.key === key);
+      ui().toast(`📋 Adventure done: ${def.ico} ${def.label}!`, 3600, true);
+      if (allDone() && !q.celebrated) {
+        q.celebrated = true;
+        ABC.saveSoon && ABC.saveSoon();
+        setTimeout(() => {
+          ui().confetti(80);
+          ABC.audio.sfx.fanfare();
+          ui().addStars(5);
+          ABC.portal.charge(2);
+          ui().bellaSays('ALL of today’s adventures are DONE! You are a superstar, {player}! 🎆⭐', 6500);
+        }, 1200);
+      }
+    }
+    function showBoard() {
+      const q = state();
+      let html = `<div class="bigEmoji">📋</div><h2>Today's Adventures</h2>
+        <div class="scene">Three special things to do today!</div>`;
+      ABC.QUEST_DEFS.forEach(d => {
+        const done = !!q.done[d.key];
+        html += `<div class="sentenceCard" style="display:flex; align-items:center; gap:12px; ${done ? 'opacity:.65; border-style:solid; border-color:#51cf66;' : ''}">
+          <span style="font-size:30px;">${done ? '✅' : d.ico}</span>
+          <span style="flex:1; text-align:left;">${d.label}</span></div>`;
+      });
+      html += `<div class="dlgRow"><button class="bigBtn green" id="qbOk">${allDone() ? 'All done! 🎆' : 'Let’s go! 🚀'}</button></div>`;
+      ABC.ui.openDialog(html);
+      ABC.audio.say(allDone() ? 'All adventures done! Amazing!' : 'Here are today’s three adventures!');
+      document.getElementById('qbOk').onclick = () => ABC.ui.closeDialog();
+    }
+    return { mark, showBoard, refreshChip, state };
+  })();
+
+  /* =====================================================
+     SHOW & TELL 🧩 — describe your own creations
+     ===================================================== */
+  let lastShowTell = 0;
+  function initShowTell(count) { lastShowTell = count || 0; }
+  function maybeShowTell(placedCount) {
+    if (placedCount - lastShowTell < 25) return;
+    lastShowTell = placedCount;
+    const sentence = ui().pick(ABC.SHOWTELL_SENTENCES);
+    setTimeout(() => {
+      if (ABC.ui.isOpen()) return;
+      ui().askBuilder(
+        'WOW, {player}! Look at what you are building! Tell me about it — tap the words in order:',
+        sentence, null, { emoji: '🏗️✨', stars: 2 });
+    }, 600);
   }
 
   /* =====================================================
@@ -445,11 +544,12 @@ ABC.activities = (function () {
       ui().confetti(30);
       ui().addHearts(2);
       ABC.portal.charge(2);   // real-world words are SUPER word power
+      ABC.quests.mark('words');
       ui().bellaSays(`You used your words with ${who.label}! That is real magic! 💖🌀`, 5500);
     };
   }
 
   return { showBuildMenu, tryFillGhost, magicFill, quitProject, talkToAnimal,
-           emotionTick, slimeLab, oreoKitchen, kindWords,
+           emotionTick, slimeLab, oreoKitchen, kindWords, maybeShowTell, initShowTell,
            hasActiveProject: () => !!active };
 })();

--- a/public/blockcraft/js/data.js
+++ b/public/blockcraft/js/data.js
@@ -404,6 +404,31 @@ ABC.MISSION_PHRASES = [
   'I am feeling a little tired.', 'Look, I made a giant Oreo!',
 ];
 
+/* Animals sometimes have something — practice ASKING for it (requesting) 🥕 */
+ABC.ANIMAL_WANTS = [
+  { ico:'🥕', word:'the crunchy carrot' },
+  { ico:'🍎', word:'the juicy red apple' },
+  { ico:'🎾', word:'the bouncy ball' },
+  { ico:'🌸', word:'the pretty flower' },
+  { ico:'🍪', word:'a yummy cookie' },
+  { ico:'🫧', word:'the shiny bubbles' },
+];
+
+/* Show & Tell sentences (assembled word-by-word in the Sentence Builder) */
+ABC.SHOWTELL_SENTENCES = [
+  'I built something amazing all by myself!',
+  'Look at my big colorful creation!',
+  'I made this with my own two hands!',
+  'My building is tall and super cool!',
+];
+
+/* Today's Adventures — 3 focus quests per day 📋 */
+ABC.QUEST_DEFS = [
+  { key:'build',  ico:'🏗️', label:'Finish one build stage' },
+  { key:'animal', ico:'💖', label:'Help an animal friend feel better' },
+  { key:'words',  ico:'💬', label:'Do Kind Words, Slime Lab or Oreo Kitchen' },
+];
+
 /* Wormhole portal — the reward for using expressive language 🌀 */
 ABC.PORTAL = {
   NEED: 5,                                  // expressive successes to open it

--- a/public/blockcraft/js/main.js
+++ b/public/blockcraft/js/main.js
@@ -190,6 +190,8 @@
             p.y + 1 > feet.y && p.y < feet.y + 1.8) return;
         if (ABC.world.set(p.x, p.y, p.z, ABC.ui.getSelected())) {
           ABC.world.flush(); ABC.audio.sfx.pop(); saveSoon();
+          ABC.state.placedCount = (ABC.state.placedCount || 0) + 1;
+          ABC.activities.maybeShowTell(ABC.state.placedCount);   // Show & Tell moments
         }
       }
     }
@@ -388,6 +390,8 @@
         squishies: ABC.squishy.serialize(),
         playerName: ABC.state.playerName,
         portalCharge: ABC.state.portalCharge || 0,
+        quests: ABC.state.quests || null,
+        placedCount: ABC.state.placedCount || 0,
         stars: ABC.state.stars, hearts: ABC.state.hearts,
         unlocked: [...ABC.state.unlocked], completed: [...ABC.state.completed],
         tutorialDone: ABC.state.tutorialDone,
@@ -408,6 +412,8 @@
       ABC.squishy.deserialize(d.squishies);
       if (d.playerName) ABC.state.playerName = d.playerName;
       ABC.state.portalCharge = d.portalCharge || 0;
+      ABC.state.quests = d.quests || null;
+      ABC.state.placedCount = d.placedCount || 0;
       ABC.state.stars = d.stars || 0;
       ABC.state.hearts = d.hearts || 0;
       (d.unlocked || []).forEach(b => ABC.state.unlocked.add(b));
@@ -429,6 +435,7 @@
   $('quitProjBtn').onclick = () => ABC.activities.quitProject();
   $('viewBtn').onclick     = () => toggleView();
   $('portalChip').onclick  = () => ABC.portal.findPortal();
+  $('questChip').onclick   = () => ABC.quests.showBoard();
 
   /* full screen — works standalone and inside the dashboard iframe */
   function toggleFullscreen() {
@@ -475,6 +482,8 @@
     refreshHand();
     ABC.ui.refreshScore();
     ABC.portal.refreshChip();
+    ABC.quests.refreshChip();
+    ABC.activities.initShowTell(ABC.state.placedCount || 0);
     started = true;
     saveSoon();
     setTimeout(() => { $('lookHint').style.display = 'none'; }, 9000);
@@ -488,6 +497,8 @@
       }, 900);
     } else {
       ABC.ui.bellaSays('Welcome back, {player}! Your world missed you! 💙', 4500);
+      // show today's three adventures for a focused start
+      setTimeout(() => { if (!ABC.ui.isOpen()) ABC.quests.showBoard(); }, 5500);
     }
   };
   $('howBtn').onclick = () => ABC.ui.showHelp();

--- a/public/blockcraft/js/ui.js
+++ b/public/blockcraft/js/ui.js
@@ -259,6 +259,65 @@ ABC.ui = (function () {
     return hits / t.length >= 0.45;
   }
 
+  /* ============================================================
+     SENTENCE BUILDER — assemble the sentence word by word 🧩
+     A step from picking sentences toward producing them.
+     ============================================================ */
+  function askBuilder(sceneText, sentence, onSuccess, opts) {
+    opts = opts || {};
+    sceneText = ABC.tpl(sceneText); sentence = ABC.tpl(sentence);
+    const words = sentence.split(' ');
+    let next = 0;
+    const order = shuffle(words.map((w, i) => ({ w, i })));
+    let html = `<div class="bigEmoji">${opts.emoji || '🧩'}</div>
+      <h2>Build the Sentence!</h2>
+      <div class="scene">${sceneText} <span class="speakIco" id="sbHear">🔊</span></div>
+      <div class="sentenceCard" id="sbTarget" style="min-height:58px;">&nbsp;</div>
+      <div class="pickGrid" id="sbChips">`;
+    order.forEach((o, k) => {
+      html += `<button class="pickCard sbChip" data-i="${o.i}" style="width:auto; padding:10px 16px; font-size:19px;">${esc(o.w)}</button>`;
+    });
+    html += '</div>';
+    openDialog(html);
+    ABC.audio.say(sceneText + ' ... Tap the words in order: ' + sentence);
+    $('sbHear').onclick = () => ABC.audio.say(sentence, { force: true });
+
+    let missCount = 0;
+    box().querySelectorAll('.sbChip').forEach(chip => {
+      chip.addEventListener('click', () => {
+        const i = +chip.dataset.i;
+        if (i === next) {
+          chip.style.visibility = 'hidden';
+          next++;
+          $('sbTarget').textContent = words.slice(0, next).join(' ');
+          ABC.audio.sfx.pop();
+          ABC.audio.say(words[i], { force: true });
+          if (next >= words.length) {
+            ABC.audio.sfx.ding();
+            setTimeout(() => {
+              ABC.audio.say(sentence, { force: true });
+              closeDialog();
+              confetti(20);
+              addStars(opts.stars != null ? opts.stars : 2);
+              ABC.portal && ABC.portal.charge(1);
+              toast('🧩 ' + pick(ABC.PRAISE), 3600);
+              onSuccess && onSuccess();
+            }, 500);
+          }
+        } else {
+          ABC.audio.sfx.gentle();
+          chip.style.transform = 'rotate(-5deg)';
+          setTimeout(() => { chip.style.transform = ''; }, 250);
+          // gentle hint: glow the right chip after 2 misses
+          if (++missCount >= 2) {
+            const hint = box().querySelector(`.sbChip[data-i="${next}"]`);
+            if (hint) hint.style.boxShadow = '0 0 0 4px #ffd43b';
+          }
+        }
+      });
+    });
+  }
+
   /* ---------------- pick-a-card helper (for slime/oreo/kind acts) ---------------- */
   function pickCard(title, sceneText, cards, onPick, emoji) {
     sceneText = ABC.tpl(sceneText);
@@ -380,7 +439,7 @@ ABC.ui = (function () {
   }
 
   return { openDialog, closeDialog, isOpen, toast, bellaSays, confetti, floatHearts,
-           refreshScore, addStars, addHearts, askExpressive, pickCard, message,
+           refreshScore, addStars, addHearts, askExpressive, askBuilder, pickCard, message,
            buildHotbar, selectBlock, selectByIndex, getSelected, unlockBlock,
            showSettings, showHelp, pick, pick3, esc };
 })();


### PR DESCRIPTION
Gives the game **focus** and **more reasons to use words**:

- 📋 **Today's Adventures** — exactly 3 picture quests per day (finish a build stage / help an animal / kind words or kitchen-lab). Chip in the HUD shows progress; finishing all 3 triggers fireworks + bonus stars. Board pops up at session start for a structured beginning.
- 🥕 **Animal request exchanges** — animals find treasures; the child must *ask nicely* ("Can I have the crunchy carrot, please?") to get them. Requesting is the most functional expressive skill.
- 🧩 **Sentence Builder** — assemble sentences word-by-word from shuffled chips, with the right chip glowing after two misses. A scaffolded step from sentence-picking toward sentence production.
- 🏗️✨ **Show & Tell** — after ~25 self-placed blocks, Bella asks the child to tell about *their own* creation using the Sentence Builder. Their builds become the reason to talk.

Static game files only (`public/blockcraft/`) — no site code changes. Verified error-free boot in headless Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)