### PR TITLE
Block Craft: Timber! feedback on tree/build collapse

### DIFF
--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -305,23 +305,23 @@
 <div id="flash"></div>
 
 <script src="lib/three.min.js"></script>
-<script src="js/data.js?v=26"></script>
-<script src="js/audio.js?v=26"></script>
-<script src="js/world.js?v=26"></script>
-<script src="js/animals.js?v=26"></script>
-<script src="js/squishy.js?v=26"></script>
-<script src="js/weather.js?v=26"></script>
-<script src="js/parks.js?v=26"></script>
-<script src="js/shops.js?v=26"></script>
-<script src="js/signs.js?v=26"></script>
-<script src="js/portal.js?v=26"></script>
-<script src="js/ui.js?v=26"></script>
-<script src="js/activities.js?v=26"></script>
-<script src="js/music.js?v=26"></script>
-<script src="js/pet.js?v=26"></script>
-<script src="js/stickers.js?v=26"></script>
-<script src="js/overnight.js?v=26"></script>
-<script src="js/photo.js?v=26"></script>
-<script src="js/main.js?v=26"></script>
+<script src="js/data.js?v=27"></script>
+<script src="js/audio.js?v=27"></script>
+<script src="js/world.js?v=27"></script>
+<script src="js/animals.js?v=27"></script>
+<script src="js/squishy.js?v=27"></script>
+<script src="js/weather.js?v=27"></script>
+<script src="js/parks.js?v=27"></script>
+<script src="js/shops.js?v=27"></script>
+<script src="js/signs.js?v=27"></script>
+<script src="js/portal.js?v=27"></script>
+<script src="js/ui.js?v=27"></script>
+<script src="js/activities.js?v=27"></script>
+<script src="js/music.js?v=27"></script>
+<script src="js/pet.js?v=27"></script>
+<script src="js/stickers.js?v=27"></script>
+<script src="js/overnight.js?v=27"></script>
+<script src="js/photo.js?v=27"></script>
+<script src="js/main.js?v=27"></script>
 </body>
 </html>

--- a/public/blockcraft/js/main.js
+++ b/public/blockcraft/js/main.js
@@ -299,6 +299,9 @@
       }
       if (supported || !cluster.length) continue;
       dropCluster(cluster);     // TIMBER! the whole disconnected piece comes down
+      const treeish = cluster.some(c => c.t === 'wood' || c.t === 'leaf');
+      ABC.ui.toast(treeish ? '🪓 TIMBER! The tree is falling down! 🌳'
+                           : '🏚️ Watch out — it’s tumbling down!', 2600, true);
     }
   }
   /* the unsupported piece collapses: every block falls and piles up on the


### PR DESCRIPTION
Confirmed the falling-block physics works (self-test fells 12 blocks when a trunk base is cut). The reason it seemed not to work: it only triggers when you cut the **trunk**, not the leaves, and there was no feedback. Added a clear '🪓 TIMBER!' spoken toast + crash sound when anything collapses. Cache v=27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)