### PR TITLE
Block Craft: US National Parks world — biomes, weather, color-grading, passport

### DIFF
--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -273,6 +273,7 @@
     <button class="menuBtn sideBtn" id="zoomInBtn" title="Zoom in">🔍<small>＋</small></button>
     <button class="menuBtn sideBtn" id="zoomOutBtn" title="Zoom out">🔍<small>−</small></button>
     <button class="menuBtn sideBtn" id="mapBtn" title="Sky map">🗺️<small>Map</small></button>
+    <button class="menuBtn sideBtn" id="passportBtn" title="Park passport">📔<small>Parks</small></button>
     <button class="menuBtn sideBtn" id="photoBtn" title="Take a photo">📸<small>Photo</small></button>
     <button class="menuBtn sideBtn" id="albumBtn" title="Photo album">🖼️<small>Album</small></button>
   </div>
@@ -300,19 +301,21 @@
 <div id="flash"></div>
 
 <script src="lib/three.min.js"></script>
-<script src="js/data.js?v=16"></script>
-<script src="js/audio.js?v=16"></script>
-<script src="js/world.js?v=16"></script>
-<script src="js/animals.js?v=16"></script>
-<script src="js/squishy.js?v=16"></script>
-<script src="js/portal.js?v=16"></script>
-<script src="js/ui.js?v=16"></script>
-<script src="js/activities.js?v=16"></script>
-<script src="js/music.js?v=16"></script>
-<script src="js/pet.js?v=16"></script>
-<script src="js/stickers.js?v=16"></script>
-<script src="js/overnight.js?v=16"></script>
-<script src="js/photo.js?v=16"></script>
-<script src="js/main.js?v=16"></script>
+<script src="js/data.js?v=17"></script>
+<script src="js/audio.js?v=17"></script>
+<script src="js/world.js?v=17"></script>
+<script src="js/animals.js?v=17"></script>
+<script src="js/squishy.js?v=17"></script>
+<script src="js/weather.js?v=17"></script>
+<script src="js/parks.js?v=17"></script>
+<script src="js/portal.js?v=17"></script>
+<script src="js/ui.js?v=17"></script>
+<script src="js/activities.js?v=17"></script>
+<script src="js/music.js?v=17"></script>
+<script src="js/pet.js?v=17"></script>
+<script src="js/stickers.js?v=17"></script>
+<script src="js/overnight.js?v=17"></script>
+<script src="js/photo.js?v=17"></script>
+<script src="js/main.js?v=17"></script>
 </body>
 </html>

