### PR TITLE
Block Craft: true mobile mode (icons only under ~11 inches)

### DIFF
--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <title>Aaria's Block Craft 3D 🌈</title>
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 <style>
   * { margin:0; padding:0; box-sizing:border-box; user-select:none; -webkit-user-select:none; }
   html,body { width:100%; height:100%; overflow:hidden; background:#aee7ff;
@@ -143,7 +143,22 @@
     padding:14px; margin:10px 0; color:#5c4500; line-height:1.4; }
   .stirZone { font-size:70px; cursor:pointer; display:inline-block; transition:transform .08s; }
 
-  /* 📱 compact layout on phones/small tablets — less text, more world */
+  /* 📱 mobile & small tablets (under ~11"): icons only, no helper text */
+  @media (max-width: 1100px) {
+    .btnTxt { display:none; }                       /* menu buttons become icons */
+    .menuBtn { font-size:20px; padding:8px 11px; border-radius:14px; }
+    .sideBtn small { display:none; }                /* side buttons: icon only */
+    .sideBtn { width:52px; height:52px; font-size:22px; }
+    #lookHint { display:none !important; }          /* no tutorial text on mobile */
+    #orgFooter { font-size:11px; padding:5px 12px; }
+    #titleScreen .subtitle { font-size:15px; }
+    #titleScreen .titleEmojis { font-size:26px; letter-spacing:5px; }
+    #logoImg { width:120px; }
+    .scoreChip { font-size:15px; padding:5px 11px; }
+    #nameRow { font-size:15px; } #nameRow input { font-size:17px; width:150px; }
+    .bigBtn { font-size:20px; padding:12px 30px; }
+  }
+  /* 📱 extra-compact on phones */
   @media (max-width: 820px) {
     .menuBtn { font-size:13px; padding:6px 8px; border-radius:12px; }
     #menuBar { gap:4px; flex-wrap:wrap; justify-content:flex-end; max-width:62vw; }
@@ -207,10 +222,10 @@
     <div class="scoreChip" id="questChip" title="Today's Adventures">📋 0/3</div>
   </div>
   <div id="menuBar">
-    <button class="menuBtn" id="buildMenuBtn">🏗️ Build</button>
-    <button class="menuBtn" id="slimeBtn">🌈 Slime Lab</button>
-    <button class="menuBtn" id="oreoBtn">🍪 Oreo Kitchen</button>
-    <button class="menuBtn" id="kindBtn">💌 Kind Words</button>
+    <button class="menuBtn" id="buildMenuBtn">🏗️<span class="btnTxt"> Build</span></button>
+    <button class="menuBtn" id="slimeBtn">🌈<span class="btnTxt"> Slime Lab</span></button>
+    <button class="menuBtn" id="oreoBtn">🍪<span class="btnTxt"> Oreo Kitchen</span></button>
+    <button class="menuBtn" id="kindBtn">💌<span class="btnTxt"> Kind Words</span></button>
     <button class="menuBtn" id="fsBtn" title="Full screen">⛶</button>
     <button class="menuBtn" id="settingsBtn">⚙️</button>
     <button class="menuBtn" id="helpBtn">❓</button>
@@ -252,14 +267,14 @@
 <div id="flash"></div>
 
 <script src="lib/three.min.js"></script>
-<script src="js/data.js?v=11"></script>
-<script src="js/audio.js?v=11"></script>
-<script src="js/world.js?v=11"></script>
-<script src="js/animals.js?v=11"></script>
-<script src="js/squishy.js?v=11"></script>
-<script src="js/portal.js?v=11"></script>
-<script src="js/ui.js?v=11"></script>
-<script src="js/activities.js?v=11"></script>
-<script src="js/main.js?v=11"></script>
+<script src="js/data.js?v=12"></script>
+<script src="js/audio.js?v=12"></script>
+<script src="js/world.js?v=12"></script>
+<script src="js/animals.js?v=12"></script>
+<script src="js/squishy.js?v=12"></script>
+<script src="js/portal.js?v=12"></script>
+<script src="js/ui.js?v=12"></script>
+<script src="js/activities.js?v=12"></script>
+<script src="js/main.js?v=12"></script>
 </body>
 </html>


### PR DESCRIPTION
📱 Screens under 1100px get an icon-only UI: menu buttons collapse to emoji, side buttons lose labels, helper text hidden, compact title screen, pinch-zoom disabled. Laptops/large screens (>11") keep the full text experience. Cache v=12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)