### PR TITLE
Block Craft: wider zoom + Safari/iOS full-screen fix

### DIFF
--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -9,6 +9,10 @@
   html,body { width:100%; height:100%; overflow:hidden; background:#aee7ff;
     font-family:"Comic Sans MS","Chalkboard SE","Marker Felt","Segoe UI",sans-serif; }
   #gameCanvas { position:fixed; inset:0; display:block; }
+  /* Safari / iOS faux-fullscreen: lift the game above everything and fill the screen */
+  body.fauxFs #hud, body.fauxFs #gameCanvas, body.fauxFs #dialogOverlay, body.fauxFs #flash {
+    position:fixed !important; inset:0 !important; z-index:2147483600; }
+  body.fauxFs { position:fixed; inset:0; width:100vw; height:100vh; overflow:hidden; }
 
   /* ---------- Title screen ---------- */
   #titleScreen { position:fixed; inset:0; z-index:100; display:flex; flex-direction:column;
@@ -301,22 +305,22 @@
 <div id="flash"></div>
 
 <script src="lib/three.min.js"></script>
-<script src="js/data.js?v=22"></script>
-<script src="js/audio.js?v=22"></script>
-<script src="js/world.js?v=22"></script>
-<script src="js/animals.js?v=22"></script>
-<script src="js/squishy.js?v=22"></script>
-<script src="js/weather.js?v=22"></script>
-<script src="js/parks.js?v=22"></script>
-<script src="js/shops.js?v=22"></script>
-<script src="js/portal.js?v=22"></script>
-<script src="js/ui.js?v=22"></script>
-<script src="js/activities.js?v=22"></script>
-<script src="js/music.js?v=22"></script>
-<script src="js/pet.js?v=22"></script>
-<script src="js/stickers.js?v=22"></script>
-<script src="js/overnight.js?v=22"></script>
-<script src="js/photo.js?v=22"></script>
-<script src="js/main.js?v=22"></script>
+<script src="js/data.js?v=23"></script>
+<script src="js/audio.js?v=23"></script>
+<script src="js/world.js?v=23"></script>
+<script src="js/animals.js?v=23"></script>
+<script src="js/squishy.js?v=23"></script>
+<script src="js/weather.js?v=23"></script>
+<script src="js/parks.js?v=23"></script>
+<script src="js/shops.js?v=23"></script>
+<script src="js/portal.js?v=23"></script>
+<script src="js/ui.js?v=23"></script>
+<script src="js/activities.js?v=23"></script>
+<script src="js/music.js?v=23"></script>
+<script src="js/pet.js?v=23"></script>
+<script src="js/stickers.js?v=23"></script>
+<script src="js/overnight.js?v=23"></script>
+<script src="js/photo.js?v=23"></script>
+<script src="js/main.js?v=23"></script>
 </body>
 </html>

--- a/public/blockcraft/js/main.js
+++ b/public/blockcraft/js/main.js
@@ -23,19 +23,34 @@
     lastFwdTap = now;
   }
   let thirdPerson = false;
-  let zoom = 1;                                   // 0.55 (close) … 1.7 (far)
-  function setZoom(dz) {
-    zoom = Math.max(0.55, Math.min(1.7, zoom + dz));
-    camera.fov = 72 * (thirdPerson ? 1 : Math.max(0.6, Math.min(1.25, zoom)));
+  let zoom = 1;                                   // 0.5 (right up close) … 6 (high in the sky)
+  function applyZoom() {
+    // zooming out past ~1.4 lifts you up and behind for a wide view;
+    // zooming all the way in returns to first person
+    const want3p = zoom > 1.4;
+    if (want3p !== thirdPerson) {
+      thirdPerson = want3p;
+      avatar.visible = thirdPerson;
+      hand.visible = !thirdPerson;
+      refreshHand();
+      $('viewBtn').classList.toggle('active', thirdPerson);
+    }
+    camera.fov = 72 * (thirdPerson ? 1 : Math.max(0.55, Math.min(1.35, zoom)));
     camera.updateProjectionMatrix();
+  }
+  function setZoom(dz) {
+    zoom = Math.max(0.5, Math.min(6, zoom + dz));
+    applyZoom();
     ABC.audio.sfx.gentle();
   }
 
-  window.addEventListener('resize', () => {
+  function onResize() {
     camera.aspect = window.innerWidth / window.innerHeight;
     camera.updateProjectionMatrix();
     renderer.setSize(window.innerWidth, window.innerHeight);
-  });
+  }
+  window.addEventListener('resize', onResize);
+  window.addEventListener('orientationchange', () => setTimeout(onResize, 200));
 
   const scene = ABC.world.initScene(renderer);
   ABC.world.generate();
@@ -137,10 +152,9 @@
   });
 
   function toggleView() {
-    thirdPerson = !thirdPerson;
-    avatar.visible = thirdPerson;
-    hand.visible = !thirdPerson;
-    $('viewBtn').classList.toggle('active', thirdPerson);
+    // jump between a close first-person zoom and a comfy third-person zoom
+    zoom = thirdPerson ? 1 : 2.2;
+    applyZoom();
     ABC.audio.sfx.gentle();
   }
 
