### PR TITLE
Block Craft: shops & villages — food, water, trading posts everywhere

### DIFF
--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -301,21 +301,22 @@
 <div id="flash"></div>
 
 <script src="lib/three.min.js"></script>
-<script src="js/data.js?v=20"></script>
-<script src="js/audio.js?v=20"></script>
-<script src="js/world.js?v=20"></script>
-<script src="js/animals.js?v=20"></script>
-<script src="js/squishy.js?v=20"></script>
-<script src="js/weather.js?v=20"></script>
-<script src="js/parks.js?v=20"></script>
-<script src="js/portal.js?v=20"></script>
-<script src="js/ui.js?v=20"></script>
-<script src="js/activities.js?v=20"></script>
-<script src="js/music.js?v=20"></script>
-<script src="js/pet.js?v=20"></script>
-<script src="js/stickers.js?v=20"></script>
-<script src="js/overnight.js?v=20"></script>
-<script src="js/photo.js?v=20"></script>
-<script src="js/main.js?v=20"></script>
+<script src="js/data.js?v=21"></script>
+<script src="js/audio.js?v=21"></script>
+<script src="js/world.js?v=21"></script>
+<script src="js/animals.js?v=21"></script>
+<script src="js/squishy.js?v=21"></script>
+<script src="js/weather.js?v=21"></script>
+<script src="js/parks.js?v=21"></script>
+<script src="js/shops.js?v=21"></script>
+<script src="js/portal.js?v=21"></script>
+<script src="js/ui.js?v=21"></script>
+<script src="js/activities.js?v=21"></script>
+<script src="js/music.js?v=21"></script>
+<script src="js/pet.js?v=21"></script>
+<script src="js/stickers.js?v=21"></script>
+<script src="js/overnight.js?v=21"></script>
+<script src="js/photo.js?v=21"></script>
+<script src="js/main.js?v=21"></script>
 </body>
 </html>

