### PR TITLE
Block Craft: soft-body slime, cookie cutters, school bag, shaped blocks

### DIFF
--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -125,6 +125,9 @@
     cursor:pointer; font-family:inherit; font-size:15px; transition:transform .1s; color:#234; }
   .pickCard:hover { transform:scale(1.07); border-color:#74c0fc; background:#e7f5ff; }
   .pickCard .ico { font-size:38px; display:block; margin-bottom:4px; }
+  .bagSection { font-size:18px; font-weight:bold; color:#1d4ed8; margin:14px 0 4px;
+    border-bottom:2px dashed #cde; padding-bottom:4px; text-align:left; }
+  .bagItem { width:104px; font-size:13px; line-height:1.3; }
   #micCircle { width:92px; height:92px; border-radius:50%; margin:10px auto; font-size:42px; border:none;
     cursor:pointer; background:linear-gradient(180deg,#ff8787,#fa5252); color:#fff;
     box-shadow:0 5px 0 #c92a2a; }
@@ -176,6 +179,7 @@
     <div class="scoreChip" id="questChip" title="Today's Adventures">📋 0/3</div>
   </div>
   <div id="menuBar">
+    <button class="menuBtn" id="bagBtn">🎒 Bag</button>
     <button class="menuBtn" id="buildMenuBtn">🏗️ Build</button>
     <button class="menuBtn" id="slimeBtn">🌈 Slime Lab</button>
     <button class="menuBtn" id="oreoBtn">🍪 Oreo Kitchen</button>

--- a/public/blockcraft/js/audio.js
+++ b/public/blockcraft/js/audio.js
@@ -26,13 +26,46 @@ ABC.audio = (function () {
     o.start(t); o.stop(t + dur + 0.05);
   }
 
+  /* shared white-noise buffer for wet/organic sounds */
+  let _noise = null;
+  function noiseBuffer() {
+    const c = ensureCtx();
+    if (_noise) return _noise;
+    _noise = c.createBuffer(1, c.sampleRate, c.sampleRate);
+    const d = _noise.getChannelData(0);
+    for (let i = 0; i < d.length; i++) d[i] = Math.random() * 2 - 1;
+    return _noise;
+  }
+  /* a wet squelch: noise squeezed through a falling band-pass + a soft thump */
+  function wet(dur, f0, f1, vol) {
+    if (!S.sound) return;
+    const c = ensureCtx(), t = c.currentTime;
+    const src = c.createBufferSource(); src.buffer = noiseBuffer();
+    src.playbackRate.value = 0.7 + Math.random() * 0.6;
+    const bp = c.createBiquadFilter(); bp.type = 'bandpass'; bp.Q.value = 2.5;
+    bp.frequency.setValueAtTime(f0 * (0.85 + Math.random() * 0.3), t);
+    bp.frequency.exponentialRampToValueAtTime(f1, t + dur);
+    const g = c.createGain();
+    g.gain.setValueAtTime(0.0001, t);
+    g.gain.exponentialRampToValueAtTime(vol, t + dur * 0.25);
+    g.gain.exponentialRampToValueAtTime(0.0001, t + dur);
+    src.connect(bp).connect(g).connect(c.destination);
+    src.start(t); src.stop(t + dur + 0.05);
+    tone(90 + Math.random() * 40, dur * 0.8, 'sine', vol * 0.7, 0, 55);
+  }
+
   const sfx = {
     pop()      { tone(420, .12, 'square', .08); tone(640, .1, 'sine', .1, .02); },
     remove()   { tone(300, .15, 'triangle', .1, 0, 150); },
     ding()     { tone(880, .3, 'sine', .14); tone(1320, .4, 'sine', .08, .05); },
     star()     { [880,1108,1318,1760].forEach((f,i)=>tone(f,.25,'sine',.1,i*.09)); },
     fanfare()  { [523,659,784,1046,1318].forEach((f,i)=>tone(f,.35,'triangle',.12,i*.13)); },
-    squish()   { tone(180, .2, 'sawtooth', .05, 0, 90); tone(90, .25, 'sine', .12, .02, 60); },
+    squish()   { wet(0.22, 480, 110, 0.22); },                                  // press into dough
+    squishBig(){ wet(0.4, 380, 70, 0.3); wet(0.18, 700, 200, 0.12); },          // deep two-stage splat
+    stretchy() { wet(0.35, 140, 520, 0.16); },                                  // pulling taffy upward
+    plop()     { wet(0.16, 300, 90, 0.2); tone(70, .2, 'sine', .15, .04, 45); },// lands back down
+    stamp()    { wet(0.12, 600, 250, 0.2); tone(660, .18, 'triangle', .12, .08); tone(990, .25, 'sine', .1, .14); },
+    grow()     { [330,392,494,587].forEach((f,i)=>tone(f,.22,'triangle',.09,i*.12)); },
     honk()     { tone(330, .25, 'square', .12); tone(415, .3, 'square', .12, .25); },
     whoosh()   { tone(220, 1.4, 'sawtooth', .07, 0, 1100); tone(110, 1.6, 'triangle', .08, 0, 700); },
     gentle()   { tone(660, .25, 'sine', .08); },

--- a/public/blockcraft/js/data.js
+++ b/public/blockcraft/js/data.js
@@ -31,6 +31,13 @@ ABC.BLOCK_DEFS = {
   yellow:  { name:'Sunny Yellow', emoji:'🌟', color:'#ffd43b', pat:'plain' },
   black:   { name:'Night Black',  emoji:'⬛', color:'#343a40', pat:'plain' },
   white:   { name:'Cloud White',  emoji:'⬜', color:'#f1f3f5', pat:'plain' },
+  gold:    { name:'Golden Brick', emoji:'🟨', color:'#e7b416', pat:'bricks', glow:true },
+  slab:    { name:'Half Slab',    emoji:'▬', color:'#d9a05b', pat:'planks', shape:'slab' },
+  wedge:   { name:'Triangle',     emoji:'🔺', color:'#c0584b', pat:'bricks', shape:'wedge', rotates:true },
+  pillar:  { name:'Round Pillar', emoji:'⚪', color:'#f1f3f5', pat:'plain',  shape:'pillar' },
+  door:    { name:'Cute Door',    emoji:'🚪', color:'#8a5a2b', pat:'door',   shape:'pane', rotates:true },
+  pane:    { name:'Window Pane',  emoji:'🪟', color:'#bfeaff', pat:'glass',  alpha:0.5, shape:'pane', rotates:true },
+  knob:    { name:'Golden Handle',emoji:'🔘', color:'#ffd43b', pat:'plain',  shape:'knob', glow:true },
   slimeGreen:  { name:'Green Slime',  emoji:'🟢', color:'#7be042', pat:'slime', alpha:0.85, locked:true },
   slimePink:   { name:'Pink Slime',   emoji:'🩷', color:'#ff8fc8', pat:'slime', alpha:0.85, locked:true },
   slimePurple: { name:'Purple Slime', emoji:'🟣', color:'#b388ff', pat:'slime', alpha:0.85, locked:true },
@@ -40,9 +47,18 @@ ABC.BLOCK_DEFS = {
 };
 
 /* Hotbar order (unlocked-by-default first) */
-ABC.HOTBAR_ORDER = ['grass','dirt','wood','plank','brick','stone','glass','sand','snow',
+ABC.HOTBAR_ORDER = ['grass','dirt','wood','plank','brick','gold','stone','glass','sand','snow',
   'leaf','flower','rainbow','star','water','red','blue','yellow','black','white',
+  'slab','wedge','pillar','door','pane','knob',
   'slimeGreen','slimePink','slimePurple','slimeBlue','oreo','oreoPink'];
+
+/* Cookie cutters for the playdough/slime 🍪 */
+ABC.CUTTERS = [
+  { shape:'star',   ico:'⭐', label:'Star Cutter' },
+  { shape:'heart',  ico:'❤️', label:'Heart Cutter' },
+  { shape:'flower', ico:'🌸', label:'Flower Cutter' },
+  { shape:'circle', ico:'⚪', label:'Circle Cutter' },
+];
 
 /* ============================== BLUEPRINTS ============================== */
 /* Helpers build arrays of cells {x,y,z,t} (relative, y=0 sits on ground top). */

--- a/public/blockcraft/js/main.js
+++ b/public/blockcraft/js/main.js
@@ -60,8 +60,23 @@
   camera.add(hand);
   scene.add(camera);
   function refreshHand() {
-    const id = ABC.ui.getSelected();
-    if (ABC.world.materials[id]) hand.material = ABC.world.materials[id];
+    const h = ABC.ui.getHand ? ABC.ui.getHand() : { kind: 'block', id: ABC.ui.getSelected() };
+    hand.visible = !thirdPerson;
+    hand.scale.set(1, 1, 1);
+    if (h.kind === 'block' && ABC.world.materials[h.id]) {
+      hand.material = ABC.world.materials[h.id];
+    } else if (h.kind === 'tool') {
+      hand.material = new THREE.MeshLambertMaterial({ color: 0x8a8f98 });   // pickaxe head
+      hand.scale.set(0.6, 1.4, 0.6);
+    } else if (h.kind === 'cutter') {
+      hand.material = new THREE.MeshLambertMaterial({ color: 0xff8fc8 });
+      hand.scale.set(1, 0.35, 1);
+    } else if (h.kind === 'sapling') {
+      hand.material = ABC.world.materials.leaf;
+      hand.scale.set(0.6, 0.9, 0.6);
+    } else if (h.kind === 'animal') {
+      hand.visible = false;   // carrying a friend gently in both hands
+    }
   }
   ABC.refreshHand = refreshHand;
 
@@ -159,52 +174,103 @@
     const vox = castVoxel(origin, dir);
     if (ent && (!vox || ent.distance < vox.dist)) {
       const o = ent.object;
-      if (o.userData.animalRef)  return { kind: 'animal', animal: o.userData.animalRef };
-      if (o.userData.squishyRef) return { kind: 'squishy', squishy: o.userData.squishyRef };
-      if (o.userData.portalRef)  return { kind: 'portal', portal: o.userData.portalRef };
-      if (o.userData.ghost)      return { kind: 'ghost', mesh: o };
+      if (o.userData.animalRef)  return { kind: 'animal', animal: o.userData.animalRef, point: ent.point };
+      if (o.userData.squishyRef) return { kind: 'squishy', squishy: o.userData.squishyRef, point: ent.point };
+      if (o.userData.portalRef)  return { kind: 'portal', portal: o.userData.portalRef, point: ent.point };
+      if (o.userData.ghost)      return { kind: 'ghost', mesh: o, point: ent.point };
     }
     if (vox) return { kind: 'block', cell: vox.cell, place: vox.prev };
     return null;
   }
 
+  /* ---------------- tree growing 🌱 ---------------- */
+  function growTree(x, y, z) {
+    ABC.audio.sfx.grow();
+    ABC.ui.toast('🌱 A little tree is growing…', 2600);
+    const h = 3 + Math.floor(Math.random() * 2);
+    const steps = [];
+    for (let i = 0; i < h; i++) steps.push(() => ABC.world.set(x, y + i, z, 'wood'));
+    for (let dy = 0; dy <= 2; dy++) for (let dx = -2; dx <= 2; dx++) for (let dz = -2; dz <= 2; dz++)
+      if (Math.abs(dx) + Math.abs(dz) + dy < 4)
+        steps.push(() => ABC.world.set(x + dx, y + h - 1 + dy, z + dz, 'leaf'));
+    let i = 0;
+    const t = setInterval(() => {
+      if (i >= steps.length) {
+        clearInterval(t);
+        ABC.ui.confetti(14); ABC.audio.sfx.ding();
+        ABC.ui.toast('🌳 Your tree is all grown! You are a nature helper!', 3600, true);
+        saveSoon();
+        return;
+      }
+      for (let n = 0; n < 4 && i < steps.length; n++) steps[i++]();
+      ABC.world.flush();
+      if (i % 8 === 0) ABC.audio.sfx.pop();
+    }, 160);
+  }
+
+  /* ---------------- spawn an animal friend from the bag ---------------- */
+  function placeAnimal(type, x, z) {
+    if (ABC.animals.list.length > 40) { ABC.ui.toast('🐾 The meadow is full of friends! Maybe dig some space first!', 3200); return; }
+    const a = ABC.animals.spawn(type, x, z);
+    ABC.state.friends = ABC.state.friends || [];
+    ABC.state.friends.push({ kind: type, x, z, name: a.name });
+    ABC.ui.confetti(12); ABC.audio.sfx.ding();
+    ABC.ui.toast(`${a.def.emoji} ${a.name} the ${a.def.label} hopped out of your bag!`, 3800, true);
+    saveSoon();
+  }
+
   /* ---------------- act: every click/tap routes here ---------------- */
-  function act(info, m) {
-    // friends & magic things always respond, no matter the mode
+  function act(info, m, hitPoint) {
+    const hand = ABC.ui.getHand();
     if (!info) return;
+    // friends & magic things respond first
     if (info.kind === 'animal')  { ABC.activities.talkToAnimal(info.animal); return; }
     if (info.kind === 'portal')  { ABC.portal.use(info.portal); return; }
-    if (info.kind === 'squishy') { ABC.squishy.poke(info.squishy); return; }
+    if (info.kind === 'squishy') {
+      if (hand.kind === 'cutter') ABC.squishy.stamp(info.squishy, hand.shape);
+      else ABC.squishy.poke(info.squishy, hitPoint);
+      return;
+    }
     if (info.kind === 'ghost')   { ABC.activities.tryFillGhost(info.mesh); return; }
     if (info.kind === 'block') {
-      if (m === 'dig') {
+      const digging = m === 'dig' || hand.kind === 'tool';
+      if (digging) {
         if (ABC.world.remove(info.cell.x, info.cell.y, info.cell.z)) {
           ABC.world.flush(); ABC.audio.sfx.remove(); saveSoon();
         } else if (info.cell.y === ABC.world.MIN_Y) {
           ABC.ui.toast('🪨 That is the super-strong bottom rock!', 2400);
         }
-      } else {
-        const p = info.place;
-        // don't build inside yourself
-        if (Math.abs(p.x + 0.5 - feet.x) < 0.85 && Math.abs(p.z + 0.5 - feet.z) < 0.85 &&
-            p.y + 1 > feet.y && p.y < feet.y + 1.8) return;
-        if (ABC.world.set(p.x, p.y, p.z, ABC.ui.getSelected())) {
-          ABC.world.flush(); ABC.audio.sfx.pop(); saveSoon();
-          ABC.state.placedCount = (ABC.state.placedCount || 0) + 1;
-          ABC.activities.maybeShowTell(ABC.state.placedCount);   // Show & Tell moments
-        }
+        return;
+      }
+      const p = info.place;
+      if (hand.kind === 'sapling') { growTree(p.x, p.y, p.z); return; }
+      if (hand.kind === 'animal')  { placeAnimal(hand.type, p.x + 0.5, p.z + 0.5); return; }
+      if (hand.kind === 'cutter')  { ABC.ui.toast(hand.ico + '🍪 Tap your squishy slime with the cutter!', 2600); return; }
+      // place a block — shaped blocks face the way you are looking
+      if (Math.abs(p.x + 0.5 - feet.x) < 0.85 && Math.abs(p.z + 0.5 - feet.z) < 0.85 &&
+          p.y + 1 > feet.y && p.y < feet.y + 1.8) return;
+      const id = hand.kind === 'block' ? hand.id : ABC.ui.getSelected();
+      const def = ABC.BLOCK_DEFS[id];
+      const rot = def.rotates ? ((Math.round(yaw / (Math.PI / 2)) % 4) + 4) % 4 : 0;
+      if (ABC.world.set(p.x, p.y, p.z, id, rot)) {
+        ABC.world.flush(); ABC.audio.sfx.pop(); saveSoon();
+        ABC.state.placedCount = (ABC.state.placedCount || 0) + 1;
+        ABC.activities.maybeShowTell(ABC.state.placedCount);   // Show & Tell moments
       }
     }
   }
 
-  function setMode(m) {
+  function setMode(m, quiet) {
     mode = m;
     $('tMode').textContent = mode === 'dig' ? '⛏️' : '🧱';
     $('tMode').classList.toggle('digMode', mode === 'dig');
-    ABC.ui.toast(mode === 'dig' ? '⛏️ Dig mode — click blocks to dig them up!'
-                                : '🧱 Build mode — click to place blocks!', 2400);
-    ABC.audio.sfx.gentle();
+    if (!quiet) {
+      ABC.ui.toast(mode === 'dig' ? '⛏️ Dig mode — click blocks to dig them up!'
+                                  : '🧱 Build mode — click to place blocks!', 2400);
+      ABC.audio.sfx.gentle();
+    }
   }
+  ABC.setMode = setMode;
 
   /* ---------------- unified pointer input (mouse + touch) ----------------
      drag on the world = look around · quick click/tap = act
@@ -258,7 +324,7 @@
       const info = aim(e.clientX, e.clientY);
       // right-click does the opposite of the current mode (handy for grown-ups)
       const m = e.button === 2 ? (mode === 'dig' ? 'place' : 'dig') : mode;
-      act(info, m);
+      act(info, m, info && info.point);
     }
     pDown = false;
   });
@@ -280,7 +346,13 @@
   jb.addEventListener('pointerdown', (e) => { e.preventDefault(); tapSpace(); keys.Space = true; });
   jb.addEventListener('pointerup',   (e) => { e.preventDefault(); keys.Space = false; });
   jb.addEventListener('pointercancel', () => { keys.Space = false; });
-  $('tMode').addEventListener('click', () => setMode(mode === 'dig' ? 'place' : 'dig'));
+  $('tMode').addEventListener('click', () => {
+    const next = mode === 'dig' ? 'place' : 'dig';
+    if (next === 'place' && ABC.ui.getHand().kind !== 'block') {
+      ABC.ui.selectBlock(ABC.ui.getSelected());   // put the tool away, take the block back out
+    }
+    setMode(next);
+  });
 
   /* ---------------- movement & physics ---------------- */
   const solid = (x, y, z) => !!ABC.world.get(Math.floor(x), Math.floor(y), Math.floor(z));
@@ -392,6 +464,7 @@
         portalCharge: ABC.state.portalCharge || 0,
         quests: ABC.state.quests || null,
         placedCount: ABC.state.placedCount || 0,
+        friends: ABC.state.friends || [],
         stars: ABC.state.stars, hearts: ABC.state.hearts,
         unlocked: [...ABC.state.unlocked], completed: [...ABC.state.completed],
         tutorialDone: ABC.state.tutorialDone,
@@ -414,6 +487,10 @@
       ABC.state.portalCharge = d.portalCharge || 0;
       ABC.state.quests = d.quests || null;
       ABC.state.placedCount = d.placedCount || 0;
+      ABC.state.friends = d.friends || [];
+      ABC.state.friends.forEach(f => {
+        if (ABC.ANIMAL_DEFS[f.kind]) ABC.animals.spawn(f.kind, f.x, f.z, f.name);
+      });
       ABC.state.stars = d.stars || 0;
       ABC.state.hearts = d.hearts || 0;
       (d.unlocked || []).forEach(b => ABC.state.unlocked.add(b));
@@ -426,6 +503,7 @@
 
   /* ---------------- HUD wiring ---------------- */
   $('buildMenuBtn').onclick = () => ABC.activities.showBuildMenu();
+  $('bagBtn').onclick      = () => ABC.ui.openBag();
   $('kindBtn').onclick     = () => ABC.activities.kindWords();
   $('slimeBtn').onclick    = () => ABC.activities.slimeLab();
   $('oreoBtn').onclick     = () => ABC.activities.oreoKitchen();

--- a/public/blockcraft/js/squishy.js
+++ b/public/blockcraft/js/squishy.js
@@ -16,10 +16,19 @@ ABC.squishy = (function () {
       color: SLIME_COLORS[data.color] || 0x7be042,
       transparent: true, opacity: 0.88, shininess: 90,
       specular: 0xffffff });
-    const blob = new THREE.Mesh(new THREE.SphereGeometry(0.9, 24, 18), mat);
+    // unique geometry per slime — its vertices get squished in real time
+    const geo = new THREE.SphereGeometry(0.9, 22, 16);
+    const blob = new THREE.Mesh(geo, mat);
     blob.scale.y = 0.72;
     blob.position.y = 0.62;
+    blob.userData.isBlob = true;
     g.add(blob);
+    g.userData.soft = {
+      blob,
+      base: geo.attributes.position.array.slice(),   // rest shape
+      d: new Float32Array(geo.attributes.position.count),   // radial dent per vertex
+      v: new Float32Array(geo.attributes.position.count),   // dent velocity
+    };
     // googly eyes — slimes are friends too
     const eyeW = new THREE.MeshBasicMaterial({ color: 0xffffff });
     const eyeB = new THREE.MeshBasicMaterial({ color: 0x222222 });
@@ -76,9 +85,65 @@ ABC.squishy = (function () {
     return g;
   }
 
+  /* ---------- cookie-cutter cutouts (playdough shapes!) ---------- */
+  function cutoutShape(shape) {
+    const s = new THREE.Shape();
+    if (shape === 'heart') {
+      s.moveTo(0, -0.45);
+      s.bezierCurveTo(0.55, 0.05, 0.45, 0.5, 0, 0.22);
+      s.bezierCurveTo(-0.45, 0.5, -0.55, 0.05, 0, -0.45);
+    } else if (shape === 'star') {
+      for (let i = 0; i < 10; i++) {
+        const r = i % 2 ? 0.22 : 0.52, a = i / 10 * Math.PI * 2 - Math.PI / 2;
+        i ? s.lineTo(Math.cos(a) * r, Math.sin(a) * r) : s.moveTo(Math.cos(a) * r, Math.sin(a) * r);
+      }
+    } else if (shape === 'flower') {
+      for (let i = 0; i <= 36; i++) {
+        const a = i / 36 * Math.PI * 2;
+        const r = 0.38 + Math.sin(a * 6) * 0.13;            // scalloped petals
+        i ? s.lineTo(Math.cos(a) * r, Math.sin(a) * r) : s.moveTo(Math.cos(a) * r, Math.sin(a) * r);
+      }
+    } else {  // circle
+      s.absarc(0, 0, 0.45, 0, Math.PI * 2);
+    }
+    return s;
+  }
+  function buildCutout(data) {
+    const g = new THREE.Group();
+    const geo = new THREE.ExtrudeGeometry(cutoutShape(data.shape),
+      { depth: 0.22, bevelEnabled: true, bevelSize: 0.05, bevelThickness: 0.04, bevelSegments: 2 });
+    geo.rotateX(-Math.PI / 2);
+    const m = new THREE.Mesh(geo, new THREE.MeshPhongMaterial({
+      color: data.colorHex || 0xff8fc8, shininess: 60 }));
+    m.position.y = 0.16;
+    g.add(m);
+    return g;
+  }
+  /* stamp a cutter into a slime → pops out a matching dough shape */
+  function stamp(target, shape) {
+    if (target.data.kind !== 'slime') {
+      ABC.ui.toast('🍪 The cutter works on your squishy slime!', 2600);
+      return;
+    }
+    poke(target);
+    ABC.audio.sfx.stamp();
+    const p = target.group.position;
+    const a = Math.random() * Math.PI * 2;
+    const s = spawn({ kind: 'cutout', shape,
+      colorHex: SLIME_COLORS[target.data.color] || 0xff8fc8,
+      x: p.x + Math.cos(a) * 1.6, z: p.z + Math.sin(a) * 1.6 });
+    s.spring.vy -= 5;   // lands with a wobble
+    ABC.ui.confetti(10);
+    ABC.ui.floatHearts(2);
+    ABC.saveSoon && ABC.saveSoon();
+    return s;
+  }
+
   /* ---------- spawn / serialize ---------- */
   function spawn(data) {
-    const g = data.kind === 'slime' ? buildSlime(data) : buildOreo(data);
+    const g = data.kind === 'slime' ? buildSlime(data)
+            : data.kind === 'cutout' ? buildCutout(data)
+            : buildOreo(data);
     g.position.set(data.x, groundYAt(data.x, data.z), data.z);
     scene.add(g);
     const s = { group: g, data,
@@ -109,19 +174,39 @@ ABC.squishy = (function () {
     ABC.audio.sfx.squish();
   }
 
-  function poke(s) {
-    // SQUASH! flatten hard, then jiggle back like jelly
-    s.spring.vy -= 9;
-    s.spring.vx += 5;
+  /* dent the jelly surface around a world-space contact point */
+  function dent(s, worldPoint, power) {
+    const soft = s.group.userData.soft;
+    if (!soft) return;
+    const local = worldPoint ? soft.blob.worldToLocal(worldPoint.clone())
+                             : new THREE.Vector3(0, 0.9, 0);   // default: press the top
+    const pos = soft.base, n = soft.v.length;
+    for (let i = 0; i < n; i++) {
+      const dx = pos[i*3] - local.x, dy = pos[i*3+1] - local.y, dz = pos[i*3+2] - local.z;
+      const w = Math.max(0, 1 - Math.sqrt(dx*dx + dy*dy + dz*dz) / 1.1);
+      soft.v[i] -= power * w * w;
+    }
+  }
+
+  function poke(s, worldPoint) {
+    if (s.data.kind === 'cutout') {           // cutouts give a firm dough bounce
+      s.spring.vy -= 4; s.jiggle = 0.6;
+      ABC.audio.sfx.plop();
+      return;
+    }
+    dent(s, worldPoint, 7);                   // deep finger dent right where touched
+    s.spring.vy -= (s.data.kind === 'slime' ? 4 : 8);
+    s.spring.vx += 3;
     s.jiggle = 1;
-    squelch(true);
+    if (s.data.kind === 'slime') ABC.audio.sfx.squishBig(); else squelch(true);
     if (Math.random() < 0.3) ABC.ui.floatHearts(2);
   }
   function grab(s) {
     s.grabbed = true;
     s.dragTarget = null;
     s.spring.vy += 4;        // lifts and stretches up as you grab it
-    squelch(true);
+    dent(s, null, -3);       // top bulges up toward your hand
+    if (s.data.kind === 'slime') ABC.audio.sfx.stretchy(); else squelch(true);
   }
   function dragTo(s, x, z) {
     if (!s.grabbed) return;
@@ -136,10 +221,38 @@ ABC.squishy = (function () {
     s.spring.vy -= 6;
     s.spring.vx += 4;
     s.jiggle = 1;
-    squelch(true);
+    dent(s, null, 5);          // top splats flat as it lands
+    if (s.data.kind === 'slime') ABC.audio.sfx.plop(); else squelch(true);
     s.data.x = s.group.position.x;
     s.data.z = s.group.position.z;
     ABC.saveSoon && ABC.saveSoon();
+  }
+
+  /* per-frame jelly vertex integration */
+  function updateSoft(s, dt, moveX, moveZ, speed) {
+    const soft = s.group.userData.soft;
+    if (!soft) return;
+    const pos = soft.blob.geometry.attributes.position;
+    const base = soft.base, d = soft.d, v = soft.v, n = v.length;
+    // gooey trailing while dragged: trailing side bulges, leading side flattens
+    let fx = 0, fz = 0;
+    if (speed > 0.05) { fx = -moveX / (speed || 1); fz = -moveZ / (speed || 1); }
+    const decay = Math.pow(0.004, dt);
+    for (let i = 0; i < n; i++) {
+      if (speed > 0.05) {
+        const align = (base[i*3] * fx + base[i*3+2] * fz);  // + on trailing side
+        v[i] += align * speed * 2.2 * dt;
+      }
+      v[i] += -70 * d[i] * dt;            // spring back to rest
+      v[i] *= decay;                       // damping
+      d[i] = Math.max(-0.55, Math.min(0.8, d[i] + v[i] * dt));
+      const k = 1 + d[i];
+      pos.array[i*3]   = base[i*3]   * k;
+      pos.array[i*3+1] = base[i*3+1] * k;
+      pos.array[i*3+2] = base[i*3+2] * k;
+    }
+    pos.needsUpdate = true;
+    soft.blob.geometry.computeVertexNormals();
   }
 
   /* ---------- per-frame ---------- */
@@ -154,13 +267,13 @@ ABC.squishy = (function () {
       s.wobbleT += dt;
       s.jiggle = Math.max(0, (s.jiggle || 0) - dt * 1.4);
 
-      let speed = 0;
+      let speed = 0, mvX = 0, mvZ = 0;
       if (s.grabbed && s.dragTarget) {
         // slime chases your finger with gooey lag, stretching as it goes
         const g = s.group;
         const dx = s.dragTarget.x - g.position.x, dz = s.dragTarget.z - g.position.z;
         const dist = Math.hypot(dx, dz);
-        speed = dist;
+        speed = dist; mvX = dx; mvZ = dz;
         const step = Math.min(1, dt * 7);
         g.position.x += dx * step;
         g.position.z += dz * step;
@@ -188,6 +301,7 @@ ABC.squishy = (function () {
       const sx = sp.sx * idle * (1 + pull * 0.35);
       const sy = (sp.sy / Math.sqrt(sp.sx)) * (s.grabbed ? 1.25 + pull * 0.3 : 1);
       s.group.scale.set(sx, sy * idle, sx);
+      updateSoft(s, dt, mvX, mvZ, speed);    // jelly surface ripples
     }
   }
 
@@ -197,6 +311,6 @@ ABC.squishy = (function () {
     return out;
   }
 
-  return { init, spawn, update, poke, grab, dragTo, release,
+  return { init, spawn, update, poke, grab, dragTo, release, stamp,
            serialize, deserialize, meshTargets, list };
 })();

--- a/public/blockcraft/js/ui.js
+++ b/public/blockcraft/js/ui.js
@@ -347,6 +347,63 @@ ABC.ui = (function () {
     $('msgOk').onclick = () => { ABC.audio.sfx.pop(); closeDialog(); onClose && onClose(); };
   }
 
+  /* ---------------- hand item & school bag 🎒 ----------------
+     hand = {kind:'block',id} | {kind:'tool',tool:'pickaxe'} |
+            {kind:'cutter',shape,ico} | {kind:'sapling'} | {kind:'animal',type} */
+  let hand = { kind: 'block', id: 'plank' };
+  function getHand() { return hand; }
+  function setHand(h, label) {
+    hand = h;
+    if (h.kind === 'block') selectBlock(h.id);
+    else {
+      document.querySelectorAll('.hotSlot').forEach(s => s.classList.remove('selected'));
+      if (ABC.setMode) ABC.setMode(h.kind === 'tool' ? 'dig' : 'place', true);
+      if (ABC.refreshHand) ABC.refreshHand();
+      if (label) toast(label, 2800);
+      ABC.audio.sfx.pop();
+    }
+  }
+
+  function openBag() {
+    const avail = ABC.HOTBAR_ORDER.filter(id => !ABC.BLOCK_DEFS[id].locked || ABC.state.unlocked.has(id));
+    let html = `<div class="bigEmoji">🎒</div><h2>{player}'s School Bag</h2>
+      <div class="bagSection">🔨 Tools</div><div class="pickGrid">
+        <button class="pickCard bagItem" data-kind="tool">⛏️<br>Pickaxe</button>`;
+    ABC.CUTTERS.forEach((c, i) => {
+      html += `<button class="pickCard bagItem" data-kind="cutter" data-i="${i}">${c.ico}🍪<br>${c.label}</button>`;
+    });
+    html += `</div><div class="bagSection">🌱 Nature &amp; Friends</div><div class="pickGrid">
+        <button class="pickCard bagItem" data-kind="sapling">🌱<br>Tree Sapling</button>`;
+    for (const [k, d] of Object.entries(ABC.ANIMAL_DEFS)) {
+      if (d.special) continue;
+      html += `<button class="pickCard bagItem" data-kind="animal" data-animal="${k}">${d.emoji}<br>${d.label}</button>`;
+    }
+    html += `</div><div class="bagSection">🧱 Blocks</div><div class="pickGrid">`;
+    avail.forEach(id => {
+      const def = ABC.BLOCK_DEFS[id];
+      html += `<button class="pickCard bagItem" data-kind="block" data-block="${id}" style="padding:8px;">
+        <span class="swatch" style="display:inline-block;width:34px;height:34px;border-radius:8px;background:${def.color};">${def.emoji}</span><br>${def.name}</button>`;
+    });
+    html += '</div>';
+    openDialog(ABC.tpl(html));
+    ABC.audio.say('What will you take out of your school bag?');
+    box().querySelectorAll('.bagItem').forEach(b => {
+      b.addEventListener('click', () => {
+        const kind = b.dataset.kind;
+        closeDialog();
+        if (kind === 'block')   setHand({ kind:'block', id: b.dataset.block });
+        if (kind === 'tool')    setHand({ kind:'tool', tool:'pickaxe' }, '⛏️ Pickaxe out! Click blocks to dig.');
+        if (kind === 'sapling') setHand({ kind:'sapling' }, '🌱 Sapling! Click the ground to plant a tree!');
+        if (kind === 'animal')  setHand({ kind:'animal', type: b.dataset.animal },
+          ABC.ANIMAL_DEFS[b.dataset.animal].emoji + ' Click the ground — a new friend will appear!');
+        if (kind === 'cutter') {
+          const c = ABC.CUTTERS[+b.dataset.i];
+          setHand({ kind:'cutter', shape: c.shape, ico: c.ico }, c.ico + '🍪 Cutter ready! Tap your slime to stamp a shape!');
+        }
+      });
+    });
+  }
+
   /* ---------------- hotbar ---------------- */
   let selectedBlock = 'plank';
   function buildHotbar() {
@@ -367,9 +424,11 @@ ABC.ui = (function () {
   }
   function selectBlock(id) {
     selectedBlock = id;
+    hand = { kind: 'block', id };
     document.querySelectorAll('.hotSlot').forEach(s =>
       s.classList.toggle('selected', s.dataset.block === id));
     ABC.audio.sfx.gentle();
+    if (ABC.setMode) ABC.setMode('place', true);   // picking a block means building
     if (ABC.refreshHand) ABC.refreshHand();
   }
   function selectByIndex(i) {
@@ -441,5 +500,6 @@ ABC.ui = (function () {
   return { openDialog, closeDialog, isOpen, toast, bellaSays, confetti, floatHearts,
            refreshScore, addStars, addHearts, askExpressive, askBuilder, pickCard, message,
            buildHotbar, selectBlock, selectByIndex, getSelected, unlockBlock,
+           getHand, setHand, openBag,
            showSettings, showHelp, pick, pick3, esc };
 })();

--- a/public/blockcraft/js/world.js
+++ b/public/blockcraft/js/world.js
@@ -7,6 +7,7 @@ ABC.world = (function () {
   let scene, materials = {}, meshes = {}, dirty = new Set(), underMesh = null;
   let blockGeo = null;
   const map = new Map();      // "x,y,z" -> type
+  const rotMap = new Map();   // "x,y,z" -> 0..3 quarter-turns (rotating shapes only)
   const key = (x,y,z) => x + ',' + y + ',' + z;
 
   /* ---------- canvas textures ---------- */
@@ -78,6 +79,13 @@ ABC.world = (function () {
         g.fillStyle = '#3a2c20';
         for (let i=0;i<12;i++) { g.beginPath(); g.arc(5+rnd()*54, (rnd()<.5?2+rnd()*18:44+rnd()*18), 2.5, 0, 7); g.fill(); }
         break;
+      case 'door':
+        g.fillStyle = '#6e4520'; g.fillRect(0,0,64,64);
+        g.strokeStyle = '#4a2d12'; g.lineWidth = 4;
+        g.strokeRect(8,6,48,52); g.strokeRect(14,12,36,18); g.strokeRect(14,36,36,18);
+        g.fillStyle = '#ffd43b'; g.beginPath(); g.arc(50,34,5,0,7); g.fill();  // golden knob
+        g.strokeStyle = '#b8860b'; g.lineWidth = 2; g.beginPath(); g.arc(50,34,5,0,7); g.stroke();
+        break;
     }
     // subtle block border for the voxel look
     g.strokeStyle = 'rgba(0,0,0,.18)'; g.lineWidth = 4; g.strokeRect(0,0,64,64);
@@ -88,9 +96,38 @@ ABC.world = (function () {
   function mulberry(a){ return function(){ a|=0; a=a+0x6D2B79F5|0; let t=Math.imul(a^a>>>15,1|a);
     t=t+Math.imul(t^t>>>7,61|t)^t; return ((t^t>>>14)>>>0)/4294967296; }; }
 
+  /* ---------- shaped block geometries ---------- */
+  function wedgeGeo() {
+    // a right-triangle ramp: full at -z, slopes down toward +z
+    const g = new THREE.BufferGeometry();
+    const v = [ // x,y,z triplets — two triangle sides + slope + bottom + back
+      -.5,-.5,-.5,  .5,-.5,-.5,  .5,.5,-.5,   -.5,-.5,-.5,  .5,.5,-.5,  -.5,.5,-.5,   // back face
+      -.5,-.5,-.5, -.5,.5,-.5,  -.5,-.5,.5,                                            // left tri
+       .5,-.5,-.5,  .5,-.5,.5,   .5,.5,-.5,                                            // right tri
+      -.5,.5,-.5,   .5,.5,-.5,   .5,-.5,.5,   -.5,.5,-.5,  .5,-.5,.5,  -.5,-.5,.5,    // slope
+      -.5,-.5,-.5, -.5,-.5,.5,   .5,-.5,.5,   -.5,-.5,-.5,  .5,-.5,.5,  .5,-.5,-.5,   // bottom
+    ];
+    g.setAttribute('position', new THREE.Float32BufferAttribute(v, 3));
+    const uv = [];
+    for (let i = 0; i < v.length / 3; i++) uv.push((v[i*3]+0.5), (v[i*3+1]+0.5));
+    g.setAttribute('uv', new THREE.Float32BufferAttribute(uv, 2));
+    g.computeVertexNormals();
+    return g;
+  }
+  function geoFor(def) {
+    switch (def.shape) {
+      case 'slab':   return new THREE.BoxGeometry(1, 0.5, 1).translate(0, -0.25, 0);
+      case 'wedge':  return wedgeGeo();
+      case 'pillar': return new THREE.CylinderGeometry(0.42, 0.42, 1, 14);
+      case 'pane':   return new THREE.BoxGeometry(1, 1, 0.14);
+      case 'knob':   return new THREE.BoxGeometry(0.3, 0.3, 0.3);
+      default:       return blockGeo;
+    }
+  }
+
   /* ---------- mesh management (capacity grows on demand) ---------- */
   function newMesh(id, cap) {
-    const m = new THREE.InstancedMesh(blockGeo, materials[id], cap);
+    const m = new THREE.InstancedMesh(geoFor(ABC.BLOCK_DEFS[id]), materials[id], cap);
     m.count = 0;
     m.userData.type = id;
     m.userData.positions = [];
@@ -112,10 +149,10 @@ ABC.world = (function () {
   const _m4 = new THREE.Matrix4();
   function rebuild(type) {
     let m = meshes[type];
-    const pos = [];
+    const pos = [], keys = [];
     for (const [k, t] of map) if (t === type) {
       const [x,y,z] = k.split(',').map(Number);
-      pos.push([x,y,z]);
+      pos.push([x,y,z]); keys.push(k);
     }
     if (pos.length > m.instanceMatrix.count) {       // grow capacity
       scene.remove(m);
@@ -124,8 +161,11 @@ ABC.world = (function () {
       m = meshes[type] = newMesh(type, cap);
     }
     m.count = pos.length;
+    const slabOff = ABC.BLOCK_DEFS[type].shape === 'slab' ? 0 : 0;  // slab geo already offset
     for (let i=0;i<m.count;i++) {
-      _m4.makeTranslation(pos[i][0]+0.5, pos[i][1]+0.5, pos[i][2]+0.5);
+      const rot = rotMap.get(keys[i]) || 0;
+      _m4.makeRotationY(rot * Math.PI / 2);
+      _m4.setPosition(pos[i][0]+0.5, pos[i][1]+0.5 + slabOff, pos[i][2]+0.5);
       m.setMatrixAt(i, _m4);
     }
     m.userData.positions = pos;
@@ -135,13 +175,14 @@ ABC.world = (function () {
 
   function inBounds(x,y,z) { return Math.abs(x)<=SIZE && Math.abs(z)<=SIZE && y>=MIN_Y && y<=MAX_Y; }
   function get(x,y,z) { return map.get(key(x,y,z)) || null; }
-  function set(x,y,z,type) {
+  function set(x,y,z,type,rot) {
     if (!inBounds(x,y,z)) return false;
     const k = key(x,y,z);
     const old = map.get(k);
-    if (old === type) return false;
+    if (old === type && (rotMap.get(k)||0) === (rot||0)) return false;
     if (old) dirty.add(old);
     map.set(k, type);
+    if (rot) rotMap.set(k, rot); else rotMap.delete(k);
     dirty.add(type);
     return true;
   }
@@ -151,6 +192,7 @@ ABC.world = (function () {
     const old = map.get(k);
     if (!old) return false;
     map.delete(k);
+    rotMap.delete(k);
     dirty.add(old);
     return true;
   }
@@ -246,20 +288,23 @@ ABC.world = (function () {
   /* ---------- save / load (diff against the generated world) ---------- */
   function serialize() {
     const diffs = [];
-    for (const [k,t] of map) if (defaultMap.get(k) !== t) diffs.push(k + ':' + t);
+    for (const [k,t] of map) {
+      const r = rotMap.get(k) || 0;
+      if (defaultMap.get(k) !== t || r) diffs.push(k + ':' + t + (r ? ':' + r : ''));
+    }
     const removed = [];
     for (const k of defaultMap.keys()) if (!map.has(k)) removed.push(k);
     return { d: diffs, r: removed };
   }
   function deserialize(data) {
     if (!data) return;
-    map.clear();
+    map.clear(); rotMap.clear();
     for (const [k,t] of defaultMap) map.set(k, t);
     for (const k of (data.r||[])) map.delete(k);
     for (const e of (data.d||[])) {
-      const i = e.lastIndexOf(':');
-      const k = e.slice(0,i), t = e.slice(i+1);
-      if (ABC.BLOCK_DEFS[t]) map.set(k, t);
+      const parts = e.split(':');            // "x,y,z" ":type" [":rot"]
+      const k = parts[0], t = parts[1], r = +parts[2] || 0;
+      if (ABC.BLOCK_DEFS[t]) { map.set(k, t); if (r) rotMap.set(k, r); }
     }
     for (const t of Object.keys(meshes)) dirty.add(t);
     flush();


### PR DESCRIPTION
- 🫙 **Real soft-body slime** — surface dents at the touch point, gooey trailing while dragged, jelly ripples; new wet squelch/stretch/plop sounds (filtered-noise synthesis)
- 🍪 **Cookie cutters** (star/heart/flower/circle) stamp persistent playdough cutouts from slime
- 🎒 **School Bag** — pickaxe, cutters, tree saplings (grow animated trees), placeable animal friends (persist across sessions), and all unlocked blocks
- 🧱 **New shaped blocks**: golden brick, half slab, triangle ramp, round pillar, door, window pane, golden handle — shapes auto-face the player
- Picking a block = build mode; pickaxe = dig mode

Static game files only. Verified error-free boot in headless Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)