@@ -536,7 +550,8 @@
     camera.rotateY(yaw); camera.rotateX(pitch);
     if (thirdPerson) {
       const back = new THREE.Vector3(Math.sin(yaw), 0, Math.cos(yaw));
-      camera.position.set(feet.x, feet.y + EYE + 1.6 * zoom, feet.z).addScaledVector(back, 4.2 * zoom);
+      // higher and further the more you zoom out — up to a soaring bird's-eye view
+      camera.position.set(feet.x, feet.y + EYE + 2.2 * zoom, feet.z).addScaledVector(back, 4.0 * zoom);
       avatar.position.set(feet.x, feet.y, feet.z);
       avatar.rotation.y = yaw + Math.PI;
     } else {
@@ -665,27 +680,39 @@
   $('tFly').addEventListener('click', () => $('flyBtn').click());
   $('questChip').onclick   = () => ABC.quests.showBoard();
 
-  /* full screen — works standalone and inside the dashboard iframe */
-  function toggleFullscreen() {
-    const fsEl = document.fullscreenElement || document.webkitFullscreenElement;
-    if (fsEl) {
-      (document.exitFullscreen || document.webkitExitFullscreen).call(document);
-    } else {
-      const root = document.documentElement;
-      const req = root.requestFullscreen || root.webkitRequestFullscreen;
-      if (req) {
-        const p = req.call(root);
-        if (p && p.catch) p.catch(() => {
-          ABC.ui.toast('Use the “Play Full Screen” button on the website instead! 🖥️', 3200);
-        });
-      }
-    }
-  }
-  document.addEventListener('fullscreenchange', () => {
-    const on = !!document.fullscreenElement;
+  /* full screen — works on Chrome/Edge/Firefox AND Safari (incl. iOS, which
+     has no Fullscreen API, via a CSS faux-fullscreen fallback) */
+  function nativeFsEl() { return document.fullscreenElement || document.webkitFullscreenElement; }
+  function fsLabel() {
+    const on = !!nativeFsEl() || document.body.classList.contains('fauxFs');
     $('fsBtn').textContent = on ? '🗗' : '⛶';
     $('fsBtn').title = on ? 'Exit full screen' : 'Full screen';
-  });
+  }
+  function setFaux(on) {
+    document.body.classList.toggle('fauxFs', on);
+    fsLabel();
+    onResize();   // game canvas resizes to the new viewport
+  }
+  function toggleFullscreen() {
+    // already in faux mode → just leave it
+    if (document.body.classList.contains('fauxFs')) { setFaux(false); return; }
+    if (nativeFsEl()) {
+      (document.exitFullscreen || document.webkitExitFullscreen).call(document);
+      return;
+    }
+    const root = document.documentElement;
+    const req = root.requestFullscreen || root.webkitRequestFullscreen;
+    if (req) {
+      try {
+        const p = req.call(root);
+        if (p && p.catch) p.catch(() => setFaux(true));   // Safari may reject → faux
+      } catch (e) { setFaux(true); }
+    } else {
+      setFaux(true);   // iOS Safari: no API at all → faux fullscreen
+    }
+  }
+  document.addEventListener('fullscreenchange', fsLabel);
+  document.addEventListener('webkitfullscreenchange', fsLabel);
   $('fsBtn').onclick = toggleFullscreen;
   $('fsTitleBtn').onclick = toggleFullscreen;
   $('flyBtn').onclick      = () => {


### PR DESCRIPTION
- 🔍 Zoom range greatly extended — especially zoom OUT, up to a high bird's-eye view (lifts camera up & back past ~1.4)
- 🍎 Full screen now works in Safari (webkit-prefixed API/events) and on iOS Safari via a CSS faux-fullscreen fallback (iOS has no Fullscreen API at all); orientation change re-fits the canvas

Cache v=23. Error-free headless boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)