--- a/public/blockcraft/js/activities.js
+++ b/public/blockcraft/js/activities.js
@@ -218,9 +218,11 @@ ABC.activities = (function () {
 
   /* 🏪 the village market — ask politely, pay with stars, say thank you */
   function shop(a) {
-    ui().pickCard('Village Market 🏪',
+    const goods = (a.shopGoods || ['water', 'apple', 'cookie'])
+      .map(k => ABC.GOODS[k]).filter(Boolean);
+    ui().pickCard(`${a.name}'s Shop 🏪`,
       `Hello, {player}! I’m ${a.name}. What would you like today? You have ${ABC.state.stars} ⭐`,
-      ABC.SHOP_GOODS.map(g => ({ ico: g.ico, label: `${g.label} — ${g.price}⭐`, g })),
+      goods.map(g => ({ ico: g.ico, label: `${g.label} — ${g.price}⭐`, g })),
       (card) => {
         const g = card.g;
         if (ABC.state.stars < g.price) {
@@ -232,7 +234,7 @@ ABC.activities = (function () {
           emoji: g.ico,
           scene: `${a.name} smiles. How do we ask to buy it?`,
           options: [
-            { t: `Can I buy ${g.word}, please? Here are ${g.price} stars.`, q: 'best' },
+            { t: `Can I have ${g.word}, please? Here are ${g.price} stars.`, q: 'best' },
             { t: 'Want.', q: 'name' },
             { t: 'My hat is red.', q: 'off' } ],
         }, () => {
@@ -240,11 +242,14 @@ ABC.activities = (function () {
           ui().refreshScore();
           ABC.saveSoon && ABC.saveSoon();
           const p = ABC.player.position;
-          if (g.grant === 'apples') { ui().addHearts(1); ui().toast('🍎 Yum! Share the apples with your animal friends!', 3600, true); }
-          if (g.grant === 'balloon') { ui().floatHearts(8); ABC.portal.charge(2); ui().toast('🎈 The magic balloon fills you with word power!', 3600, true); }
-          if (g.grant === 'lamps') { for (let i=0;i<3;i++) ABC.world.set(Math.round(p.x)+i-1, 1, Math.round(p.z)-3, 'star'); ABC.world.flush(); ui().toast('⭐ Three glowing lamps, all yours!', 3400, true); }
-          if (g.grant === 'cookie') { ABC.squishy.spawn({ kind:'cutout', shape:'circle', colorHex:0x8a5a2b, x:Math.round(p.x)+2, z:Math.round(p.z)+2 }); ui().toast('🍪 One yummy cookie! What do we say? THANK YOU!', 3800, true); }
-          ui().bellaSays(`${a.name} says: thank you for shopping and for your lovely words! 💛`, 4600);
+          const k = g.kind;
+          if (k === 'water') { ABC.audio.sfx.gentle(); ui().floatHearts(2); ui().toast(`${g.ico} Glug glug — so refreshing! Ahh!`, 3600, true); }
+          else if (k === 'food') { ABC.audio.sfx.munch(); ui().addHearts(1); ui().toast(`${g.ico} Yum yum! Thank you, ${a.name}!`, 3600, true); }
+          else if (k === 'cookie') { ABC.squishy.spawn({ kind:'cutout', shape:'circle', colorHex:0x8a5a2b, x:Math.round(p.x)+2, z:Math.round(p.z)+2 }); ui().toast('🍪 A yummy cookie appeared! What do we say? THANK YOU!', 3800, true); }
+          else if (k === 'blocks') { for (let i=0;i<3;i++) ABC.world.set(Math.round(p.x)+i-1, Math.round(p.y)-1, Math.round(p.z)-3, 'star'); ABC.world.flush(); ui().toast('⭐ Three glowing lamps, all yours!', 3400, true); }
+          else if (k === 'balloon') { ui().floatHearts(8); ABC.portal.charge(2); ui().toast('🎈 The magic balloon fills you with word power!', 3600, true); }
+          ABC.stickers && ABC.stickers.award && ABC.stickers.award('shopper');
+          ui().bellaSays(`${a.name} says: thank you for shopping and for your kind words! 💛`, 4600);
         }, { stars: 0 });
       }, '🏪');
   }

--- a/public/blockcraft/js/animals.js
+++ b/public/blockcraft/js/animals.js
@@ -214,9 +214,7 @@ ABC.animals = (function () {
     // Bella the Blue Elephant — guide, stays near spawn
     const bella = spawn('elephant', 4, -8, 'Bella');
     bella.isGuide = true; bella.home = {x:4, z:-8}; bella.range = 6;
-    // 🏪 Mr. Maple runs the home-meadow market
-    const vendor = spawn('capy', -14, 4, 'Mr. Maple');
-    vendor.isVendor = true; vendor.home = { x: -14, z: 4 }; vendor.range = 2;
+    // shops (incl. vendors) are placed by ABC.shops after spawnAll
     // a few gentle friends near home — the parks add their own as you explore
     spawn('bunny', -6, -10); spawn('butterfly', 2, 4); spawn('puppy', 8, 6);
     return list;

--- a/public/blockcraft/js/data.js
+++ b/public/blockcraft/js/data.js
@@ -134,12 +134,39 @@ ABC.SURPRISES = [
 ];
 
 /* Village market 🏪 — learn asking, paying and thanking */
-ABC.SHOP_GOODS = [
-  { ico:'🍎', label:'Apple Basket', price:2, word:'the apple basket', grant:'apples' },
-  { ico:'🎈', label:'Magic Balloon', price:3, word:'a magic balloon', grant:'balloon' },
-  { ico:'⭐', label:'Lamp Blocks',  price:4, word:'three glowing lamp blocks', grant:'lamps' },
-  { ico:'🍪', label:'Cookie Treat', price:2, word:'a cookie treat', grant:'cookie' },
-];
+/* one shared catalog of food, water & treats — sold at shops everywhere 🏪 */
+ABC.GOODS = {
+  water:    { ico:'💧', label:'Water Bottle', price:1, word:'a cool water bottle', kind:'water' },
+  juice:    { ico:'🧃', label:'Juice Box',    price:2, word:'a sweet juice box',   kind:'food' },
+  banana:   { ico:'🍌', label:'Banana',       price:2, word:'a yellow banana',      kind:'food' },
+  apple:    { ico:'🍎', label:'Apple',        price:2, word:'a red apple',          kind:'food' },
+  berries:  { ico:'🫐', label:'Berries',      price:2, word:'a cup of berries',     kind:'food' },
+  melon:    { ico:'🍉', label:'Watermelon',   price:3, word:'a juicy watermelon',   kind:'food' },
+  sandwich: { ico:'🥪', label:'Sandwich',     price:3, word:'a yummy sandwich',     kind:'food' },
+  soup:     { ico:'🍲', label:'Warm Soup',    price:3, word:'a bowl of warm soup',  kind:'food' },
+  fish:     { ico:'🐟', label:'Fresh Fish',   price:3, word:'a fresh fish',         kind:'food' },
+  milk:     { ico:'🥛', label:'Milk',         price:2, word:'a glass of milk',      kind:'food' },
+  cookie:   { ico:'🍪', label:'Cookie',       price:2, word:'a yummy cookie',       kind:'cookie' },
+  lamps:    { ico:'⭐', label:'Lamp Blocks',  price:4, word:'three glowing lamps',  kind:'blocks' },
+  balloon:  { ico:'🎈', label:'Magic Balloon',price:3, word:'a magic balloon',      kind:'balloon' },
+};
+/* a themed shop in every region + the home village — vendor name, animal, goods 🏪 */
+ABC.SHOPS = {
+  home1:       { name:'Mr. Maple',      animal:'capy',     at:{x:-14,z:4},  goods:['water','apple','cookie','lamps'] },
+  home2:       { name:'Baker Biscuit',  animal:'panda',    at:{x:-20,z:-4}, goods:['sandwich','cookie','milk'] },
+  home3:       { name:'Fruit Stand Poppy', animal:'bunny', at:{x:-22,z:8},  goods:['banana','melon','juice','water'] },
+  yosemite:    { name:'Ranger Pinecone', animal:'puppy',    goods:['water','sandwich','soup','lamps'] },
+  zion:        { name:'Sandy',           animal:'bunny',    goods:['water','juice','melon'] },
+  grandcanyon: { name:'Dusty',           animal:'bunny',    goods:['water','juice','banana'] },
+  yellowstone: { name:'Camp Cook Bru',   animal:'mammoth',  goods:['water','sandwich','soup','cookie'] },
+  olympic:     { name:'Fern',            animal:'cat',      goods:['water','berries','banana'] },
+  everglades:  { name:'Marsh',           animal:'penguin',  goods:['water','fish','juice'] },
+  glacier:     { name:'Frosty',          animal:'penguin',  goods:['water','soup','milk'] },
+  denali:      { name:'Yuki',            animal:'panda',    goods:['water','soup','sandwich'] },
+  acadia:      { name:'Captain Shelly',  animal:'penguin',  goods:['water','fish','milk'] },
+  hawaii:      { name:'Kai',             animal:'butterfly',goods:['water','melon','juice'] },
+  galaxy:      { name:'Comet',           animal:'butterfly',goods:['milk','cookie','water'] },
+};
 
 /* Cookie cutters for the playdough/slime 🍪 */
 ABC.CUTTERS = [

--- a/public/blockcraft/js/main.js
+++ b/public/blockcraft/js/main.js
@@ -44,6 +44,8 @@
   ABC.portal.init(scene);
   ABC.music.init(scene);
   ABC.weather.init(scene);
+  ABC.shops.init(scene);
+  ABC.shops.placeAll();
 
   ABC.teleport = (x, y, z) => { feet.set(x, y, z); vy = 0; };
 
@@ -760,6 +762,7 @@
       updateFly(dt);
       updateParticles(dt);
       ABC.weather.update(dt, camera.position);
+      ABC.shops.update(dt);
       ABC.animals.update(dt, now / 1000);
       ABC.pet.update(dt, feet);
       ABC.squishy.update(dt, camera);

--- a/public/blockcraft/js/shops.js
+++ b/public/blockcraft/js/shops.js
@@ -1,0 +1,80 @@
+/* Aaria's Block Craft 3D — village & park shops 🏪: a home village cluster plus
+   a themed trading post in every region, each with a vendor who sells food,
+   water & treats for stars. Buying is the polite-words practice (ask/pay/thanks). */
+ABC.shops = (function () {
+  let scene = null;
+  const stalls = [];
+
+  function roundRect(c, x, y, w, h, r) {
+    c.beginPath(); c.moveTo(x + r, y);
+    c.arcTo(x + w, y, x + w, y + h, r); c.arcTo(x + w, y + h, x, y + h, r);
+    c.arcTo(x, y + h, x, y, r); c.arcTo(x, y, x + w, y, r); c.closePath();
+  }
+  function awning(c1, c2) {
+    const g = new THREE.Group();
+    const wood = new THREE.MeshLambertMaterial({ color: 0x8a5a2b });
+    const post = (x, z) => { const m = new THREE.Mesh(new THREE.BoxGeometry(0.22, 2, 0.22), wood); m.position.set(x, 1, z); g.add(m); };
+    post(-1.6, -1.1); post(1.6, -1.1); post(-1.6, 1.1); post(1.6, 1.1);
+    const cnt = new THREE.Mesh(new THREE.BoxGeometry(3.6, 0.5, 0.6), wood); cnt.position.set(0, 0.8, 1.2); g.add(cnt);
+    for (let i = 0; i < 5; i++) {
+      const m = new THREE.Mesh(new THREE.BoxGeometry(0.72, 0.18, 2.8),
+        new THREE.MeshLambertMaterial({ color: i % 2 ? c1 : c2 }));
+      m.position.set(-1.44 + i * 0.72, 2.15, 0); m.rotation.x = -0.18; g.add(m);
+    }
+    return g;
+  }
+  function sign(name) {
+    const cv = document.createElement('canvas'); cv.width = 256; cv.height = 128;
+    const x = cv.getContext('2d');
+    x.fillStyle = 'rgba(255,255,255,.95)'; roundRect(x, 8, 6, 240, 84, 18); x.fill();
+    x.strokeStyle = '#ffd43b'; x.lineWidth = 5; x.stroke();
+    x.textAlign = 'center';
+    x.fillStyle = '#1d4ed8'; x.font = 'bold 34px sans-serif'; x.fillText('🏪 Shop', 128, 44);
+    x.fillStyle = '#333'; x.font = '22px sans-serif'; x.fillText(name, 128, 78);
+    const tex = new THREE.CanvasTexture(cv);
+    const sp = new THREE.Sprite(new THREE.SpriteMaterial({ map: tex, transparent: true, depthTest: false }));
+    sp.scale.set(4.2, 2.1, 1);
+    return sp;
+  }
+  function place(px, pz, name, c1, c2) {
+    const g = awning(c1, c2); g.position.set(px, 1, pz); scene.add(g);
+    const s = sign(name); s.position.set(px, 4.4, pz); scene.add(s);
+    stalls.push({ g, s, x: px, z: pz });
+  }
+  function vendor(s, vx, vz) {
+    const v = ABC.animals.spawn(s.animal, vx, vz, s.name);
+    v.isVendor = true; v.shopGoods = s.goods; v.home = { x: vx, z: vz }; v.range = 2;
+    return v;
+  }
+
+  function init(sc) { scene = sc; }
+  function placeAll() {
+    // 🏘️ home village — a cozy cluster of stalls near spawn
+    ['home1', 'home2', 'home3'].forEach(k => {
+      const s = ABC.SHOPS[k]; if (!s) return;
+      vendor(s, s.at.x + 1, s.at.z + 1);
+      place(s.at.x, s.at.z, s.name, 0xff6b6b, 0xffffff);
+    });
+    // 🏞️ one themed trading post at the centre of each park's compass slice
+    const parks = ABC.REGIONS.parks, R = 205;
+    parks.forEach((reg, i) => {
+      const s = ABC.SHOPS[reg.key]; if (!s) return;
+      const ang = ((i + 0.5) / parks.length) * Math.PI * 2 - Math.PI;
+      const x = Math.round(Math.cos(ang) * R), z = Math.round(Math.sin(ang) * R);
+      vendor(s, x + 1, z + 1);
+      place(x, z, s.name, 0x69b3ff, 0xffffff);
+    });
+  }
+  function update(dt) {
+    // settle each stall + sign onto the ground once nearby chunks generate
+    for (const st of stalls) {
+      const tb = ABC.world.topBlock(Math.floor(st.x), Math.floor(st.z));
+      if (tb) {
+        const gy = tb.y + 1;
+        st.g.position.y += (gy - st.g.position.y) * Math.min(1, dt * 4);
+        st.s.position.y = st.g.position.y + 3.4;
+      }
+    }
+  }
+  return { init, placeAll, update };
+})();


### PR DESCRIPTION
Expands the proven shop loop across the world:
- 🏘️ **Home village** cluster of 3 stalls near spawn
- 🏞️ A **themed trading post in every region** (11), each with its own vendor and goods, at the centre of its compass slice — a reason to meet someone and talk wherever you explore
- 💧🥪 **Food & water catalog** (water, juice, fruit, sandwich, soup, fish, milk, cookie…) — functional requesting vocabulary
- Floating 🏪 signs to spot shops from afar; stalls settle to the ground as chunks load
- Buying is the **ask politely → pay stars → say thanks** language loop; **no hunger/thirst meter** (calm role-play, not survival)

Cache v=21. Error-free headless boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)