### PR TITLE
Block Craft: fix control overlap, warmer voice, treasure-chest bag

### DIFF
--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -56,12 +56,21 @@
   .menuBtn { font-family:inherit; font-size:17px; padding:10px 14px; border:none; border-radius:18px;
     background:rgba(255,255,255,.92); cursor:pointer; box-shadow:0 3px 8px rgba(0,0,0,.18); transition:transform .1s; }
   .menuBtn:hover { transform:scale(1.08); background:#fff; }
+  /* the school bag — her treasure chest 🎒✨ */
   #bagBtn { position:absolute; bottom:14px; left:14px;
-    width:78px; height:78px; font-size:42px; border:none; border-radius:20px; cursor:pointer;
-    background:linear-gradient(180deg,#ffd43b,#ffa94d); box-shadow:0 5px 0 #e8920c, 0 8px 14px rgba(0,0,0,.25);
-    pointer-events:auto; animation:bounceTitle 3s ease-in-out infinite; z-index:5; }
-  #bagBtn:hover { transform:scale(1.1); }
-  #bagBtn:active { transform:translateY(3px); box-shadow:0 2px 0 #e8920c; }
+    width:88px; height:88px; font-size:46px; border:none; border-radius:22px; cursor:pointer;
+    background:linear-gradient(180deg,#ffe066,#ff922b);
+    box-shadow:0 6px 0 #e8590c, 0 10px 18px rgba(0,0,0,.3);
+    pointer-events:auto; z-index:5; animation:chestGlow 2s ease-in-out infinite; }
+  @keyframes chestGlow {
+    0%,100% { box-shadow:0 6px 0 #e8590c, 0 10px 18px rgba(0,0,0,.3), 0 0 0 0 rgba(255,212,59,.8); }
+    50%     { box-shadow:0 6px 0 #e8590c, 0 10px 18px rgba(0,0,0,.3), 0 0 0 12px rgba(255,212,59,0); }
+  }
+  #bagBtn::after { content:'✨'; position:absolute; top:-10px; right:-8px; font-size:26px;
+    animation:bounceTitle 1.6s ease-in-out infinite; }
+  #bagBtn.opened::after { content:''; }
+  #bagBtn:hover { transform:scale(1.1) rotate(-4deg); }
+  #bagBtn:active { transform:translateY(3px); }
   #hotbar { position:absolute; bottom:14px; left:50%; transform:translateX(-50%); max-width:calc(96vw - 200px);
     display:flex; gap:6px; pointer-events:auto; background:rgba(0,0,0,.25); padding:8px; border-radius:18px;
     max-width:96vw; overflow-x:auto; }
@@ -73,10 +82,14 @@
   #lookHint { position:absolute; bottom:96px; left:50%; transform:translateX(-50%);
     background:rgba(255,255,255,.92); padding:10px 22px; border-radius:22px; font-size:19px; color:#246;
     box-shadow:0 4px 10px rgba(0,0,0,.2); }
-  #sideBtns { position:absolute; right:14px; top:46%; display:flex; flex-direction:column; gap:10px; pointer-events:auto; }
-  .sideBtn { width:64px; height:64px; font-size:24px; display:flex; flex-direction:column;
-    align-items:center; justify-content:center; border-radius:16px; }
-  .sideBtn small { font-size:11px; }
+  /* side buttons: anchored under the top menu, wrapping inward — can never reach
+     the bottom action buttons no matter the screen height */
+  #sideBtns { position:absolute; right:14px; top:64px; display:flex; flex-direction:column;
+    flex-wrap:wrap-reverse; gap:8px; pointer-events:auto;
+    max-height:calc(100vh - 320px); align-content:flex-start; }
+  .sideBtn { width:56px; height:56px; font-size:21px; display:flex; flex-direction:column;
+    align-items:center; justify-content:center; border-radius:14px; }
+  .sideBtn small { font-size:10px; }
   .sideBtn.active { background:#ffe066; box-shadow:0 0 0 3px #fab005, 0 3px 8px rgba(0,0,0,.18); }
 
   /* on-screen control pad — always visible, no Esc or mouse-lock needed */
@@ -163,8 +176,9 @@
     .tBtn { width:44px; height:44px; font-size:17px; }
     #tUp{left:47px;top:0} #tLeft{left:0;top:47px} #tRight{left:94px;top:47px} #tDown{left:47px;top:94px}
     /* bag + hotbar share the bottom edge cleanly */
-    #bagBtn { width:54px; height:54px; font-size:28px; left:10px; bottom:10px; animation:none; }
-    #hotbar { bottom:10px; left:74px; transform:none; max-width:calc(100vw - 160px);
+    #bagBtn { width:62px; height:62px; font-size:32px; left:10px; bottom:10px; }
+    #bagBtn::after { font-size:18px; top:-7px; right:-5px; }
+    #hotbar { bottom:10px; left:82px; transform:none; max-width:calc(100vw - 170px);
       padding:5px; gap:4px; }
     .hotSlot { width:42px; height:42px; min-width:42px; font-size:9px; }
     .hotSlot .swatch { width:22px; height:22px; }