--- a/public/blockcraft/js/animals.js
+++ b/public/blockcraft/js/animals.js
@@ -214,23 +214,11 @@ ABC.animals = (function () {
     // Bella the Blue Elephant — guide, stays near spawn
     const bella = spawn('elephant', 4, -8, 'Bella');
     bella.isGuide = true; bella.home = {x:4, z:-8}; bella.range = 6;
-    // 🏪 Mr. Maple runs the village market
+    // 🏪 Mr. Maple runs the home-meadow market
     const vendor = spawn('capy', -14, 4, 'Mr. Maple');
     vendor.isVendor = true; vendor.home = { x: -14, z: 4 }; vendor.range = 2;
-    // 🏘️ Mrs. Cocoa runs the town market (south-east town)
-    const vendor2 = spawn('panda', 46, 56, 'Mrs. Cocoa');
-    vendor2.isVendor = true; vendor2.home = { x: 46, z: 56 }; vendor2.range = 2;
-    // town & forest dwellers
-    spawn('puppy', 45, 47); spawn('cat', 49, 49);
-    spawn('bunny', -50, 45); spawn('butterfly', -55, 50); spawn('penguin', 55, -40);
-    // cute friends near spawn (incl. the big round cuties!)
-    spawn('capy', 10, -4); spawn('panda', -10, -2);
-    spawn('bunny', -5, -10);  spawn('bunny', 14, 6);
-    spawn('cat', 6, 8);       spawn('puppy', -8, 4);
-    spawn('butterfly', 0, 2); spawn('butterfly', 10, -4);
-    // prehistoric pals roam a bit further out
-    spawn('trex', 26, 20);    spawn('trice', -24, 22);
-    spawn('longneck', 30, -20); spawn('mammoth', -28, -24);
+    // a few gentle friends near home — the parks add their own as you explore
+    spawn('bunny', -6, -10); spawn('butterfly', 2, 4); spawn('puppy', 8, 6);
     return list;
   }
 

--- a/public/blockcraft/js/data.js
+++ b/public/blockcraft/js/data.js
@@ -45,11 +45,21 @@ ABC.BLOCK_DEFS = {
   slimeBlue:   { name:'Blue Slime',   emoji:'🔵', color:'#5dc8f5', pat:'slime', alpha:0.85, locked:true },
   oreo:        { name:'Oreo Cookie',  emoji:'🍪', color:'#2b2118', pat:'oreo',  locked:true },
   oreoPink:    { name:'Berry Oreo',   emoji:'🍓', color:'#2b2118', pat:'oreoPink', locked:true },
+  /* National Park nature blocks 🏞️ */
+  redrock:   { name:'Red Rock',     emoji:'🧱', color:'#c1572f', pat:'speck', speck:'#9c3f22' },
+  sandstone: { name:'Sandstone',    emoji:'🟧', color:'#e0a86a', pat:'speck', speck:'#c98f50' },
+  granite:   { name:'Granite',      emoji:'🗻', color:'#b8b2ad', pat:'speck', speck:'#928c87' },
+  moss:      { name:'Mossy Stone',  emoji:'🌿', color:'#6e8b54', pat:'speck', speck:'#4f6b3a' },
+  ice:       { name:'Ice',          emoji:'🧊', color:'#b9e8ff', pat:'speck', speck:'#9fd6f2', alpha:0.85 },
+  lava:      { name:'Lava',         emoji:'🌋', color:'#ff6a2b', pat:'plain', glow:true },
+  blackrock: { name:'Black Rock',   emoji:'⬛', color:'#2f2a2b', pat:'speck', speck:'#1d1a1b' },
+  canvas:    { name:'Tent Cloth',   emoji:'⛺', color:'#e8584e', pat:'plain' },
 };
 
 /* Hotbar order (unlocked-by-default first) */
 ABC.HOTBAR_ORDER = ['grass','dirt','wood','plank','brick','gold','stone','glass','sand','snow',
   'leaf','flower','rainbow','star','water','red','blue','yellow','black','white',
+  'redrock','sandstone','granite','moss','ice','lava','blackrock','canvas',
   'slab','wedge','stair','pillar','door','pane','knob',
   'slimeGreen','slimePink','slimePurple','slimeBlue','oreo','oreoPink'];
 
@@ -60,6 +70,49 @@ ABC.THEMES = [
   { key:'night',  ico:'🌙', label:'Starry Night',sky:0x32406e, grass:0xaabbe0 },
   { key:'candy',  ico:'🍭', label:'Candy Land',  sky:0xe9c8ff, grass:0xffd9ee },
 ];
+
+/* ============================================================
+   NATIONAL PARK REGIONS 🏞️ — walk a direction, reach a real park.
+   Each region has its own terrain (built in world.js), sky color
+   grading, gentle weather, a signature animal and a build to make.
+   Regions are arranged in a compass around the calm home meadow.
+   ============================================================ */
+ABC.REGIONS = (function () {
+  const HOME_R = 50;     // calm home meadow radius (no weather, gentle land)
+  const home = { key:'home', name:'Home Meadow', emoji:'🌼', weather:'clear',
+    theme:{ sky:0x9fdcff, fog:0xc8e8ff, near:60, far:150, light:0xfff7e0, lightI:0.95, hemi:0xbfe3ff, hemiI:0.4 } };
+  /* the ten parks, clockwise around the compass */
+  const parks = [
+    { key:'yosemite', name:'Yosemite Valley', emoji:'🏔️', weather:'clear', animal:'puppy', build:'cabin',
+      theme:{ sky:0xbfe3ff, fog:0xcfe8ff, near:55, far:150, light:0xfff4dd, lightI:1.0, hemi:0xbfe3ff, hemiI:0.42 } },
+    { key:'zion', name:'Zion Canyon', emoji:'🏜️', weather:'dust', animal:'bunny', build:'adobe',
+      theme:{ sky:0xffd9b0, fog:0xf0c89a, near:50, far:135, light:0xfff0d0, lightI:1.05, hemi:0xffe0bf, hemiI:0.4 } },
+    { key:'grandcanyon', name:'Grand Canyon', emoji:'🪨', weather:'clear', animal:'bunny', build:'lookout',
+      theme:{ sky:0xe9c9a0, fog:0xd9b890, near:55, far:155, light:0xfff0d8, lightI:1.05, hemi:0xf0d6b0, hemiI:0.4 } },
+    { key:'yellowstone', name:'Yellowstone', emoji:'💨', weather:'steam', animal:'mammoth', build:'tent',
+      theme:{ sky:0xcfe3ff, fog:0xd8e8c8, near:55, far:150, light:0xfff7e0, lightI:0.98, hemi:0xcfe3c8, hemiI:0.42 } },
+    { key:'olympic', name:'Olympic Rainforest', emoji:'🌲', weather:'rain', animal:'cat', build:'treehouse',
+      theme:{ sky:0x9fb6b0, fog:0xaec6bb, near:34, far:110, light:0xdfeede, lightI:0.78, hemi:0xa8c4b6, hemiI:0.34 } },
+    { key:'everglades', name:'Everglades', emoji:'🐊', weather:'rain', animal:'penguin', build:'stilt',
+      theme:{ sky:0xcfe0c0, fog:0xc0d4a8, near:42, far:120, light:0xeef6d8, lightI:0.85, hemi:0xc0d4a8, hemiI:0.38 } },
+    { key:'glacier', name:'Glacier Fjords', emoji:'🧊', weather:'snow', animal:'penguin', build:'igloo',
+      theme:{ sky:0xd4ecff, fog:0xe0f0ff, near:48, far:140, light:0xf0f8ff, lightI:0.9, hemi:0xd4ecff, hemiI:0.42 } },
+    { key:'denali', name:'Denali (Alaska)', emoji:'🏔️', weather:'snow', animal:'panda', build:'igloo',
+      theme:{ sky:0xcfe0f5, fog:0xdcecff, near:46, far:140, light:0xeaf2ff, lightI:0.85, hemi:0xcfe0f5, hemiI:0.4 } },
+    { key:'acadia', name:'Acadia Coast', emoji:'🌊', weather:'mist', animal:'penguin', build:'lighthouse',
+      theme:{ sky:0xc8d4dc, fog:0xcdd9e0, near:38, far:118, light:0xe8eef2, lightI:0.82, hemi:0xc8d4dc, hemiI:0.36 } },
+    { key:'hawaii', name:"Hawai'i Volcanoes", emoji:'🌋', weather:'clear', animal:'butterfly', build:'beachhut',
+      theme:{ sky:0xffd0a0, fog:0xf2c69a, near:55, far:150, light:0xfff0d8, lightI:1.05, hemi:0xffd6b0, hemiI:0.42 } },
+  ];
+  function regionAt(x, z) {
+    if (Math.hypot(x, z) < HOME_R) return home;
+    let a = Math.atan2(z, x) + Math.PI;            // 0..2π
+    const i = Math.floor((a / (Math.PI * 2)) * parks.length) % parks.length;
+    return parks[i];
+  }
+  return { HOME_R, home, parks, regionAt,
+    all: [home, ...parks] };
+})();
 
 /* Surprise pocket 🎁 — one surprise per day; saying what you found takes it out */
 ABC.SURPRISES = [
@@ -178,7 +231,60 @@ ABC.buildBlueprints = function () {
     }
   cell(vRoof,3,6,0,'star');                                      // porch light
 
+  /* ---- LOG CABIN 🪵 (Yosemite) ---- */
+  const cabW=[], cabR=[];
+  box(cabW, 0,0,0, 4,0,4, 'plank');
+  for (let y=1;y<=2;y++) for (let x=0;x<=4;x++) for (let z=0;z<=4;z++)
+    if (x===0||x===4||z===0||z===4) cell(cabW,x,y,z,'wood');
+  const cabWF = cabW.filter(c=>!(c.z===0&&c.x===2&&(c.y===1||c.y===2)));
+  cell(cabWF,2,1,0,'door'); cell(cabWF,1,2,0,'pane'); cell(cabWF,3,2,4,'pane'); cell(cabWF,0,2,2,'pane');
+  for (let i=0;i<3;i++) for (let x=-1;x<=5;x++) { cell(cabR,x,3+i,i,'wood'); cell(cabR,x,3+i,4-i,'wood'); }
+  cell(cabR,2,3,2,'star');
+
+  /* ---- CAMPING TENT ⛺ (Yellowstone) ---- */
+  const tentBody=[], tentTop=[];
+  box(tentBody, 0,0,0, 4,0,4, 'grass');
+  for (let z=0;z<=4;z++) { cell(tentBody,0,1,z,'canvas'); cell(tentBody,4,1,z,'canvas');
+    cell(tentBody,1,2,z,'canvas'); cell(tentBody,3,2,z,'canvas'); }
+  for (let z=0;z<=4;z++) cell(tentTop,2,3,z,'canvas');
+  cell(tentTop,2,1,0,'black'); cell(tentTop,2,2,0,'black');     // door flap opening
+  cell(tentTop,2,4,2,'star');
+
+  /* ---- IGLOO 🧊 (Glacier / Denali) ---- */
+  const igDome=[], igDoor=[];
+  for (let x=-2;x<=2;x++) for (let z=-2;z<=2;z++) cell(igDome,x,0,z,'snow');
+  const ring=[[-2,0],[2,0],[0,-2],[0,2],[-1,-1],[1,1],[-1,1],[1,-1],[-2,-1],[-2,1],[2,-1],[2,1],[-1,-2],[1,-2],[-1,2],[1,2]];
+  ring.forEach(([x,z])=>{ cell(igDome,x,1,z,'ice'); });
+  [[-1,0],[1,0],[0,-1],[0,1]].forEach(([x,z])=>cell(igDome,x,2,z,'ice'));
+  cell(igDome,0,3,0,'ice');
+  cell(igDoor,0,1,-3,'ice'); cell(igDoor,0,1,-2,'snow'); cell(igDoor,0,2,-3,'ice'); // entry tunnel
+
+  /* ---- LIGHTHOUSE 🌊 (Acadia) ---- */
+  const lhBase=[], lhTower=[], lhTop=[];
+  for (let x=-1;x<=1;x++) for (let z=-1;z<=1;z++) cell(lhBase,x,0,z,'granite');
+  for (let y=1;y<=6;y++) { cell(lhTower,0,y,0,'white');
+    cell(lhTower,1,y,0, y%2?'red':'white'); cell(lhTower,-1,y,0, y%2?'red':'white');
+    cell(lhTower,0,y,1, y%2?'red':'white'); cell(lhTower,0,y,-1, y%2?'red':'white'); }
+  cell(lhTop,0,7,0,'star'); cell(lhTop,0,8,0,'gold');
+  [[1,0],[-1,0],[0,1],[0,-1]].forEach(([x,z])=>cell(lhTop,x,7,z,'glass'));
+
   return {
+    cabin: {
+      id:'cabin', title:'🪵 Log Cabin', emoji:'🪵', site:{x:80, z:6},
+      stages:[ { name:'Log Walls & Door', cells:cabWF }, { name:'Wooden Roof & Lamp', cells:cabR } ],
+    },
+    tent: {
+      id:'tent', title:'⛺ Camping Tent', emoji:'⛺', site:{x:6, z:80},
+      stages:[ { name:'Tent Sides', cells:tentBody }, { name:'Top & Doorway', cells:tentTop } ],
+    },
+    igloo: {
+      id:'igloo', title:'🧊 Cozy Igloo', emoji:'🧊', site:{x:-80, z:-6},
+      stages:[ { name:'Snow & Ice Dome', cells:igDome }, { name:'Entry Tunnel', cells:igDoor } ],
+    },
+    lighthouse: {
+      id:'lighthouse', title:'🌊 Lighthouse', emoji:'🌊', site:{x:-6, z:-80},
+      stages:[ { name:'Base & Striped Tower', cells:lhTower.concat(lhBase) }, { name:'Glass Top & Beacon', cells:lhTop } ],
+    },
     villa: {
       id:'villa', title:'🏡 Two-Storey Villa', emoji:'🏡',
       site:{x:16, z:-22},
@@ -267,6 +373,46 @@ ABC.COACH_WRONG = [
 
 /* Each prompt: scene text, emoji, options [{t,q}] q: best | name | off. Keep text SHORT. */
 ABC.PROJECT_PROMPTS = {
+  cabin: {
+    intro: { emoji:'🪵', scene:'A cabin for the mountains! What are we making?',
+      options:[ { t:'A cozy wooden log cabin for the forest!', q:'best' }, { t:'Wood.', q:'name' }, { t:'I like blue.', q:'off' } ] },
+    stages:[
+      { emoji:'🪵', scene:'Log walls are up! Tell me:',
+        options:[ { t:'The brown log walls have a little door!', q:'best' }, { t:'Walls.', q:'name' }, { t:'Fish swim.', q:'off' } ] },
+      { emoji:'🏠', scene:'Cabin done! How does it look?',
+        options:[ { t:'My log cabin has a pointy roof and a warm lamp!', q:'best' }, { t:'Done.', q:'name' }, { t:'It is hot.', q:'off' } ] },
+    ],
+  },
+  tent: {
+    intro: { emoji:'⛺', scene:'Time to go camping! What are we building?',
+      options:[ { t:'A red camping tent to sleep in!', q:'best' }, { t:'Tent.', q:'name' }, { t:'I have toes.', q:'off' } ] },
+    stages:[
+      { emoji:'⛺', scene:'Tent sides up! What do you see?',
+        options:[ { t:'The red tent cloth makes cozy slanted walls!', q:'best' }, { t:'Red.', q:'name' }, { t:'Dogs bark.', q:'off' } ] },
+      { emoji:'🏕️', scene:'Tent finished! Describe it:',
+        options:[ { t:'My tent has a doorway to crawl in and a star on top!', q:'best' }, { t:'Done.', q:'name' }, { t:'My cup is full.', q:'off' } ] },
+    ],
+  },
+  igloo: {
+    intro: { emoji:'🧊', scene:'A house made of snow! What are we making?',
+      options:[ { t:'A round igloo made of snow and ice!', q:'best' }, { t:'Snow.', q:'name' }, { t:'I see a bus.', q:'off' } ] },
+    stages:[
+      { emoji:'❄️', scene:'The dome is built! Tell me:',
+        options:[ { t:'The white snowy dome is round like a ball!', q:'best' }, { t:'Round.', q:'name' }, { t:'I eat soup.', q:'off' } ] },
+      { emoji:'🧊', scene:'Igloo done! How does it look?',
+        options:[ { t:'My igloo has an icy tunnel to crawl inside!', q:'best' }, { t:'Done.', q:'name' }, { t:'Birds fly.', q:'off' } ] },
+    ],
+  },
+  lighthouse: {
+    intro: { emoji:'🌊', scene:'A tower by the sea! What are we building?',
+      options:[ { t:'A tall lighthouse to shine over the ocean!', q:'best' }, { t:'Tower.', q:'name' }, { t:'I like apples.', q:'off' } ] },
+    stages:[
+      { emoji:'🚥', scene:'Striped tower is up! What do you see?',
+        options:[ { t:'The tall tower has red and white stripes!', q:'best' }, { t:'Tall.', q:'name' }, { t:'Cats nap.', q:'off' } ] },
+      { emoji:'🌊', scene:'Lighthouse done! Describe it:',
+        options:[ { t:'My lighthouse has a glass top with a bright glowing light!', q:'best' }, { t:'Done.', q:'name' }, { t:'It is Tuesday.', q:'off' } ] },
+    ],
+  },
   villa: {
     intro: { emoji:'🏡', scene:'A BIG project! What are we building?',
       options:[

--- a/public/blockcraft/js/main.js
+++ b/public/blockcraft/js/main.js
@@ -43,6 +43,7 @@
   ABC.squishy.init(scene);
   ABC.portal.init(scene);
   ABC.music.init(scene);
+  ABC.weather.init(scene);
 
   ABC.teleport = (x, y, z) => { feet.set(x, y, z); vy = 0; };
 
@@ -581,6 +582,7 @@
         stickers: ABC.stickers.serialize(),
         overnight: ABC.overnight.serialize(),
         photo: ABC.photo.serialize(),
+        parks: ABC.parks.serialize(),
         playerName: ABC.state.playerName,
         portalCharge: ABC.state.portalCharge || 0,
         quests: ABC.state.quests || null,
@@ -614,6 +616,7 @@
       ABC.world.deserialize(d.world);
       ABC.squishy.deserialize(d.squishies);
       ABC.pet.deserialize(d.pet);
+      ABC.parks.deserialize(d.parks);
       ABC.stickers.deserialize(d.stickers);
       ABC.overnight.deserialize(d.overnight);
       ABC.photo.deserialize(d.photo);
@@ -651,6 +654,7 @@
   $('zoomInBtn').onclick   = () => setZoom(-0.18);
   $('zoomOutBtn').onclick  = () => setZoom(+0.18);
   $('mapBtn').onclick      = () => showMap();
+  $('passportBtn').onclick = () => ABC.parks.openPassport();
   $('photoBtn').onclick    = () => ABC.photo.takePhoto();
   $('albumBtn').onclick    = () => ABC.photo.openAlbum();
   $('stickersBtn').onclick = () => ABC.stickers.openBook();
@@ -742,10 +746,17 @@
     last = now;
     if (started) {
       chunkTimer += dt;
-      if (chunkTimer > 0.3) { chunkTimer = 0; ABC.world.ensureChunks(feet.x, feet.z); }
+      if (chunkTimer > 0.3) {
+        chunkTimer = 0;
+        ABC.world.ensureChunks(feet.x, feet.z);
+        const reg = ABC.parks.check(feet);                          // park arrival + passport
+        ABC.weather.setType(ABC.audio.settings.weather === false ? 'clear' : reg.weather);
+      }
+      ABC.world.gradeFrame(feet.x, feet.z, dt);                     // color-grade the sky by region
       updatePlayer(dt);
       updateFly(dt);
       updateParticles(dt);
+      ABC.weather.update(dt, camera.position);
       ABC.animals.update(dt, now / 1000);
       ABC.pet.update(dt, feet);
       ABC.squishy.update(dt, camera);

--- a/public/blockcraft/js/parks.js
+++ b/public/blockcraft/js/parks.js
@@ -1,0 +1,74 @@
+/* Aaria's Block Craft 3D — National Park Passport 📔: travel to real parks,
+   hear their name, describe what you see, and collect a stamp for each one. */
+ABC.parks = (function () {
+  let visited = new Set();
+  let cur = null;
+
+  /* what to say when you first arrive at each park (describing words!) */
+  const DESC = {
+    yosemite:    { best: 'I see tall grey granite cliffs and pointy green pine trees!', off: 'I like soup.' },
+    zion:        { best: 'I see big red rocks and warm orange sand all around!', off: 'My shoe is wet.' },
+    grandcanyon: { best: 'I see deep canyon walls with a blue river far below!', off: 'Cats sleep.' },
+    yellowstone: { best: 'I see golden grass and steamy water springs!', off: 'I have a ball.' },
+    olympic:     { best: 'I see a green rainforest with mossy ground and soft rain!', off: 'It is loud.' },
+    everglades:  { best: 'I see a wet swamp with tall reeds and shallow water!', off: 'I eat toast.' },
+    glacier:     { best: 'I see icy blue water and shiny white snow everywhere!', off: 'Buses go fast.' },
+    denali:      { best: 'I see huge snowy mountains touching the sky!', off: 'My hat is red.' },
+    acadia:      { best: 'I see the blue ocean splashing on grey rocky cliffs!', off: 'Dogs bark.' },
+    hawaii:      { best: 'I see black rocks and glowing orange lava by the sea!', off: 'I like Tuesdays.' },
+  };
+
+  function check(feet) {
+    const reg = ABC.REGIONS.regionAt(feet.x, feet.z);
+    if (reg.key === cur) return reg;
+    cur = reg.key;
+    if (reg.key === 'home') return reg;
+    const first = !visited.has(reg.key);
+    ABC.ui.bellaSays(`${reg.emoji} Welcome to ${reg.name}!`, 4200);
+    if (first) {
+      visited.add(reg.key);
+      ABC.saveSoon && ABC.saveSoon();
+      ABC.ui.confetti(20);
+      // one signature animal greets you (fewer animals, more meaningful)
+      if (reg.animal && ABC.animals && ABC.animals.list.length < 22) {
+        const a = ABC.animals.spawn(reg.animal, Math.round(feet.x) + 3, Math.round(feet.z) + 3);
+        (ABC.state.friends = ABC.state.friends || []).push({ kind: reg.animal, x: a.group.position.x, z: a.group.position.z, name: a.name });
+      }
+      setTimeout(() => { if (!ABC.ui.isOpen()) describe(reg); }, 1800);
+    }
+    return reg;
+  }
+
+  function describe(reg) {
+    const d = DESC[reg.key] || { best: `I am exploring ${reg.name}!`, off: 'I like blue.' };
+    ABC.ui.askExpressive({
+      emoji: reg.emoji,
+      scene: `You stamped your passport at ${reg.name}! Tell me what you see.`,
+      options: [
+        { t: d.best, q: 'best' },
+        { t: reg.name.split(' ')[0] + '.', q: 'name' },
+        { t: d.off, q: 'off' } ],
+    }, () => {
+      ABC.ui.bellaSays(`${reg.emoji} A new stamp for your passport! ${visited.size}/${ABC.REGIONS.parks.length} parks!`, 5000);
+    }, { stars: 2 });
+  }
+
+  function openPassport() {
+    let html = `<div class="bigEmoji">📔</div><h2>My Park Passport — ${visited.size}/${ABC.REGIONS.parks.length}</h2>
+      <div class="scene" style="font-size:15px;">Walk in any direction to find a new park!</div><div class="pickGrid">`;
+    ABC.REGIONS.parks.forEach(p => {
+      const has = visited.has(p.key);
+      html += `<div class="pickCard" style="cursor:default; ${has ? 'border-color:#51cf66; background:#eaffea;' : 'opacity:.5;'}">
+        <span class="ico">${has ? p.emoji : '❓'}</span>${has ? p.name : '???'}</div>`;
+    });
+    html += `</div><div class="dlgRow"><button class="bigBtn green" id="ppOk">Adventure! 🧭</button></div>`;
+    ABC.ui.openDialog(html);
+    ABC.audio.say(`Your park passport. You have visited ${visited.size} of ${ABC.REGIONS.parks.length} national parks!`);
+    document.getElementById('ppOk').onclick = () => ABC.ui.closeDialog();
+  }
+
+  function serialize() { return { visited: [...visited] }; }
+  function deserialize(d) { if (d && d.visited) visited = new Set(d.visited); }
+
+  return { check, openPassport, serialize, deserialize, count: () => visited.size };
+})();

--- a/public/blockcraft/js/ui.js
+++ b/public/blockcraft/js/ui.js
@@ -500,6 +500,7 @@ ABC.ui = (function () {
       { ico: '📋', label: 'Adventures', go: () => { closeDialog(); ABC.quests.showBoard(); } },
       { ico: '🌻', label: 'Sunflower',  go: () => { closeDialog(); ABC.overnight.showFlower(); } },
       { ico: '🗺️', label: 'Map',        go: press('mapBtn') },
+      { ico: '📔', label: 'Parks',      go: press('passportBtn') },
       { ico: '📸', label: 'Photo',      go: press('photoBtn') },
       { ico: '🖼️', label: 'Album',      go: press('albumBtn') },
       { ico: '👀', label: 'View',       go: press('viewBtn') },
@@ -529,6 +530,7 @@ ABC.ui = (function () {
       <button class="choiceBtn" id="setTheme">🎨 World colors — tap to change the sky!</button>
       <button class="choiceBtn" id="setSound">${chk(s.sound)} 🎵 Sound effects</button>
       <button class="choiceBtn" id="setMusic">${chk(s.music)} 🎶 Gentle music</button>
+      <button class="choiceBtn" id="setWeather">${chk(s.weather !== false)} 🌦️ Gentle weather (rain &amp; snow)</button>
       <button class="choiceBtn" id="setReset" style="border-color:#ffa8a8;">🧹 Start a brand-new world (erases this one)</button>
       <div class="scene" style="font-size:15px; color:#557;">Made with 💙 by <b>${ABC.BRAND.org}</b> — ${ABC.BRAND.tagline}<br>${ABC.BRAND.url.replace('https://','')}</div>
       <div class="dlgRow"><button class="bigBtn green" id="setDone">Done ✔</button></div>`);
@@ -550,14 +552,16 @@ ABC.ui = (function () {
     wire('setVoice', () => { s.voiceMode = !s.voiceMode; ABC.saveSoon(); showSettings(); });
     wire('setVoiceName', () => { ABC.audio.cycleVoice(); ABC.saveSoon(); showSettings(); });
     wire('setTheme', () => {
-      pickCard('World Colors 🎨', 'Pick a mood for your world!',
-        ABC.THEMES.map(t => ({ ico: t.ico, label: t.label, t })),
+      const opts = [{ key:'auto', ico:'🏞️', label:'By Place (auto)' }].concat(ABC.THEMES);
+      pickCard('World Colors 🎨', 'Each national park has its own sky — or pick one mood for everywhere!',
+        opts.map(t => ({ ico: t.ico, label: t.label, t })),
         (c) => { closeDialog(); ABC.world.setTheme(c.t.key); s.theme = c.t.key; ABC.saveSoon();
                  toast(c.t.ico + ' ' + c.t.label + '!', 2600, true); }, '🎨');
     });
     wire('setRead',  () => { s.readAloud = !s.readAloud; ABC.saveSoon(); showSettings(); });
     wire('setSound', () => { s.sound = !s.sound; ABC.saveSoon(); showSettings(); });
     wire('setMusic', () => { s.music = !s.music; ABC.saveSoon(); showSettings(); });
+    wire('setWeather', () => { s.weather = s.weather === false; ABC.saveSoon(); showSettings(); });
     wire('setDone',  () => closeDialog());
     wire('setReset', () => {
       message('Start over?', 'This erases the whole world. Are you sure?', 'Yes, new world! 🌍', () => {

--- a/public/blockcraft/js/weather.js
+++ b/public/blockcraft/js/weather.js
@@ -1,0 +1,64 @@
+/* Aaria's Block Craft 3D — gentle weather 🌦️: rain, snow, drifting dust,
+   rising geyser steam, soft mist. Always calm — no thunder, no flashes. */
+ABC.weather = (function () {
+  let scene = null, pts = null, geo = null, mat = null, pos = null, type = 'clear';
+  const N = 340, BOX = 30, TOP = 22;
+
+  function init(sc) {
+    scene = sc;
+    pos = new Float32Array(N * 3);
+    for (let i = 0; i < N; i++) {
+      pos[i*3] = (Math.random()*2-1)*BOX;
+      pos[i*3+1] = Math.random()*TOP;
+      pos[i*3+2] = (Math.random()*2-1)*BOX;
+    }
+    geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+    mat = new THREE.PointsMaterial({ size: 0.35, transparent: true, opacity: 0.8,
+      depthWrite: false, color: 0xffffff, sizeAttenuation: true });
+    pts = new THREE.Points(geo, mat);
+    pts.frustumCulled = false;
+    pts.visible = false;
+    scene.add(pts);
+  }
+
+  const CFG = {
+    clear: null,
+    rain:  { color: 0xaccbff, size: 0.16, vy: -24, sway: 0,   vx: 0,   op: 0.55 },
+    snow:  { color: 0xffffff, size: 0.42, vy: -3.0, sway: 1.5, vx: 0,   op: 0.95 },
+    dust:  { color: 0xe2caa0, size: 0.28, vy: -0.5, sway: 0,   vx: 5.5, op: 0.45 },
+    steam: { color: 0xffffff, size: 0.6,  vy: 3.2,  sway: 0.7, vx: 0,   op: 0.4  },
+    mist:  { color: 0xeaf2f5, size: 0.95, vy: 0.2,  sway: 0.3, vx: 1.4, op: 0.38 },
+  };
+
+  function setType(tp) {
+    if (tp === type || !pts) return;
+    type = tp;
+    const c = CFG[tp];
+    if (!c) { pts.visible = false; return; }
+    pts.visible = true;
+    mat.color.set(c.color); mat.size = c.size; mat.opacity = c.op;
+  }
+
+  function update(dt, cam) {
+    if (!pts || !pts.visible) return;
+    const c = CFG[type]; if (!c) return;
+    const cx = cam.x, cy = cam.y, cz = cam.z;
+    for (let i = 0; i < N; i++) {
+      const j = i * 3;
+      pos[j+1] += c.vy * dt;
+      if (c.sway) pos[j] += Math.sin((pos[j+1] + i) * 1.5) * c.sway * dt;
+      if (c.vx) pos[j] += c.vx * dt;
+      const off = pos[j+1] < cy - 4 || pos[j+1] > cy + TOP ||
+                  Math.abs(pos[j] - cx) > BOX || Math.abs(pos[j+2] - cz) > BOX;
+      if (off) {
+        pos[j]   = cx + (Math.random()*2-1) * BOX;
+        pos[j+2] = cz + (Math.random()*2-1) * BOX;
+        pos[j+1] = c.vy > 0 ? cy - 3 + Math.random()*3 : cy + TOP * Math.random();
+      }
+    }
+    geo.attributes.position.needsUpdate = true;
+  }
+
+  return { init, setType, update, serialize: () => ({}), deserialize: () => {} };
+})();

--- a/public/blockcraft/js/world.js
+++ b/public/blockcraft/js/world.js
@@ -315,15 +315,32 @@ ABC.world = (function () {
   }
 
   /* ---------- color themes 🎨 ---------- */
-  let hemiLight = null;
+  let hemiLight = null, sunLight = null, lockedTheme = null;
+  /* a manual theme from Settings locks the look; 'auto' (or null) lets the
+     world color-grade by national-park region as you walk 🏞️ */
   function setTheme(key) {
-    const t = (ABC.THEMES || []).find(t => t.key === key) || ABC.THEMES[0];
-    scene.background = new THREE.Color(t.sky);
-    scene.fog.color.set(t.sky);
-    if (hemiLight) hemiLight.color.set(t.sky);
-    const dark = key === 'night';
-    scene.traverse(o => { if (o.isLight && o.isDirectionalLight) o.intensity = dark ? 0.45 : 0.95; });
-    if (hemiLight) hemiLight.intensity = dark ? 0.2 : 0.35;
+    if (!key || key === 'auto') { lockedTheme = null; return; }
+    lockedTheme = (ABC.THEMES || []).find(t => t.key === key) || null;
+  }
+  const _c1 = new THREE.Color(), _c2 = new THREE.Color();
+  function gradeTo(th, dt) {
+    if (!scene) return;
+    const k = Math.min(1, dt * 0.7);
+    const sky = th.sky, fog = th.fog != null ? th.fog : th.sky;
+    const near = th.near != null ? th.near : 60, far = th.far != null ? th.far : 150;
+    const light = th.light != null ? th.light : 0xfff7e0, lightI = th.lightI != null ? th.lightI : 0.95;
+    const hemi = th.hemi != null ? th.hemi : sky, hemiI = th.hemiI != null ? th.hemiI : 0.38;
+    if (scene.background.isColor) scene.background.lerp(_c1.set(sky), k);
+    scene.fog.color.lerp(_c1.set(fog), k);
+    scene.fog.near += (near - scene.fog.near) * k;
+    scene.fog.far += (far - scene.fog.far) * k;
+    if (sunLight) { sunLight.color.lerp(_c1.set(light), k); sunLight.intensity += (lightI - sunLight.intensity) * k; }
+    if (hemiLight) { hemiLight.color.lerp(_c1.set(hemi), k); hemiLight.intensity += (hemiI - hemiLight.intensity) * k; }
+  }
+  /* called every frame from the main loop with the player position */
+  function gradeFrame(x, z, dt) {
+    const target = lockedTheme || (ABC.REGIONS ? ABC.REGIONS.regionAt(x, z).theme : null);
+    if (target) gradeTo(target, dt);
   }
 
   /* ---------- scene setup ---------- */
@@ -331,9 +348,9 @@ ABC.world = (function () {
     scene = new THREE.Scene();
     scene.background = new THREE.Color(0x9fdcff);
     scene.fog = new THREE.Fog(0x9fdcff, 60, 140);
-    const sun = new THREE.DirectionalLight(0xfff7e0, 0.95);
-    sun.position.set(40, 80, 25);
-    scene.add(sun);
+    sunLight = new THREE.DirectionalLight(0xfff7e0, 0.95);
+    sunLight.position.set(40, 80, 25);
+    scene.add(sunLight);
     scene.add(new THREE.AmbientLight(0xcfe8ff, 0.75));
     hemiLight = new THREE.HemisphereLight(0xbfe3ff, 0x7ed957, 0.35);
     scene.add(hemiLight);
@@ -425,23 +442,110 @@ ABC.world = (function () {
     for (let dx = -2; dx <= 2; dx++) for (let dz = -2; dz <= 2; dz++) for (let dy = 0; dy <= 2; dy++)
       if (Math.abs(dx) + Math.abs(dz) + dy < 4) gset(keys, x + dx, baseY + th + dy, z + dz, 'leaf');
   }
+  function genPine(keys, x, z, baseY) {     // tall conifer for forests/valleys
+    const h = 4 + ((hash2(x, z) * 3) | 0);
+    for (let y = 1; y <= h; y++) gset(keys, x, baseY + y, z, 'wood');
+    for (let r = 2; r >= 0; r--) {
+      const yy = baseY + h - (2 - r);
+      for (let dx = -r; dx <= r; dx++) for (let dz = -r; dz <= r; dz++)
+        if (Math.abs(dx) + Math.abs(dz) <= r) gset(keys, x + dx, yy, z + dz, 'leaf');
+    }
+    gset(keys, x, baseY + h + 1, z, 'leaf');
+  }
+  function genHome(keys, x, z) {             // calm flat home meadow
+    gset(keys, x, 0, z, 'grass');
+    const sp = Math.hypot(x, z), h = hash2(x * 3 + 1, z * 3 + 7);
+    if (vnoise(x + 777, z - 777, 34) > 0.6 && h < 0.06 && sp > 16) genTree(keys, x, z, 0);
+    else if (h < 0.013) gset(keys, x, 1, z, 'flower');
+  }
+  /* region terrain — each US national park looks distinct 🏞️ */
   function genColumn(keys, x, z) {
-    const sp = Math.hypot(x, z);
-    let e = vnoise(x, z, 46), m = vnoise(x + 777, z - 777, 34);
-    let rv = Math.abs(vnoise(x - 911, z + 911, 70) - 0.5);
-    if (sp < 34) { e = 0.45; rv = 0.5; m = 0.4; }          // calm flat home meadow
-    const mount = e > 0.70 ? Math.round((e - 0.70) * 34) : 0;
-    const water = mount === 0 && rv < 0.035;
     gset(keys, x, -2, z, 'stone');                          // bedrock
     gset(keys, x, -1, z, 'dirt');
-    if (water) { gset(keys, x, 0, z, 'water'); return; }
-    gset(keys, x, 0, z, (rv < 0.055 && mount === 0) ? 'sand' : 'grass');
-    for (let y = 1; y <= mount; y++)
-      gset(keys, x, y, z, (y >= mount - 1 && mount > 5) ? 'snow' : 'stone');
-    if (mount === 0) {
-      const h = hash2(x * 3 + 1, z * 3 + 7);
-      if (m > 0.60 && h < 0.085 && sp > 16) genTree(keys, x, z, 0);
-      else if (h < 0.013) gset(keys, x, 1, z, 'flower');
+    const reg = ABC.REGIONS.regionAt(x, z);
+    if (reg.key === 'home') return genHome(keys, x, z);
+    const sp = Math.hypot(x, z);
+    const t = Math.min(1, Math.max(0, (sp - ABC.REGIONS.HOME_R) / 30));  // ease in from home
+    const hsh = hash2(x * 3 + 1, z * 3 + 7);
+    const col = (y0, top, sub) => { for (let y = 1; y <= y0; y++) gset(keys, x, y, z, y === y0 ? top : sub); };
+    switch (reg.key) {
+      case 'yosemite': {
+        gset(keys, x, 0, z, 'grass');
+        const cf = vnoise(x + 50, z - 20, 26);
+        const mh = cf > 0.62 ? Math.round((cf - 0.62) * 70 * t) : 0;
+        for (let y = 1; y <= mh; y++) gset(keys, x, y, z, (y > mh - 2 && mh > 7) ? 'snow' : 'granite');
+        if (mh === 0 && vnoise(x, z, 26) > 0.6 && hsh < 0.06) genPine(keys, x, z, 0);
+        break;
+      }
+      case 'zion': {
+        gset(keys, x, 0, z, 'sand');
+        const me = vnoise(x - 30, z + 40, 30);
+        const mh = me > 0.58 ? Math.round((me - 0.58) * 64 * t) : 0;
+        for (let y = 1; y <= mh; y++) gset(keys, x, y, z, (y % 3 === 0) ? 'sandstone' : 'redrock');
+        break;
+      }
+      case 'grandcanyon': {
+        const river = Math.abs(vnoise(x + 11, z - 77, 64) - 0.5);
+        if (river < 0.04) { gset(keys, x, 0, z, 'water'); break; }
+        gset(keys, x, 0, z, 'sandstone');
+        const wall = Math.round((0.5 - river) * 2 * 11 * t);
+        for (let y = 1; y <= wall; y++) gset(keys, x, y, z, (Math.floor(y / 2) % 2) ? 'redrock' : 'sandstone');
+        break;
+      }
+      case 'yellowstone': {
+        gset(keys, x, 0, z, 'grass');
+        if (vnoise(x + 5, z + 5, 18) > 0.8) gset(keys, x, 0, z, 'water');   // hot springs
+        else if (hsh < 0.012) gset(keys, x, 1, z, 'flower');
+        break;
+      }
+      case 'olympic': {
+        gset(keys, x, 0, z, 'moss');
+        if (vnoise(x, z, 18) > 0.5 && hsh < 0.16) genPine(keys, x, z, 0);    // dense rainforest
+        break;
+      }
+      case 'everglades': {
+        if (vnoise(x, z, 14) < 0.46) {
+          gset(keys, x, 0, z, 'water');
+          if (hash2(x, z) < 0.05) { gset(keys, x, 1, z, 'leaf'); gset(keys, x, 2, z, 'leaf'); }  // reeds
+        } else { gset(keys, x, 0, z, 'grass'); if (hsh < 0.05) genTree(keys, x, z, 0); }
+        break;
+      }
+      case 'glacier': {
+        const fj = Math.abs(vnoise(x, z, 40) - 0.5);
+        if (fj < 0.06) { gset(keys, x, 0, z, 'water'); break; }
+        gset(keys, x, 0, z, vnoise(x + 9, z, 20) > 0.6 ? 'ice' : 'snow');
+        const pk = vnoise(x - 40, z + 10, 30);
+        const mh = pk > 0.66 ? Math.round((pk - 0.66) * 54 * t) : 0;
+        for (let y = 1; y <= mh; y++) gset(keys, x, y, z, 'snow');
+        break;
+      }
+      case 'denali': {
+        gset(keys, x, 0, z, 'snow');
+        const pk = vnoise(x + 20, z - 20, 34);
+        const mh = pk > 0.5 ? Math.round((pk - 0.5) * 64 * t) : 0;
+        for (let y = 1; y <= mh; y++) gset(keys, x, y, z, (y > mh - 3) ? 'snow' : 'stone');
+        break;
+      }
+      case 'acadia': {
+        const oc = vnoise(x, z, 46);
+        if (oc < 0.46) { gset(keys, x, 0, z, 'water'); break; }
+        gset(keys, x, 0, z, oc < 0.52 ? 'sand' : 'grass');
+        const rk = vnoise(x + 30, z, 18);
+        const mh = rk > 0.7 ? Math.round((rk - 0.7) * 30 * t) : 0;
+        for (let y = 1; y <= mh; y++) gset(keys, x, y, z, 'granite');
+        break;
+      }
+      case 'hawaii': {
+        const oc = vnoise(x, z, 50);
+        if (oc < 0.4) { gset(keys, x, 0, z, 'water'); break; }
+        gset(keys, x, 0, z, oc < 0.46 ? 'sand' : 'blackrock');
+        if (oc >= 0.46 && vnoise(x + 7, z + 7, 16) > 0.84) gset(keys, x, 1, z, 'lava');
+        const vc = vnoise(x - 25, z - 25, 30);
+        const mh = vc > 0.7 ? Math.round((vc - 0.7) * 54 * t) : 0;
+        for (let y = 1; y <= mh; y++) gset(keys, x, y, z, (y > mh - 2 && mh > 6) ? 'lava' : 'blackrock');
+        break;
+      }
+      default: gset(keys, x, 0, z, 'grass');
     }
   }
   function genHouse(keys, hx, hz) {          // a discoverable village house
@@ -459,11 +563,6 @@ ABC.world = (function () {
     const keys = [];
     for (let x = cx * CHUNK; x < (cx + 1) * CHUNK; x++)
       for (let z = cz * CHUNK; z < (cz + 1) * CHUNK; z++) genColumn(keys, x, z);
-    // sometimes a cozy village house appears in flat, dry land
-    const hcx = cx * CHUNK + 5, hcz = cz * CHUNK + 5;
-    if (Math.hypot(hcx, hcz) > 48 && hash2(cx * 13, cz * 17) < 0.05 &&
-        vnoise(hcx, hcz, 46) < 0.62 && Math.abs(vnoise(hcx - 911, hcz + 911, 70) - 0.5) > 0.08)
-      genHouse(keys, hcx, hcz);
     // handcrafted spawn features (arch, markets, garden, sky island)
     for (const [k, v] of structMap) {
       const [x, , z] = k.split(',').map(Number);
@@ -570,6 +669,6 @@ ABC.world = (function () {
 
   return { SIZE, MAX_Y, MIN_Y, initScene, generate: infiniteInit, get, set, remove, flush, key,
            blockMeshes, serialize: serializeEdits, deserialize: deserializeEdits, materials,
-           ensureChunks, setTheme, getRot, topBlock,
+           ensureChunks, setTheme, gradeFrame, getRot, topBlock,
            getScene: () => scene };
 })();


### PR DESCRIPTION
Travel from the calm home meadow in any direction to reach a real US National Park, each a distinct voxel biome with its own sky and gentle weather.

- 🏞️ **10 parks by compass**: Yosemite, Zion, Grand Canyon, Yellowstone, Olympic, Everglades, Glacier, Denali (Alaska), Acadia, Hawai'i Volcanoes
- 🌦️ **Gentle weather** per region (rain/snow/dust/steam/mist) — no thunder ever; Settings toggle
- 🎨 **Sky color-grading** shifts smoothly across park borders; 'By Place (auto)' or a fixed mood
- 📔 **Park Passport**: arrival banner + describing prompt + stamp on first visit; signature animal greets you
- 🪵⛺🧊🌊 **Region buildings**: Log Cabin, Camping Tent, Igloo, Lighthouse
- 🐾 **Fewer, meaningful animals** — declutters the world
- New nature blocks (red rock, sandstone, granite, moss, ice, lava, black rock)

Note: new world save key (v3 infinite already); existing builds reachable. Verified error-free headless boot. Cache v=17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)