@@ -286,19 +300,19 @@
 <div id="flash"></div>
 
 <script src="lib/three.min.js"></script>
-<script src="js/data.js?v=15"></script>
-<script src="js/audio.js?v=15"></script>
-<script src="js/world.js?v=15"></script>
-<script src="js/animals.js?v=15"></script>
-<script src="js/squishy.js?v=15"></script>
-<script src="js/portal.js?v=15"></script>
-<script src="js/ui.js?v=15"></script>
-<script src="js/activities.js?v=15"></script>
-<script src="js/music.js?v=15"></script>
-<script src="js/pet.js?v=15"></script>
-<script src="js/stickers.js?v=15"></script>
-<script src="js/overnight.js?v=15"></script>
-<script src="js/photo.js?v=15"></script>
-<script src="js/main.js?v=15"></script>
+<script src="js/data.js?v=16"></script>
+<script src="js/audio.js?v=16"></script>
+<script src="js/world.js?v=16"></script>
+<script src="js/animals.js?v=16"></script>
+<script src="js/squishy.js?v=16"></script>
+<script src="js/portal.js?v=16"></script>
+<script src="js/ui.js?v=16"></script>
+<script src="js/activities.js?v=16"></script>
+<script src="js/music.js?v=16"></script>
+<script src="js/pet.js?v=16"></script>
+<script src="js/stickers.js?v=16"></script>
+<script src="js/overnight.js?v=16"></script>
+<script src="js/photo.js?v=16"></script>
+<script src="js/main.js?v=16"></script>
 </body>
 </html>

--- a/public/blockcraft/js/audio.js
+++ b/public/blockcraft/js/audio.js
@@ -103,7 +103,9 @@ ABC.audio = (function () {
     if (!vs.length) return;
     if (S.voiceName) { voice = vs.find(v => v.name === S.voiceName) || voice; if (voice) return; }
     // prefer the most natural-sounding voices available on this device
-    const ranks = [/natural/i, /premium/i, /enhanced/i, /Ava|Zoe|Allison|Joelle/i, /Samantha/i, /Google US English/i, /Karen|Moira|female/i];
+    // (Edge "Online Natural", neural voices, enhanced Apple voices, then Google)
+    const ranks = [/online.*natural/i, /natural/i, /neural/i, /premium/i, /enhanced/i,
+      /Ava|Zoe|Allison|Joelle|Aria|Jenny/i, /Samantha/i, /Google US English/i, /Karen|Moira|female/i];
     for (const r of ranks) { const v = vs.find(v => r.test(v.name)); if (v) { voice = v; return; } }
     voice = vs[0];
   }
@@ -127,13 +129,22 @@ ABC.audio = (function () {
     if (!clean.trim()) return;
     speechSynthesis.cancel();
     // Chrome quirk: speaking immediately after cancel() silently drops the
-    // utterance — queue it a tick later
+    // utterance — queue it a tick later. Speak sentence-by-sentence with
+    // natural micro-pauses, the way a person reads to a child.
     setTimeout(() => {
-      const u = new SpeechSynthesisUtterance(clean);
-      u.rate = 0.95; u.pitch = 1.04;   // gentler — less chipmunk, more human
       if (!voice) pickVoice();          // voices sometimes load late
-      if (voice) u.voice = voice;
-      speechSynthesis.speak(u);
+      const parts = clean.match(/[^.!?…]+[.!?…]*/g) || [clean];
+      for (const part of parts) {
+        const p = part.trim();
+        if (!p) continue;
+        const u = new SpeechSynthesisUtterance(p);
+        u.rate = 0.92; u.pitch = 1.0;   // calm, human pace — no chipmunk
+        // tiny lift on questions and excitement, like real speech
+        if (/\?$/.test(p)) u.pitch = 1.08;
+        else if (/!$/.test(p)) { u.pitch = 1.05; u.rate = 0.96; }
+        if (voice) u.voice = voice;
+        speechSynthesis.speak(u);       // queued utterances get natural gaps
+      }
     }, 60);
   }
   // Chrome quirk #2: long speech silently pauses after ~15s — keep it awake

--- a/public/blockcraft/js/ui.js
+++ b/public/blockcraft/js/ui.js
@@ -369,6 +369,11 @@ ABC.ui = (function () {
     const today = new Date().toISOString().slice(0, 10);
     return ABC.state.pocket === today;
   }
+  /* the bag sparkles ✨ while today's surprise is still inside */
+  setInterval(() => {
+    const b = $('bagBtn');
+    if (b) b.classList.toggle('opened', pocketOpened());
+  }, 4000);
   function openPocket() {
     closeDialog();
     const sp = pick(ABC.SURPRISES);


### PR DESCRIPTION
- 🔧 Side buttons wrap inward below the top menu with a reserved bottom zone — no overlap with ⬆⬇ controls at any screen height
- 🗣️ Warmer speech: sentence-chunked with natural pauses, human pitch, neural-voice preference
- 🎒 Bag = glowing treasure chest with pulsing golden ring + ✨ badge while the daily surprise is unopened

Cache v=16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)