### PR TITLE
feat: Belu's World — 3D ASD learning game + dashboard link

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -97,6 +97,7 @@ const UnderstandingAutism = lazy(() => import('./pages/UnderstandingAutism'));
 const Interventions = lazy(() => import('./pages/Interventions'));
 const Screening = lazy(() => import('./pages/Screening'));
 const CircleOfFriends = lazy(() => import('./pages/CircleOfFriends'));
+const BelusWorld = lazy(() => import('./pages/BelusWorld'));
 
 // Loading fallback
 const PageLoader = () => (
@@ -148,6 +149,7 @@ const App: React.FC = () => {
                 <Route path="/resources/interventions" element={<Interventions />} />
                 <Route path="/resources/screening" element={<Screening />} />
                 <Route path="/circle-of-friends" element={<CircleOfFriends />} />
+                <Route path="/belus-world" element={<BelusWorld />} />
                 <Route path="/buddy" element={<Navigate to="/circle-of-friends" replace />} />
                 <Route path="/story" element={<Navigate to="/?share=story" replace />} />
                 

--- a/components/game/BelusWorld/BeluCharacter.tsx
+++ b/components/game/BelusWorld/BeluCharacter.tsx
@@ -1,0 +1,268 @@
+import React from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+export type BeluEmotion = 'happy' | 'sad' | 'scared' | 'excited' | 'calm' | 'curious' | 'overwhelmed';
+
+interface Props {
+  emotion: BeluEmotion;
+  size?: number;
+  className?: string;
+  onClick?: () => void;
+  animate?: boolean;
+}
+
+// Eye shapes per emotion
+const EyeShape: Record<BeluEmotion, React.FC<{ cx: number; cy: number; flip?: boolean }>> = {
+  happy: ({ cx, cy }) => (
+    <g>
+      <ellipse cx={cx} cy={cy} rx={11} ry={9} fill="#fff" />
+      <ellipse cx={cx} cy={cy + 2} rx={7} ry={6} fill="#3D2B1F" />
+      <circle cx={cx + 2} cy={cy} r={2.5} fill="#fff" />
+      {/* Happy squint line */}
+      <path d={`M ${cx - 11} ${cy - 3} Q ${cx} ${cy - 10} ${cx + 11} ${cy - 3}`} stroke="#3D2B1F" strokeWidth="2.5" fill="none" strokeLinecap="round" />
+    </g>
+  ),
+  sad: ({ cx, cy }) => (
+    <g>
+      <ellipse cx={cx} cy={cy} rx={11} ry={9} fill="#fff" />
+      <ellipse cx={cx} cy={cy + 1} rx={7} ry={7} fill="#3D2B1F" />
+      <circle cx={cx + 2} cy={cy - 1} r={2} fill="#fff" />
+      {/* Drooping upper lid */}
+      <path d={`M ${cx - 11} ${cy} Q ${cx} ${cy + 7} ${cx + 11} ${cy}`} stroke="#3D2B1F" strokeWidth="2" fill="none" strokeLinecap="round" />
+      {/* Tear */}
+      <ellipse cx={cx - 3} cy={cy + 13} rx={3} ry={4} fill="#A8D8EA" opacity={0.85} />
+    </g>
+  ),
+  scared: ({ cx, cy }) => (
+    <g>
+      <circle cx={cx} cy={cy} r={12} fill="#fff" />
+      <circle cx={cx} cy={cy} r={8} fill="#3D2B1F" />
+      <circle cx={cx + 3} cy={cy - 2} r={3} fill="#fff" />
+      {/* Wide open lids */}
+      <path d={`M ${cx - 12} ${cy} Q ${cx} ${cy - 14} ${cx + 12} ${cy}`} stroke="#3D2B1F" strokeWidth="2" fill="none" strokeLinecap="round" />
+      <path d={`M ${cx - 12} ${cy} Q ${cx} ${cy + 13} ${cx + 12} ${cy}`} stroke="#3D2B1F" strokeWidth="2" fill="none" strokeLinecap="round" />
+    </g>
+  ),
+  excited: ({ cx, cy }) => (
+    <g>
+      <ellipse cx={cx} cy={cy} rx={12} ry={12} fill="#fff" />
+      {/* Star-shaped pupil */}
+      <polygon points={`${cx},${cy - 8} ${cx + 3},${cy - 3} ${cx + 8},${cy - 3} ${cx + 4},${cy + 1} ${cx + 5},${cy + 7} ${cx},${cy + 4} ${cx - 5},${cy + 7} ${cx - 4},${cy + 1} ${cx - 8},${cy - 3} ${cx - 3},${cy - 3}`} fill="#FFD700" />
+      <circle cx={cx} cy={cy} r={3} fill="#3D2B1F" />
+      <circle cx={cx + 2} cy={cy - 2} r={1.5} fill="#fff" />
+      {/* Sparkle */}
+      <line x1={cx + 13} y1={cy - 8} x2={cx + 16} y2={cy - 11} stroke="#FFD700" strokeWidth="2" />
+      <line x1={cx + 15} y1={cy - 5} x2={cx + 19} y2={cy - 5} stroke="#FFD700" strokeWidth="2" />
+    </g>
+  ),
+  calm: ({ cx, cy }) => (
+    <g>
+      <ellipse cx={cx} cy={cy} rx={11} ry={9} fill="#fff" />
+      <ellipse cx={cx} cy={cy + 1} rx={7} ry={5} fill="#3D2B1F" />
+      <circle cx={cx + 2} cy={cy} r={2} fill="#fff" />
+      {/* Half-lidded top */}
+      <path d={`M ${cx - 11} ${cy - 1} Q ${cx} ${cy + 3} ${cx + 11} ${cy - 1}`} stroke="#3D2B1F" strokeWidth="2.5" fill="none" strokeLinecap="round" />
+    </g>
+  ),
+  curious: ({ cx, cy, flip }) => (
+    <g>
+      <ellipse cx={cx} cy={cy} rx={flip ? 10 : 12} ry={flip ? 9 : 11} fill="#fff" />
+      <circle cx={cx + (flip ? 1 : -1)} cy={cy + 1} r={flip ? 6 : 8} fill="#3D2B1F" />
+      <circle cx={cx + (flip ? 3 : 1)} cy={cy - 1} r={flip ? 2 : 2.5} fill="#fff" />
+      {/* Raised eyebrow one side */}
+      {!flip && <path d={`M ${cx - 12} ${cy - 9} Q ${cx} ${cy - 16} ${cx + 12} ${cy - 10}`} stroke="#3D2B1F" strokeWidth="2.5" fill="none" strokeLinecap="round" />}
+    </g>
+  ),
+  overwhelmed: ({ cx, cy }) => (
+    <g>
+      <ellipse cx={cx} cy={cy} rx={11} ry={9} fill="#fff" />
+      {/* Spiral pupils */}
+      <path d={`M ${cx} ${cy} C ${cx + 4} ${cy - 4}, ${cx + 7} ${cy}, ${cx + 4} ${cy + 4} C ${cx + 2} ${cy + 6}, ${cx - 3} ${cy + 5}, ${cx - 5} ${cy + 2} C ${cx - 7} ${cy - 1}, ${cx - 5} ${cy - 6}, ${cx - 2} ${cy - 7}`} stroke="#3D2B1F" strokeWidth="2" fill="none" />
+      <path d={`M ${cx - 11} ${cy + 2} Q ${cx} ${cy + 10} ${cx + 11} ${cy + 2}`} stroke="#3D2B1F" strokeWidth="2" fill="none" strokeLinecap="round" />
+    </g>
+  ),
+};
+
+const MouthShape: Record<BeluEmotion, React.FC<{ cx: number; cy: number }>> = {
+  happy: ({ cx, cy }) => <path d={`M ${cx - 14} ${cy} Q ${cx} ${cy + 14} ${cx + 14} ${cy}`} stroke="#3D2B1F" strokeWidth="3" fill="none" strokeLinecap="round" />,
+  sad: ({ cx, cy }) => <path d={`M ${cx - 12} ${cy + 8} Q ${cx} ${cy} ${cx + 12} ${cy + 8}`} stroke="#3D2B1F" strokeWidth="3" fill="none" strokeLinecap="round" />,
+  scared: ({ cx, cy }) => <ellipse cx={cx} cy={cy + 5} rx={10} ry={8} fill="#3D2B1F" />,
+  excited: ({ cx, cy }) => <path d={`M ${cx - 16} ${cy - 2} Q ${cx} ${cy + 18} ${cx + 16} ${cy - 2}`} stroke="#3D2B1F" strokeWidth="3" fill="none" strokeLinecap="round" />,
+  calm: ({ cx, cy }) => <path d={`M ${cx - 10} ${cy + 2} Q ${cx} ${cy + 10} ${cx + 10} ${cy + 2}`} stroke="#3D2B1F" strokeWidth="2.5" fill="none" strokeLinecap="round" />,
+  curious: ({ cx, cy }) => <path d={`M ${cx - 8} ${cy + 4} Q ${cx + 4} ${cy + 8} ${cx + 10} ${cy + 2}`} stroke="#3D2B1F" strokeWidth="2.5" fill="none" strokeLinecap="round" />,
+  overwhelmed: ({ cx, cy }) => <path d={`M ${cx - 12} ${cy + 4} Q ${cx - 4} ${cy + 2} ${cx + 4} ${cy + 6} Q ${cx + 8} ${cy + 8} ${cx + 12} ${cy + 4}`} stroke="#3D2B1F" strokeWidth="2.5" fill="none" strokeLinecap="round" />,
+};
+
+const emotionBodyColor: Record<BeluEmotion, string> = {
+  happy: '#5BA3D9',
+  sad: '#7898B5',
+  scared: '#6A90B8',
+  excited: '#4D9FDF',
+  calm: '#5BA8C4',
+  curious: '#5BA3D9',
+  overwhelmed: '#7B8FAD',
+};
+
+const emotionWeatherGlow: Record<BeluEmotion, string> = {
+  happy: '#FFE066',
+  sad: '#A8C8E0',
+  scared: '#9BB5C8',
+  excited: '#FF9F40',
+  calm: '#B8E0D2',
+  curious: '#D4E8F5',
+  overwhelmed: '#C0C8D8',
+};
+
+export { emotionWeatherGlow };
+
+const BeluCharacter: React.FC<Props> = ({ emotion, size = 200, className = '', onClick, animate = true }) => {
+  const scale = size / 220;
+  const bodyColor = emotionBodyColor[emotion];
+  const LeftEye = EyeShape[emotion];
+  const RightEye = EyeShape[emotion];
+  const Mouth = MouthShape[emotion];
+
+  const isExcited = emotion === 'excited';
+  const isOverwhelmed = emotion === 'overwhelmed';
+
+  return (
+    <motion.div
+      className={`inline-block cursor-pointer select-none ${className}`}
+      style={{ width: size, height: size * 1.1 }}
+      onClick={onClick}
+      animate={animate ? {
+        y: isOverwhelmed ? [0, -3, 3, -3, 0] : [0, -6, 0],
+        rotate: isOverwhelmed ? [-2, 2, -2, 2, 0] : 0,
+        scale: isExcited ? [1, 1.06, 1] : 1,
+      } : {}}
+      transition={{
+        y: { duration: isOverwhelmed ? 0.4 : 2.2, repeat: Infinity, ease: 'easeInOut' },
+        rotate: { duration: 0.15, repeat: isOverwhelmed ? 3 : 0 },
+        scale: { duration: 0.7, repeat: Infinity, ease: 'easeInOut' },
+      }}
+      whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.97 }}
+    >
+      <svg
+        viewBox="0 0 220 240"
+        width={size}
+        height={size * 1.1}
+        style={{ overflow: 'visible', filter: `drop-shadow(0 8px 16px rgba(0,0,0,0.18))` }}
+      >
+        <defs>
+          <radialGradient id={`bodyGrad-${emotion}`} cx="40%" cy="35%" r="60%">
+            <stop offset="0%" stopColor="#7BBDE8" />
+            <stop offset="100%" stopColor={bodyColor} />
+          </radialGradient>
+          <radialGradient id={`earGrad-${emotion}`} cx="40%" cy="35%" r="60%">
+            <stop offset="0%" stopColor="#6AAFE0" />
+            <stop offset="100%" stopColor="#4A88C4" />
+          </radialGradient>
+          <radialGradient id="bellyGrad" cx="50%" cy="40%" r="60%">
+            <stop offset="0%" stopColor="#A8D8F0" />
+            <stop offset="100%" stopColor="#8EC8E8" />
+          </radialGradient>
+        </defs>
+
+        {/* Shadow */}
+        <ellipse cx={110} cy={235} rx={55} ry={8} fill="rgba(0,0,0,0.12)" />
+
+        {/* Left ear — animated flap */}
+        <motion.g
+          animate={animate ? { rotate: [-5, 8, -5] } : {}}
+          transition={{ duration: 2.8, repeat: Infinity, ease: 'easeInOut' }}
+          style={{ originX: '70px', originY: '90px' }}
+        >
+          <ellipse cx={58} cy={90} rx={34} ry={44} fill={`url(#earGrad-${emotion})`} stroke="#3A7BAD" strokeWidth="2" />
+          <ellipse cx={60} cy={91} rx={20} ry={27} fill="#FFB7C5" opacity={0.45} />
+        </motion.g>
+
+        {/* Right ear — animated flap opposite phase */}
+        <motion.g
+          animate={animate ? { rotate: [5, -8, 5] } : {}}
+          transition={{ duration: 2.8, repeat: Infinity, ease: 'easeInOut', delay: 0.4 }}
+          style={{ originX: '155px', originY: '90px' }}
+        >
+          <ellipse cx={162} cy={90} rx={34} ry={44} fill={`url(#earGrad-${emotion})`} stroke="#3A7BAD" strokeWidth="2" />
+          <ellipse cx={160} cy={91} rx={20} ry={27} fill="#FFB7C5" opacity={0.45} />
+        </motion.g>
+
+        {/* Body */}
+        <ellipse cx={110} cy={162} rx={68} ry={60} fill={`url(#bodyGrad-${emotion})`} stroke="#3A7BAD" strokeWidth="2.5" />
+
+        {/* Belly */}
+        <ellipse cx={110} cy={158} rx={38} ry={32} fill="url(#bellyGrad)" opacity={0.6} />
+
+        {/* Head */}
+        <circle cx={110} cy={92} r={56} fill={`url(#bodyGrad-${emotion})`} stroke="#3A7BAD" strokeWidth="2.5" />
+
+        {/* Forehead highlight */}
+        <ellipse cx={100} cy={68} rx={22} ry={14} fill="rgba(255,255,255,0.18)" />
+
+        {/* Left eye */}
+        <LeftEye cx={88} cy={88} />
+
+        {/* Right eye */}
+        <RightEye cx={132} cy={88} flip />
+
+        {/* Blush left */}
+        <ellipse cx={72} cy={106} rx={13} ry={9} fill="#FFB7C5" opacity={0.55} />
+        {/* Blush right */}
+        <ellipse cx={148} cy={106} rx={13} ry={9} fill="#FFB7C5" opacity={0.55} />
+
+        {/* Nose / snout */}
+        <ellipse cx={110} cy={112} rx={18} ry={13} fill="#4A88C4" stroke="#3A7BAD" strokeWidth="1.5" />
+        {/* Nostrils */}
+        <ellipse cx={104} cy={115} rx={4} ry={3} fill="#2C5F8A" />
+        <ellipse cx={116} cy={115} rx={4} ry={3} fill="#2C5F8A" />
+
+        {/* Mouth */}
+        <Mouth cx={110} cy={120} />
+
+        {/* Trunk — animated sway */}
+        <motion.path
+          d={emotion === 'scared' ? 'M 110 124 Q 118 145 125 165 Q 130 178 122 182' : emotion === 'excited' ? 'M 110 124 Q 130 148 135 168 Q 138 180 128 175' : 'M 110 124 Q 90 148 88 168 Q 86 180 96 178'}
+          stroke={bodyColor}
+          strokeWidth="14"
+          fill="none"
+          strokeLinecap="round"
+          style={{ filter: 'none' }}
+          animate={animate ? { d: emotion === 'excited' ? ['M 110 124 Q 130 148 135 168 Q 138 180 128 175', 'M 110 124 Q 125 142 128 162 Q 130 178 120 175'] : undefined } : {}}
+          transition={{ duration: 1.2, repeat: Infinity, repeatType: 'reverse', ease: 'easeInOut' }}
+        />
+        <motion.path
+          d={emotion === 'scared' ? 'M 110 124 Q 118 145 125 165 Q 130 178 122 182' : emotion === 'excited' ? 'M 110 124 Q 130 148 135 168 Q 138 180 128 175' : 'M 110 124 Q 90 148 88 168 Q 86 180 96 178'}
+          stroke="#3A7BAD"
+          strokeWidth="14"
+          fill="none"
+          strokeLinecap="round"
+          opacity={0.3}
+        />
+
+        {/* Legs */}
+        <rect x={72} y={205} width={28} height={28} rx={10} fill={`url(#bodyGrad-${emotion})`} stroke="#3A7BAD" strokeWidth="2" />
+        <rect x={118} y={205} width={28} height={28} rx={10} fill={`url(#bodyGrad-${emotion})`} stroke="#3A7BAD" strokeWidth="2" />
+        {/* Feet highlight */}
+        <ellipse cx={86} cy={226} rx={8} ry={4} fill="rgba(255,255,255,0.25)" />
+        <ellipse cx={132} cy={226} rx={8} ry={4} fill="rgba(255,255,255,0.25)" />
+
+        {/* Excited sparkles */}
+        <AnimatePresence>
+          {isExcited && (
+            <motion.g initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+              {[{ x: 40, y: 40 }, { x: 175, y: 35 }, { x: 185, y: 100 }, { x: 28, y: 130 }].map((pos, i) => (
+                <motion.text key={i} x={pos.x} y={pos.y} fontSize={16}
+                  animate={{ scale: [0.8, 1.3, 0.8], rotate: [0, 20, 0] }}
+                  transition={{ duration: 1.2, repeat: Infinity, delay: i * 0.3 }}
+                  style={{ originX: `${pos.x}px`, originY: `${pos.y}px` }}
+                >✨</motion.text>
+              ))}
+            </motion.g>
+          )}
+        </AnimatePresence>
+      </svg>
+    </motion.div>
+  );
+};
+
+export default BeluCharacter;

--- a/components/game/BelusWorld/activities/CalmActivity.tsx
+++ b/components/game/BelusWorld/activities/CalmActivity.tsx
@@ -1,0 +1,270 @@
+// ASD area — SELF-REGULATION & SENSORY (Calm Cove). Five levels deepen from
+// simple guided breathing to building a personal calm-down plan. No fail, no
+// pressure: breathing is gently paced, every choice is affirmed. Research-based
+// (co-regulation, identify-then-strategy, self-management).
+
+import { useEffect, useRef, useState } from 'react';
+import { motion } from 'framer-motion';
+import { OverlayShell, ChoiceButton, starsFromSlips, type ActivityProps } from './shared';
+
+type Phase = 'in' | 'hold' | 'out';
+const SEQ: { phase: Phase; label: string; secs: number; scale: number }[] = [
+  { phase: 'in', label: 'Breathe in…', secs: 4, scale: 1.6 },
+  { phase: 'hold', label: 'Hold gently…', secs: 2, scale: 1.6 },
+  { phase: 'out', label: 'Breathe out…', secs: 4, scale: 0.85 },
+];
+
+const BODY_SPOTS = [
+  { id: 'tummy', label: 'Tummy', emoji: '🫄' },
+  { id: 'chest', label: 'Chest', emoji: '🫁' },
+  { id: 'shoulders', label: 'Shoulders', emoji: '💪' },
+  { id: 'hands', label: 'Hands', emoji: '🤲' },
+];
+
+const STRATEGIES = [
+  { id: 'breathe', label: 'Take deep breaths', emoji: '🌬️' },
+  { id: 'quiet', label: 'Find a quiet spot', emoji: '🤫' },
+  { id: 'squeeze', label: 'Squeeze my hands', emoji: '✊' },
+  { id: 'break', label: 'Ask for a break', emoji: '✋' },
+  { id: 'count', label: 'Count to five', emoji: '🖐️' },
+  { id: 'hug', label: 'Get a big hug', emoji: '🤗' },
+];
+
+const LOUD_SCENES = [
+  'It is very loud and busy in here.',
+  'The room is too bright and noisy.',
+  'Everything feels like too much right now.',
+];
+
+export default function CalmActivity({ level, speak, onBeluEmotion, onComplete, onExit }: ActivityProps) {
+  // breaths required scales with level
+  const breaths = level === 1 ? 2 : level === 2 ? 3 : level >= 4 ? 1 : 2;
+  // does this level have a "choosing" stage before/after breathing?
+  const hasBody = level === 3;
+  const hasStrategy = level === 4;
+  const hasPlan = level === 5;
+
+  const slips = useRef(0);
+  const [stage, setStage] = useState<'intro' | 'choose' | 'breathe' | 'done'>('intro');
+  const [picked, setPicked] = useState<string[]>([]);
+
+  // breathing state
+  const [cycle, setCycle] = useState(0);
+  const [phaseIdx, setPhaseIdx] = useState(0);
+  const [running, setRunning] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const planGoal = 3;
+
+  useEffect(() => {
+    onBeluEmotion('calm');
+    speak("Welcome to the cove. Let's feel calm together.");
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function finish() {
+    onBeluEmotion('happy');
+    speak('I feel calm and cozy now. Thank you for being with me.');
+    setStage('done');
+    setTimeout(() => onComplete({ stars: starsFromSlips(slips.current), moment: 'practiced staying calm at the cove' }), 700);
+  }
+
+  // ---- breathing loop ----
+  const current = SEQ[phaseIdx];
+  useEffect(() => {
+    if (!running) return;
+    timer.current = setTimeout(() => {
+      const next = (phaseIdx + 1) % SEQ.length;
+      if (next === 0) {
+        const c = cycle + 1;
+        setCycle(c);
+        if (c >= breaths) {
+          setRunning(false);
+          finish();
+          return;
+        }
+      }
+      setPhaseIdx(next);
+    }, current.secs * 1000);
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [running, phaseIdx]);
+
+  function startBreathing() {
+    onBeluEmotion('calm');
+    speak('Follow the bubble. Breathe in as it grows, out as it shrinks.');
+    setCycle(0);
+    setPhaseIdx(0);
+    setRunning(true);
+    setStage('breathe');
+  }
+
+  // ---- choose stage (body / strategy / plan) ----
+  function pickBody(label: string) {
+    speak(`Lovely. Feeling calm in your ${label.toLowerCase()} is wonderful.`);
+    onBeluEmotion('happy');
+    startBreathing();
+  }
+  function pickStrategy(label: string) {
+    speak(`Great idea — "${label}" really helps. Let's do one calm breath too.`);
+    onBeluEmotion('happy');
+    startBreathing();
+  }
+  function pickPlan(id: string, label: string) {
+    if (picked.includes(id)) return;
+    const np = [...picked, id];
+    setPicked(np);
+    onBeluEmotion('happy');
+    if (np.length >= planGoal) {
+      speak('That is a wonderful calm plan. Let’s finish with one breath.');
+      startBreathing();
+    } else {
+      speak(`"${label}" — good choice for your calm plan. Pick ${planGoal - np.length} more.`);
+    }
+  }
+
+  // first-then + instruction per level
+  const firstThen = {
+    first: hasStrategy ? 'Pick what helps you' : hasPlan ? 'Build your calm plan' : 'Breathe with Belu',
+    then: '⭐ Earn a star',
+  };
+  const instruction =
+    stage === 'breathe'
+      ? 'Follow the glowing bubble. Breathe slowly.'
+      : hasBody
+        ? 'Where do you feel calm in your body? Tap a spot.'
+        : hasStrategy
+          ? 'When it feels like too much, what can you do? Tap one.'
+          : hasPlan
+            ? `Tap ${planGoal} things that help you feel calm.`
+            : 'When you are ready, press Start to breathe.';
+
+  const totalSteps = hasPlan ? planGoal + 1 : hasBody || hasStrategy ? 2 : 1;
+  const stepNow = stage === 'breathe' || stage === 'done' ? totalSteps - 1 : hasPlan ? picked.length : 0;
+
+  return (
+    <OverlayShell
+      title="Calm Cove"
+      emoji="🌊"
+      accent="#5fd0e0"
+      level={level}
+      step={stepNow}
+      total={totalSteps}
+      firstThen={firstThen}
+      instruction={instruction}
+      onSpeak={() => speak(instruction)}
+      onExit={onExit}
+    >
+      {/* CHOOSING stages */}
+      {stage === 'intro' && hasBody && (
+        <Choices items={BODY_SPOTS} accent="#5fd0e0" onPick={(it) => pickBody(it.label)} />
+      )}
+      {stage === 'intro' && hasStrategy && (
+        <>
+          <p className="mb-3 rounded-2xl bg-cyan-50 px-4 py-3 text-center text-base font-semibold text-slate-700">
+            {LOUD_SCENES[(level - 1) % LOUD_SCENES.length]}
+          </p>
+          <Choices items={STRATEGIES.slice(0, 4)} accent="#5fd0e0" onPick={(it) => pickStrategy(it.label)} />
+        </>
+      )}
+      {stage === 'intro' && hasPlan && (
+        <>
+          <div className="mb-3 flex min-h-[44px] flex-wrap items-center justify-center gap-2 rounded-2xl bg-cyan-50 p-2">
+            {picked.length === 0 && <span className="text-sm text-slate-400">Your calm plan will show here…</span>}
+            {picked.map((id) => {
+              const s = STRATEGIES.find((x) => x.id === id)!;
+              return (
+                <span key={id} className="rounded-xl bg-white px-3 py-1.5 text-sm font-bold text-slate-700 shadow">
+                  {s.emoji} {s.label}
+                </span>
+              );
+            })}
+          </div>
+          <Choices items={STRATEGIES} accent="#5fd0e0" onPick={(it) => pickPlan(it.id, it.label)} disabledIds={picked} />
+        </>
+      )}
+
+      {/* plain breathing levels: show Start button */}
+      {stage === 'intro' && !hasBody && !hasStrategy && !hasPlan && (
+        <div className="flex flex-col items-center gap-4 py-2">
+          <BreathBubble running={false} phase={SEQ[0]} />
+          <button
+            onClick={startBreathing}
+            className="rounded-full bg-cyan-500 px-8 py-3 text-lg font-bold text-white shadow-lg transition active:scale-95"
+          >
+            Start breathing 🫧
+          </button>
+        </div>
+      )}
+
+      {/* BREATHING stage */}
+      {stage === 'breathe' && (
+        <div className="flex flex-col items-center gap-6 py-2">
+          <BreathBubble running={running} phase={current} />
+          <p className="text-center text-sm font-medium text-slate-500">
+            Calm breath {Math.min(cycle + 1, breaths)} of {breaths} — let your shoulders relax 💙
+          </p>
+        </div>
+      )}
+
+      {stage === 'done' && (
+        <div className="flex flex-col items-center gap-3 py-6">
+          <motion.div animate={{ scale: [1, 1.15, 1] }} transition={{ duration: 1.6, repeat: Infinity }} className="text-6xl">
+            🌊
+          </motion.div>
+          <p className="text-center text-base font-bold text-cyan-600">So calm. Well done.</p>
+        </div>
+      )}
+    </OverlayShell>
+  );
+}
+
+function Choices({
+  items,
+  accent,
+  onPick,
+  disabledIds = [],
+}: {
+  items: { id: string; label: string; emoji: string }[];
+  accent: string;
+  onPick: (it: { id: string; label: string; emoji: string }) => void;
+  disabledIds?: string[];
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      {items.map((it) => (
+        <ChoiceButton key={it.id} accent={accent} onClick={() => !disabledIds.includes(it.id) && onPick(it)}>
+          <span className="text-2xl">{it.emoji}</span>
+          <span>{it.label}</span>
+        </ChoiceButton>
+      ))}
+    </div>
+  );
+}
+
+function BreathBubble({ running, phase }: { running: boolean; phase: { label: string; secs: number; scale: number } }) {
+  return (
+    <div className="relative flex h-56 w-56 items-center justify-center">
+      <motion.div
+        className="absolute rounded-full"
+        style={{ width: 200, height: 200, background: 'radial-gradient(circle, #bdf0fa 0%, #5fd0e0 70%)' }}
+        animate={{ scale: running ? phase.scale : 1 }}
+        transition={{ duration: running ? phase.secs : 0.6, ease: 'easeInOut' }}
+      />
+      <motion.div
+        className="absolute rounded-full border-4"
+        style={{ width: 230, height: 230, borderColor: '#5fd0e066' }}
+        animate={{ scale: running ? phase.scale * 1.05 : 1, opacity: running ? 0.6 : 0.3 }}
+        transition={{ duration: running ? phase.secs : 0.6, ease: 'easeInOut' }}
+      />
+      <span className="relative z-10 text-center text-lg font-extrabold text-white drop-shadow">
+        {running ? phase.label : 'Ready?'}
+      </span>
+    </div>
+  );
+}

--- a/components/game/BelusWorld/activities/EmotionsActivity.tsx
+++ b/components/game/BelusWorld/activities/EmotionsActivity.tsx
@@ -1,0 +1,175 @@
+// ASD area — READING EMOTIONS (Feelings Meadow). Five levels following the
+// evidence-based emotion-recognition hierarchy: match faces → read body
+// language → infer from situations → desire-based reasoning → belief/
+// perspective + how to help. Errorless and no-fail: a wrong tap gently wiggles
+// and re-prompts; nothing is ever marked "wrong". Belu models learning too.
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { OverlayShell, ChoiceButton, FaceCard, starsFromSlips, type ActivityProps } from './shared';
+
+interface Follow {
+  question: string;
+  options: string[];
+  answer: string;
+}
+interface Round {
+  face: string;
+  who: string;
+  scene?: string;
+  question: string;
+  options: string[];
+  answer: string;
+  follow?: Follow;
+}
+
+const LEVEL_META: Record<number, { first: string; instruction: string }> = {
+  1: { first: 'Match the feeling faces', instruction: 'Look at the face. Which feeling is it?' },
+  2: { first: 'Read the body clues', instruction: 'Look at the face and body. How do they feel?' },
+  3: { first: 'Feelings from what happens', instruction: 'Read what happened. How do they feel?' },
+  4: { first: 'What they wanted', instruction: 'Think about what they wanted. How do they feel now?' },
+  5: { first: 'Help a friend feel better', instruction: 'Figure out the feeling, then choose a kind way to help.' },
+};
+
+const ROUNDS: Record<number, Round[]> = {
+  1: [
+    { face: '😊', who: 'Pip', question: 'Which feeling is this?', options: ['happy', 'sad'], answer: 'happy' },
+    { face: '😢', who: 'Milo', question: 'Which feeling is this?', options: ['sad', 'happy', 'angry'], answer: 'sad' },
+    { face: '😡', who: 'Bea', question: 'Which feeling is this?', options: ['angry', 'calm', 'happy'], answer: 'angry' },
+    { face: '😨', who: 'Otto', question: 'Which feeling is this?', options: ['scared', 'excited', 'sad'], answer: 'scared' },
+  ],
+  2: [
+    { face: '😔', who: 'Milo', scene: 'Slumped shoulders, looking down at the ground.', question: 'How does Milo feel?', options: ['sad', 'excited', 'angry'], answer: 'sad' },
+    { face: '🤩', who: 'Lulu', scene: 'Jumping up and down, clapping hands fast.', question: 'How does Lulu feel?', options: ['excited', 'scared', 'sad'], answer: 'excited' },
+    { face: '😨', who: 'Otto', scene: 'Hiding behind a tree, shaking a little.', question: 'How does Otto feel?', options: ['scared', 'happy', 'proud'], answer: 'scared' },
+    { face: '😤', who: 'Bea', scene: 'Arms crossed tight, stamping a foot.', question: 'How does Bea feel?', options: ['angry', 'calm', 'surprised'], answer: 'angry' },
+  ],
+  3: [
+    { face: '🎁', who: 'Pip', scene: 'Pip got a surprise birthday gift!', question: 'How does Pip feel?', options: ['happy', 'sad', 'angry', 'scared'], answer: 'happy' },
+    { face: '🍦', who: 'Sol', scene: "Sol's ice cream fell on the ground.", question: 'How does Sol feel?', options: ['sad', 'excited', 'proud'], answer: 'sad' },
+    { face: '⛈️', who: 'Otto', scene: 'A loud thunderstorm starts booming.', question: 'How does Otto feel?', options: ['scared', 'happy', 'calm'], answer: 'scared' },
+    { face: '🏆', who: 'Lulu', scene: 'Lulu finished a hard puzzle all by herself.', question: 'How does Lulu feel?', options: ['proud', 'angry', 'sad'], answer: 'proud' },
+  ],
+  4: [
+    { face: '😞', who: 'Mona', scene: 'Mona wanted the red ball, but she got the blue one.', question: 'How does Mona feel?', options: ['disappointed', 'happy', 'surprised'], answer: 'disappointed' },
+    { face: '😄', who: 'Pip', scene: 'Pip hoped for pancakes — and pancakes are ready!', question: 'How does Pip feel?', options: ['happy', 'sad', 'scared'], answer: 'happy' },
+    { face: '😲', who: 'Bea', scene: 'Bea expected one friend, but TEN friends came!', question: 'How does Bea feel?', options: ['surprised', 'angry', 'bored'], answer: 'surprised' },
+    { face: '😟', who: 'Sol', scene: 'Sol wanted to play outside, but it is raining.', question: 'How does Sol feel?', options: ['disappointed', 'excited', 'proud'], answer: 'disappointed' },
+  ],
+  5: [
+    {
+      face: '🧱', who: 'Sam', scene: "Sam doesn't know his block tower fell down.",
+      question: 'When Sam sees it, how will he feel?', options: ['sad', 'happy', 'proud'], answer: 'sad',
+      follow: { question: 'What is a kind way to help?', options: ['Give a hug and help rebuild', 'Laugh at him', 'Walk away'], answer: 'Give a hug and help rebuild' },
+    },
+    {
+      face: '🧩', who: 'Lulu', scene: 'Lulu is stuck on a puzzle and getting frustrated.',
+      question: 'How does Lulu feel?', options: ['frustrated', 'excited', 'calm'], answer: 'frustrated',
+      follow: { question: 'How can you help?', options: ['Ask if she wants help', 'Take the puzzle away', 'Ignore her'], answer: 'Ask if she wants help' },
+    },
+    {
+      face: '😢', who: 'Otto', scene: 'Otto dropped his snack and looks like he might cry.',
+      question: 'How does Otto feel?', options: ['sad', 'angry', 'surprised'], answer: 'sad',
+      follow: { question: 'What can you say?', options: ['"Are you okay? Want to share mine?"', '"Too bad for you!"', 'Say nothing'], answer: '"Are you okay? Want to share mine?"' },
+    },
+  ],
+};
+
+function shuffle(a: string[]): string[] {
+  return [...a].sort(() => 0.5 - Math.random());
+}
+
+export default function EmotionsActivity({ level, speak, onBeluEmotion, onComplete, onExit }: ActivityProps) {
+  const lvl = Math.max(1, Math.min(5, level));
+  const rounds = ROUNDS[lvl];
+  const meta = LEVEL_META[lvl];
+
+  const [idx, setIdx] = useState(0);
+  const [phase, setPhase] = useState<'main' | 'follow'>('main');
+  const [slips, setSlips] = useState(0);
+  const [shake, setShake] = useState<string | null>(null);
+  const modeled = useRef(false);
+
+  const round = rounds[idx];
+  const inFollow = phase === 'follow' && round.follow;
+  const question = inFollow ? round.follow!.question : round.question;
+  const answer = inFollow ? round.follow!.answer : round.answer;
+  const options = useMemo(
+    () => shuffle(inFollow ? round.follow!.options : round.options),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [idx, phase],
+  );
+
+  // Belu gently models that learning takes practice (first round only).
+  useEffect(() => {
+    onBeluEmotion('curious');
+    if (!modeled.current) {
+      modeled.current = true;
+      const guess = round.options.find((o) => o !== round.answer) ?? round.answer;
+      const t = setTimeout(() => speak(`Hmm... I think maybe ${guess}? Can you check for me?`), 500);
+      return () => clearTimeout(t);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function finish() {
+    onBeluEmotion('excited');
+    speak('You read every feeling so well. Thank you for teaching me!');
+    setTimeout(() => onComplete({ stars: starsFromSlips(slips), moment: 'read feelings in the meadow' }), 500);
+  }
+
+  function choose(label: string) {
+    if (label !== answer) {
+      setSlips((s) => s + 1);
+      setShake(label);
+      onBeluEmotion('curious');
+      speak('Look again — what do the clues tell us?');
+      setTimeout(() => setShake(null), 450);
+      return;
+    }
+    onBeluEmotion('happy');
+    if (round.follow && phase === 'main') {
+      speak('Yes! Now, how can we be a kind friend?');
+      setPhase('follow');
+      return;
+    }
+    if (idx + 1 >= rounds.length) {
+      finish();
+    } else {
+      speak('That’s it! You really understand feelings.');
+      setPhase('main');
+      setIdx((i) => i + 1);
+    }
+  }
+
+  return (
+    <OverlayShell
+      title="Feelings Meadow"
+      emoji="🌸"
+      accent="#ff8fc8"
+      level={lvl}
+      step={idx}
+      total={rounds.length}
+      firstThen={{ first: meta.first, then: '⭐ Earn a star' }}
+      instruction={inFollow ? 'Choose the kindest way to help.' : meta.instruction}
+      onSpeak={() => speak(inFollow ? round.follow!.question : meta.instruction)}
+      onExit={onExit}
+    >
+      <div className="flex flex-col items-center gap-4">
+        <FaceCard emoji={round.face} label={round.who} size={inFollow ? 80 : 116} />
+        {round.scene && !inFollow && (
+          <p className="rounded-2xl bg-pink-50 px-4 py-2 text-center text-base font-semibold text-slate-700">
+            {round.scene}
+          </p>
+        )}
+        <p className="text-center text-sm font-bold text-slate-500">{question}</p>
+        <div className="grid w-full grid-cols-2 gap-3">
+          {options.map((o) => (
+            <ChoiceButton key={o} onClick={() => choose(o)} shake={shake === o} accent="#ff8fc8">
+              <span className="capitalize">{o}</span>
+            </ChoiceButton>
+          ))}
+        </div>
+      </div>
+    </OverlayShell>
+  );
+}

--- a/components/game/BelusWorld/activities/FriendshipActivity.tsx
+++ b/components/game/BelusWorld/activities/FriendshipActivity.tsx
@@ -1,0 +1,367 @@
+// ASD area — EXPRESSIVE & FUNCTIONAL LANGUAGE (Friendship Forest). Five levels
+// on the Verbal Behavior progression: request (mand) → action words (verbs) →
+// two-word combos → comment/label ("I see…") → sentences + turn-taking
+// conversation. Errorless and no-fail: a wrong tap gently wiggles and
+// re-prompts; nothing is ever "wrong". Belu models the words, then fades support.
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { motion } from 'framer-motion';
+import { OverlayShell, ChoiceButton, FaceCard, starsFromSlips, type ActivityProps } from './shared';
+
+const ACCENT = '#c6a0ff';
+
+interface Item { e: string; word: string }
+
+type Round =
+  | { kind: 'request'; who: string; face: string; want: Item; options: Item[]; model: string }
+  | { kind: 'verb'; who: string; face: string; correct: string; options: string[]; model: string }
+  | { kind: 'combo'; who: string; face: string; seq: string[]; pool: string[]; model: string }
+  | { kind: 'comment'; scene: string; correct: string; options: string[]; model: string }
+  | { kind: 'sentence'; seq: string[]; pool: string[]; model: string }
+  | { kind: 'turns'; goal: number; model: string };
+
+const LEVEL_META: Record<number, { first: string; instruction: string }> = {
+  1: { first: 'Ask for what you want', instruction: 'Tap the picture to ask for what your friend wants.' },
+  2: { first: 'Pick the action word', instruction: 'Look at your friend. Tap the word for what they are doing.' },
+  3: { first: 'Put two words together', instruction: 'Tap the two word-cards in order to make a message.' },
+  4: { first: 'Tell what you see', instruction: 'Finish "I see a…" by tapping the right word.' },
+  5: { first: 'Make a sentence & chat', instruction: 'Build the sentence, then take turns talking with Belu.' },
+};
+
+function shuffle<T>(a: T[]): T[] {
+  return [...a].sort(() => 0.5 - Math.random());
+}
+
+function buildRounds(level: number): Round[] {
+  if (level === 1) {
+    const items: Item[] = [
+      { e: '🍎', word: 'apple' },
+      { e: '⚽', word: 'ball' },
+      { e: '📖', word: 'book' },
+      { e: '🥤', word: 'drink' },
+    ];
+    const friends = [
+      { who: 'Fox', face: '🦊' },
+      { who: 'Bunny', face: '🐰' },
+      { who: 'Bear', face: '🐻' },
+    ];
+    return friends.map((f, i) => {
+      const want = items[i % items.length];
+      const others = shuffle(items.filter((it) => it.word !== want.word)).slice(0, 2);
+      return {
+        kind: 'request' as const,
+        who: f.who,
+        face: f.face,
+        want,
+        options: shuffle([want, ...others]),
+        model: `Let's ask! Tap to say: "I want ${want.word}."`,
+      };
+    });
+  }
+  if (level === 2) {
+    return [
+      { kind: 'verb', who: 'Fox', face: '🦊', correct: 'running', options: shuffle(['running', 'sleeping', 'eating']), model: 'The fox is moving fast! Tap: running.' },
+      { kind: 'verb', who: 'Bird', face: '🐦', correct: 'flying', options: shuffle(['flying', 'jumping', 'eating']), model: 'Up in the sky! Tap: flying.' },
+      { kind: 'verb', who: 'Bear', face: '🐻', correct: 'eating', options: shuffle(['eating', 'running', 'flying']), model: 'Yum! Tap: eating.' },
+      { kind: 'verb', who: 'Bunny', face: '🐰', correct: 'jumping', options: shuffle(['jumping', 'sleeping', 'flying']), model: 'Hop hop! Tap: jumping.' },
+    ];
+  }
+  if (level === 3) {
+    const combos: { who: string; face: string; seq: string[]; extra: string[] }[] = [
+      { who: 'Bunny', face: '🐰', seq: ['want', 'ball'], extra: ['book'] },
+      { who: 'Fox', face: '🦊', seq: ['want', 'apple'], extra: ['drink'] },
+      { who: 'Bear', face: '🐻', seq: ['big', 'hug'], extra: ['ball'] },
+    ];
+    return combos.map((c) => ({
+      kind: 'combo' as const,
+      who: c.who,
+      face: c.face,
+      seq: c.seq,
+      pool: shuffle([...c.seq, ...c.extra]),
+      model: `Let's say: "${c.seq.join(' ')}". Tap them in order.`,
+    }));
+  }
+  if (level === 4) {
+    return [
+      { kind: 'comment', scene: '🐶', correct: 'dog', options: shuffle(['dog', 'cat', 'fish']), model: 'You noticed something! Tap: dog.' },
+      { kind: 'comment', scene: '🌳', correct: 'tree', options: shuffle(['tree', 'rock', 'cloud']), model: 'Nice looking! Tap: tree.' },
+      { kind: 'comment', scene: '⭐', correct: 'star', options: shuffle(['star', 'moon', 'sun']), model: 'Way up high! Tap: star.' },
+      { kind: 'comment', scene: '🦋', correct: 'butterfly', options: shuffle(['butterfly', 'bee', 'bird']), model: 'So pretty! Tap: butterfly.' },
+    ];
+  }
+  // level 5
+  return [
+    { kind: 'sentence', seq: ['I', 'like', 'apples'], pool: shuffle(['I', 'like', 'apples', 'run']), model: 'Let\'s say: "I like apples." Tap the words in order.' },
+    { kind: 'sentence', seq: ['I', 'see', 'you'], pool: shuffle(['I', 'see', 'you', 'big']), model: 'Now: "I see you." Tap them in order.' },
+    { kind: 'turns', goal: 4, model: 'Now let\'s chat! Take turns talking with me.' },
+  ];
+}
+
+// Module-scope shell so it keeps a STABLE identity across re-renders (a nested
+// component would remount the overlay and replay its entrance animation on
+// every tap — a visible flicker).
+function ForestShell({
+  frame,
+  total,
+  step,
+  children,
+}: {
+  frame: { lvl: number; meta: { first: string; instruction: string }; speak: (t: string) => void; onExit: () => void };
+  total: number;
+  step: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <OverlayShell
+      title="Friendship Forest"
+      emoji="🌳"
+      accent={ACCENT}
+      level={frame.lvl}
+      step={step}
+      total={total}
+      firstThen={{ first: frame.meta.first, then: '⭐ Earn a star' }}
+      instruction={frame.meta.instruction}
+      onSpeak={() => frame.speak(frame.meta.instruction)}
+      onExit={frame.onExit}
+    >
+      {children}
+    </OverlayShell>
+  );
+}
+
+export default function FriendshipActivity({ level, speak, onBeluEmotion, onComplete, onExit }: ActivityProps) {
+  const lvl = Math.max(1, Math.min(5, level));
+  const meta = LEVEL_META[lvl];
+  const rounds = useMemo(() => buildRounds(lvl), [lvl]);
+
+  const [idx, setIdx] = useState(0);
+  const [built, setBuilt] = useState<number[]>([]); // chosen pool indices (combo/sentence)
+  const [turns, setTurns] = useState(0);
+  const [holder, setHolder] = useState<'you' | 'belu'>('you');
+  const [shakeKey, setShakeKey] = useState<string | null>(null);
+  const slips = useRef(0);
+  const modeled = useRef(false);
+
+  const round = rounds[idx];
+
+  // reset per-round build state
+  useEffect(() => {
+    setBuilt([]);
+    setTurns(0);
+    setHolder('you');
+  }, [idx]);
+
+  // Belu models the target on entering a round, then fades on later rounds.
+  useEffect(() => {
+    onBeluEmotion('curious');
+    if (idx <= 1 || !modeled.current) {
+      modeled.current = true;
+      const t = setTimeout(() => speak(round.model), 450);
+      return () => clearTimeout(t);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [idx]);
+
+  function slip(key: string, line: string) {
+    slips.current += 1;
+    setShakeKey(key);
+    onBeluEmotion('curious');
+    speak(line);
+    setTimeout(() => setShakeKey(null), 450);
+  }
+
+  function finish() {
+    onBeluEmotion('excited');
+    speak('You used your words so well! I loved talking with you.');
+    setTimeout(() => onComplete({ stars: starsFromSlips(slips.current), moment: 'used my words in the forest' }), 500);
+  }
+
+  function advance(praise: string) {
+    onBeluEmotion('happy');
+    speak(praise);
+    if (idx + 1 >= rounds.length) setTimeout(finish, 650);
+    else setTimeout(() => setIdx((i) => i + 1), 650);
+  }
+
+  const frame = { lvl, meta, speak, onExit };
+
+  // ---------- REQUEST (L1) ----------
+  if (round.kind === 'request') {
+    return (
+      <ForestShell frame={frame} total={rounds.length} step={idx}>
+        <div className="flex flex-col items-center gap-4">
+          <div className="relative">
+            <FaceCard emoji={round.face} label={round.who} />
+            <div className="absolute -right-2 -top-1 rounded-2xl bg-white px-3 py-1 text-2xl shadow">{round.want.e}💭</div>
+          </div>
+          <p className="text-center text-sm font-bold text-slate-500">Tap to ask for what {round.who} wants:</p>
+          <div className="grid w-full grid-cols-3 gap-3">
+            {round.options.map((it) => (
+              <ChoiceButton
+                key={it.word}
+                big
+                accent={ACCENT}
+                shake={shakeKey === it.word}
+                onClick={() =>
+                  it.word === round.want.word
+                    ? advance(`Yes! "I want ${round.want.word}!" Here you go! 🎉`)
+                    : slip(it.word, `Look at the thought bubble. What does ${round.who} want?`)
+                }
+              >
+                <span className="flex flex-col items-center">
+                  <span className="text-4xl">{it.e}</span>
+                  <span className="text-xs">{it.word}</span>
+                </span>
+              </ChoiceButton>
+            ))}
+          </div>
+        </div>
+      </ForestShell>
+    );
+  }
+
+  // ---------- VERB (L2) ----------
+  if (round.kind === 'verb') {
+    return (
+      <ForestShell frame={frame} total={rounds.length} step={idx}>
+        <div className="flex flex-col items-center gap-4">
+          <FaceCard emoji={round.face} label={round.who} />
+          <p className="text-center text-base font-bold text-slate-600">The {round.who.toLowerCase()} is…</p>
+          <div className="grid w-full grid-cols-3 gap-3">
+            {round.options.map((w) => (
+              <ChoiceButton
+                key={w}
+                accent={ACCENT}
+                shake={shakeKey === w}
+                onClick={() =>
+                  w === round.correct
+                    ? advance(`Yes! The ${round.who.toLowerCase()} is ${round.correct}!`)
+                    : slip(w, 'Look closely — what are they doing?')
+                }
+              >
+                {w}
+              </ChoiceButton>
+            ))}
+          </div>
+        </div>
+      </ForestShell>
+    );
+  }
+
+  // ---------- COMBO / SENTENCE (L3 / L5a) — build in order ----------
+  if (round.kind === 'combo' || round.kind === 'sentence') {
+    const expected = round.seq[built.length];
+    const tapWord = (poolIdx: number, word: string) => {
+      if (built.includes(poolIdx)) return;
+      if (word === expected) {
+        const nb = [...built, poolIdx];
+        setBuilt(nb);
+        if (nb.length === round.seq.length) advance(`"${round.seq.join(' ')}" — perfect! 🌟`);
+        else onBeluEmotion('happy');
+      } else {
+        slip('w' + poolIdx, `Next word is "${expected}". You can do it!`);
+      }
+    };
+    return (
+      <ForestShell frame={frame} total={rounds.length} step={idx}>
+        <div className="flex flex-col items-center gap-4">
+          {round.kind === 'combo' && <FaceCard emoji={round.face} label={round.who} size={80} />}
+          {/* sentence strip */}
+          <div className="flex min-h-[52px] w-full flex-wrap items-center justify-center gap-2 rounded-2xl bg-purple-50 p-3">
+            {built.length === 0 && <span className="text-sm text-slate-400">Tap the words in order…</span>}
+            {built.map((pi, n) => (
+              <motion.span
+                key={pi}
+                initial={{ scale: 0 }}
+                animate={{ scale: 1 }}
+                className="rounded-xl bg-white px-3 py-2 text-base font-bold text-slate-700 shadow"
+              >
+                {round.pool[pi]}
+                {n < built.length - 1 && <span className="ml-2 text-purple-300">·</span>}
+              </motion.span>
+            ))}
+          </div>
+          <div className="grid w-full grid-cols-2 gap-3 sm:grid-cols-4">
+            {round.pool.map((w, pi) => (
+              <ChoiceButton
+                key={pi}
+                accent={ACCENT}
+                shake={shakeKey === 'w' + pi}
+                onClick={() => tapWord(pi, w)}
+              >
+                <span className={built.includes(pi) ? 'opacity-30' : ''}>{w}</span>
+              </ChoiceButton>
+            ))}
+          </div>
+        </div>
+      </ForestShell>
+    );
+  }
+
+  // ---------- COMMENT (L4) ----------
+  if (round.kind === 'comment') {
+    return (
+      <ForestShell frame={frame} total={rounds.length} step={idx}>
+        <div className="flex flex-col items-center gap-4">
+          <div className="text-[110px] leading-none">{round.scene}</div>
+          <p className="text-center text-xl font-extrabold text-slate-700">
+            I see a <span className="text-purple-400">___</span>
+          </p>
+          <div className="grid w-full grid-cols-3 gap-3">
+            {round.options.map((w) => (
+              <ChoiceButton
+                key={w}
+                accent={ACCENT}
+                shake={shakeKey === w}
+                onClick={() =>
+                  w === round.correct
+                    ? advance(`"I see a ${round.correct}!" Great noticing! 👀`)
+                    : slip(w, 'What is in the picture? Tap its name.')
+                }
+              >
+                {w}
+              </ChoiceButton>
+            ))}
+          </div>
+        </div>
+      </ForestShell>
+    );
+  }
+
+  // ---------- TURNS (L5b) ----------
+  const takeTurn = () => {
+    const n = turns + 1;
+    setTurns(n);
+    if (n >= round.goal) {
+      advance('We took turns talking so nicely! That is what friends do. 💜');
+    } else {
+      setHolder((h) => (h === 'you' ? 'belu' : 'you'));
+      onBeluEmotion('happy');
+      speak(holder === 'you' ? 'My turn — thank you for sharing!' : 'Your turn now, friend!');
+    }
+  };
+  return (
+    <ForestShell frame={frame} total={rounds.length} step={idx}>
+      <div className="flex flex-col items-center gap-5 py-2">
+        <p className="text-center text-base font-bold text-slate-600">Take turns talking — pass it back and forth.</p>
+        <div className="flex items-center justify-center gap-6">
+          <FaceCard emoji="🧒" label="You" size={66} />
+          <motion.span animate={{ x: holder === 'you' ? -6 : 6 }} className="text-3xl">
+            🗣️
+          </motion.span>
+          <FaceCard emoji="🐘" label="Belu" size={66} />
+        </div>
+        <div className="text-lg font-extrabold text-slate-700">
+          {holder === 'you' ? 'Your turn to talk!' : 'Belu is talking…'}
+        </div>
+        <button
+          onClick={takeTurn}
+          className="rounded-full bg-purple-500 px-8 py-3 text-lg font-bold text-white shadow-lg transition active:scale-95"
+        >
+          {holder === 'you' ? 'Take my turn 🗣️' : 'Listen to Belu 👂'}
+        </button>
+        <p className="text-sm text-slate-400">Turn {turns} of {round.goal}</p>
+      </div>
+    </ForestShell>
+  );
+}

--- a/components/game/BelusWorld/activities/RoutineActivity.tsx
+++ b/components/game/BelusWorld/activities/RoutineActivity.tsx
@@ -1,0 +1,233 @@
+// ASD area — LIFE SKILLS & DAILY LIVING (Morning Mountain). Five levels built
+// on task-analysis + chaining: single self-care steps → short chains → full
+// routine sequencing → safety choices → independent self-check. Errorless and
+// no-fail: a wrong tap gently wiggles and re-prompts; nothing is ever "wrong".
+
+import { useMemo, useState } from 'react';
+import { motion } from 'framer-motion';
+import { OverlayShell, ChoiceButton, starsFromSlips, type ActivityProps } from './shared';
+
+const ACCENT = '#7cc6ff';
+
+// ----- content tables -----
+interface MatchRound { prompt: string; answer: string; choices: string[]; }
+const L1: MatchRound[] = [
+  { prompt: 'Brush your teeth', answer: '🪥', choices: ['🪥', '🍕', '⚽'] },
+  { prompt: 'Wash your hands', answer: '🧼', choices: ['📺', '🧼', '🎈'] },
+  { prompt: 'Dry your hair', answer: '🧴', choices: ['🚗', '🍞', '🧴'] },
+  { prompt: 'Put on your shoes', answer: '👟', choices: ['👟', '🪀', '🍩'] },
+];
+
+interface Chain { label: string; steps: { e: string; t: string }[]; }
+const L2: Chain[] = [
+  { label: 'Brushing teeth', steps: [{ e: '🪥', t: 'Get the brush' }, { e: '🧴', t: 'Add toothpaste' }, { e: '😁', t: 'Brush!' }] },
+  { label: 'Washing hands', steps: [{ e: '💧', t: 'Turn on water' }, { e: '🧼', t: 'Use soap' }, { e: '🧻', t: 'Dry hands' }] },
+  { label: 'Getting dressed', steps: [{ e: '🩲', t: 'Underclothes' }, { e: '👕', t: 'Shirt' }, { e: '👖', t: 'Pants' }] },
+];
+
+const ROUTINE = [
+  { e: '😴', t: 'Wake up' },
+  { e: '🪥', t: 'Brush teeth' },
+  { e: '👕', t: 'Get dressed' },
+  { e: '🥣', t: 'Eat breakfast' },
+  { e: '🎒', t: 'Pack bag' },
+  { e: '👋', t: 'Say goodbye' },
+];
+
+interface Safety { situation: string; options: { e: string; t: string; safe: boolean }[]; }
+const L4: Safety[] = [
+  { situation: 'Before crossing the street, what do we do first?', options: [{ e: '👀', t: 'Look both ways', safe: true }, { e: '🏃', t: 'Run across fast', safe: false }] },
+  { situation: 'The stove is hot and red. What do we do?', options: [{ e: '🔥', t: 'Touch it', safe: false }, { e: '🙅', t: 'Stay away', safe: true }] },
+  { situation: 'A stranger asks you to go with them. What do we do?', options: [{ e: '🙋', t: 'Find a grown-up you trust', safe: true }, { e: '🚶', t: 'Go with them', safe: false }] },
+  { situation: 'Time to ride in the car. What do we do?', options: [{ e: '🎮', t: 'Stand up and play', safe: false }, { e: '🔒', t: 'Buckle your seatbelt', safe: true }] },
+];
+
+const L5_TASKS = [
+  { e: '🛏️', t: 'Make the bed' },
+  { e: '🪥', t: 'Brush teeth' },
+  { e: '👕', t: 'Get dressed' },
+  { e: '🥣', t: 'Eat breakfast' },
+  { e: '🎒', t: 'Pack my bag' },
+];
+
+function shuffle<T>(a: T[]): T[] { return [...a].sort(() => 0.5 - Math.random()); }
+
+export default function RoutineActivity({ level, speak, onBeluEmotion, onComplete, onExit }: ActivityProps) {
+  const [round, setRound] = useState(0);     // L1, L4: round index
+  const [placed, setPlaced] = useState<number[]>([]); // L2, L3: order placed
+  const [checked, setChecked] = useState<number[]>([]); // L5
+  const [shake, setShake] = useState<number | null>(null);
+  const [slips, setSlips] = useState(0);
+
+  const routineSteps = useMemo(() => (level >= 3 ? ROUTINE : ROUTINE.slice(0, 4)), [level]);
+  const pool = useMemo(
+    () => (level === 2 ? shuffle(L2[round].steps.map((_, i) => i)) : level === 3 ? shuffle(routineSteps.map((_, i) => i)) : []),
+    // re-shuffle each round/level
+    [level, round, routineSteps],
+  );
+  const choiceOrder = useMemo(
+    () => (level === 1 ? shuffle(L1[round].choices) : []),
+    [level, round],
+  );
+
+  function slip(id: number, line: string) {
+    setShake(id);
+    setSlips((s) => s + 1);
+    onBeluEmotion('curious');
+    speak(line);
+    setTimeout(() => setShake(null), 450);
+  }
+
+  function finish() {
+    onBeluEmotion('excited');
+    speak('You did it all by yourself — you are so ready!');
+    setTimeout(() => onComplete({ stars: starsFromSlips(slips), moment: 'practiced life skills on the mountain' }), 450);
+  }
+
+  // ---------- LEVEL 1: match the action ----------
+  if (level === 1) {
+    const r = L1[round];
+    return (
+      <Shell level={level} step={round} total={L1.length} firstThen={{ first: 'Match each action', then: '⭐ Earn a star' }} instruction={`Tap what we use to: ${r.prompt}.`} speak={speak} onExit={onExit}>
+        <div className="flex flex-col items-center gap-4">
+          <div className="text-center text-lg font-extrabold text-slate-700">{r.prompt}?</div>
+          <div className="grid w-full grid-cols-3 gap-3">
+            {choiceOrder.map((c, i) => (
+              <ChoiceButton key={c} big accent={ACCENT} shake={shake === i}
+                onClick={() => {
+                  if (c === r.answer) {
+                    onBeluEmotion('happy');
+                    speak('Yes! That is just right.');
+                    if (round + 1 >= L1.length) finish(); else setRound((x) => x + 1);
+                  } else slip(i, `Hmm, which one do we use to ${r.prompt.toLowerCase()}?`);
+                }}>
+                <span className="text-4xl">{c}</span>
+              </ChoiceButton>
+            ))}
+          </div>
+        </div>
+      </Shell>
+    );
+  }
+
+  // ---------- LEVEL 2 & 3: build the sequence in order ----------
+  if (level === 2 || level === 3) {
+    const steps = level === 2 ? L2[round].steps : routineSteps;
+    const label = level === 2 ? L2[round].label : 'Morning routine';
+    const total = level === 2 ? L2.length : steps.length;
+    const step = level === 2 ? round : placed.length;
+
+    function tap(i: number) {
+      if (i === placed.length) {
+        const np = [...placed, i];
+        setPlaced(np);
+        onBeluEmotion('happy');
+        if (np.length === steps.length) {
+          if (level === 2) {
+            speak(`Great! That's how we do ${label.toLowerCase()}.`);
+            if (round + 1 >= L2.length) finish();
+            else { setTimeout(() => { setRound((x) => x + 1); setPlaced([]); }, 500); }
+          } else {
+            finish();
+          }
+        } else {
+          speak(`Then comes "${steps[i].t}". What's next?`);
+        }
+      } else {
+        slip(i, level === 2 ? `What do we do first for ${label.toLowerCase()}?` : 'What do we do first in the morning?');
+      }
+    }
+
+    return (
+      <Shell level={level} step={step} total={total} firstThen={{ first: `Put ${label} in order`, then: '⭐ Earn a star' }} instruction={`Tap the steps for ${label} in the right order.`} speak={speak} onExit={onExit}>
+        {/* visual schedule building up */}
+        <div className="mb-4 flex min-h-[58px] flex-wrap items-center justify-center gap-2 rounded-2xl bg-sky-50 p-3">
+          {placed.length === 0 && <span className="text-sm text-slate-400">Start with what comes first…</span>}
+          {placed.map((i, n) => (
+            <motion.div key={i} initial={{ scale: 0 }} animate={{ scale: 1 }} className="flex items-center gap-1 rounded-xl bg-white px-3 py-2 text-sm font-bold text-slate-700 shadow">
+              <span className="text-lg">{steps[i].e}</span>{steps[i].t}
+              {n < placed.length - 1 && <span className="text-sky-300">→</span>}
+            </motion.div>
+          ))}
+        </div>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          {pool.filter((i) => !placed.includes(i)).map((i) => (
+            <motion.button key={i} onClick={() => tap(i)} whileTap={{ scale: 0.92 }} animate={shake === i ? { x: [0, -8, 8, -6, 6, 0] } : {}} transition={{ duration: 0.4 }}
+              className="flex flex-col items-center gap-1 rounded-2xl border-2 border-sky-200 bg-white p-3 font-bold text-slate-700 shadow-sm">
+              <span className="text-3xl">{steps[i].e}</span>
+              <span className="text-xs">{steps[i].t}</span>
+            </motion.button>
+          ))}
+        </div>
+      </Shell>
+    );
+  }
+
+  // ---------- LEVEL 4: safety choices ----------
+  if (level === 4) {
+    const s = L4[round];
+    return (
+      <Shell level={level} step={round} total={L4.length} firstThen={{ first: 'Pick the safe choice', then: '⭐ Earn a star' }} instruction={s.situation} speak={speak} onExit={onExit}>
+        <div className="flex flex-col gap-3">
+          {s.options.map((o, i) => (
+            <ChoiceButton key={i} accent={ACCENT} shake={shake === i}
+              onClick={() => {
+                if (o.safe) {
+                  onBeluEmotion('happy');
+                  speak('Yes — that is the safe choice. Good thinking!');
+                  if (round + 1 >= L4.length) finish(); else setRound((x) => x + 1);
+                } else slip(i, 'Let\'s keep safe. Which choice keeps us safe?');
+              }}>
+              <span className="text-2xl">{o.e}</span><span>{o.t}</span>
+            </ChoiceButton>
+          ))}
+        </div>
+      </Shell>
+    );
+  }
+
+  // ---------- LEVEL 5: independent self-check ----------
+  const allDone = checked.length >= L5_TASKS.length;
+  return (
+    <Shell level={level} step={checked.length} total={L5_TASKS.length} firstThen={{ first: 'Check off each task', then: '⭐ Earn a star' }} instruction="Get yourself ready! Tap each task as you finish it." speak={speak} onExit={onExit}>
+      <div className="flex flex-col gap-2">
+        {L5_TASKS.map((t, i) => {
+          const done = checked.includes(i);
+          return (
+            <motion.button key={i} whileTap={{ scale: 0.97 }}
+              onClick={() => {
+                if (done) return;
+                const nc = [...checked, i];
+                setChecked(nc);
+                onBeluEmotion('happy');
+                if (nc.length >= L5_TASKS.length) finish(); else speak('Nice — what will you do next?');
+              }}
+              className="flex items-center gap-3 rounded-2xl border-2 bg-white px-4 py-3 text-left font-bold text-slate-700 shadow-sm"
+              style={{ borderColor: done ? '#7ec850' : '#cfe4ff' }}>
+              <span className="flex h-7 w-7 flex-none items-center justify-center rounded-full" style={{ background: done ? '#7ec850' : '#eef4fb', color: done ? '#fff' : '#9bb' }}>{done ? '✓' : ''}</span>
+              <span className="text-2xl">{t.e}</span>
+              <span className={done ? 'text-slate-400 line-through' : ''}>{t.t}</span>
+            </motion.button>
+          );
+        })}
+      </div>
+      {allDone && <p className="mt-3 text-center text-sm font-bold text-green-600">All done — you got ready by yourself! 🌟</p>}
+    </Shell>
+  );
+}
+
+// small wrapper to avoid repeating OverlayShell boilerplate
+function Shell({
+  level, step, total, firstThen, instruction, speak, onExit, children,
+}: {
+  level: number; step: number; total: number;
+  firstThen: { first: string; then: string }; instruction: string;
+  speak: (t: string) => void; onExit: () => void; children: React.ReactNode;
+}) {
+  return (
+    <OverlayShell title="Morning Mountain" emoji="⛰️" accent={ACCENT} level={level} step={step} total={total}
+      firstThen={firstThen} instruction={instruction} onSpeak={() => speak(instruction)} onExit={onExit}>
+      {children}
+    </OverlayShell>
+  );
+}

--- a/components/game/BelusWorld/activities/registry.ts
+++ b/components/game/BelusWorld/activities/registry.ts
@@ -1,0 +1,65 @@
+// Maps each zone island to its learning activity + presentation metadata.
+import type React from 'react';
+import type { ZoneId } from '../three/worldConfig';
+import type { ActivityProps } from './shared';
+import EmotionsActivity from './EmotionsActivity';
+import RoutineActivity from './RoutineActivity';
+import CalmActivity from './CalmActivity';
+import FriendshipActivity from './FriendshipActivity';
+
+export interface ActivityMeta {
+  zone: ZoneId;
+  title: string;
+  emoji: string;
+  accent: string;
+  /** the ASD skill area this activity grows */
+  skill: string;
+  /** kid-facing one-liner for the level-select screen */
+  tagline: string;
+  /** short labels for each of the 5 levels (what the child is learning) */
+  levelNames: string[];
+  component: React.FC<ActivityProps>;
+}
+
+export const ACTIVITIES: Record<Exclude<ZoneId, 'home'>, ActivityMeta> = {
+  meadow: {
+    zone: 'meadow',
+    title: 'Feelings Meadow',
+    emoji: '🌸',
+    accent: '#ff8fc8',
+    skill: 'Reading Emotions',
+    tagline: 'Learn to read how friends feel',
+    levelNames: ['Match faces', 'Body clues', 'From the story', 'What they wanted', 'Help a friend'],
+    component: EmotionsActivity,
+  },
+  mountain: {
+    zone: 'mountain',
+    title: 'Morning Mountain',
+    emoji: '⛰️',
+    accent: '#7cc6ff',
+    skill: 'Life Skills',
+    tagline: 'Practice everyday self-care',
+    levelNames: ['One step', 'Little chains', 'Whole routine', 'Stay safe', 'All by myself'],
+    component: RoutineActivity,
+  },
+  cove: {
+    zone: 'cove',
+    title: 'Calm Cove',
+    emoji: '🌊',
+    accent: '#5fd0e0',
+    skill: 'Calm & Senses',
+    tagline: 'Find calm when things feel big',
+    levelNames: ['Breathe', 'Breathe & count', 'Body check', 'Pick a strategy', 'My calm plan'],
+    component: CalmActivity,
+  },
+  forest: {
+    zone: 'forest',
+    title: 'Friendship Forest',
+    emoji: '🌳',
+    accent: '#c6a0ff',
+    skill: 'Expressive Language',
+    tagline: 'Use your words with friends',
+    levelNames: ['Ask for it', 'Action words', 'Two words', 'I see…', 'Sentences & chat'],
+    component: FriendshipActivity,
+  },
+};

--- a/components/game/BelusWorld/activities/shared.tsx
+++ b/components/game/BelusWorld/activities/shared.tsx
@@ -1,0 +1,209 @@
+// ---------------------------------------------------------------------------
+// Shared scaffolding for the in-world learning activities.
+//
+// Research-informed (see project memory): every activity is errorless and
+// no-fail, shows a First→Then board and a visual step schedule, gives literal
+// instructions with a text-to-speech replay button, and never uses a timer or
+// a "wrong" buzzer. Wrong taps gently wiggle and re-prompt. Each activity is
+// leveled (1..MAX_LEVEL) and reports 1–3 stars on completion (best is kept).
+// ---------------------------------------------------------------------------
+
+import { motion } from 'framer-motion';
+import type { BeluEmotion } from '../BeluCharacter';
+
+export interface ActivityResult {
+  /** 1..3 — based on how smoothly it went, never below 1 (no-fail) */
+  stars: number;
+  /** short human phrase for Belu's memory, e.g. "matched feeling faces" */
+  moment: string;
+}
+
+export interface ActivityProps {
+  /** which level the child chose to play (1-based) */
+  level: number;
+  /** say a line: shows Belu's speech bubble AND speaks it aloud if narration is on */
+  speak: (text: string) => void;
+  onBeluEmotion: (e: BeluEmotion) => void;
+  onComplete: (result: ActivityResult) => void;
+  onExit: () => void;
+}
+
+/** Compute a gentle star rating from the number of gentle re-prompts. */
+export function starsFromSlips(slips: number): number {
+  if (slips <= 0) return 3;
+  if (slips <= 2) return 2;
+  return 1;
+}
+
+export function OverlayShell({
+  title,
+  emoji,
+  accent,
+  level,
+  step,
+  total,
+  firstThen,
+  instruction,
+  onSpeak,
+  onExit,
+  children,
+}: {
+  title: string;
+  emoji: string;
+  accent: string;
+  level: number;
+  step: number;
+  total: number;
+  /** the First→Then board labels, e.g. { first: 'Match the feelings', then: '⭐ Earn a star' } */
+  firstThen?: { first: string; then: string };
+  /** the single, literal instruction for the current screen */
+  instruction?: string;
+  /** re-speak the instruction (text-to-speech) */
+  onSpeak?: () => void;
+  onExit: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      className="fixed inset-0 z-40 flex items-center justify-center p-4"
+      style={{ background: 'rgba(20,28,46,0.55)', backdropFilter: 'blur(10px)' }}
+    >
+      <motion.div
+        initial={{ scale: 0.92, y: 20 }}
+        animate={{ scale: 1, y: 0 }}
+        exit={{ scale: 0.92, y: 10 }}
+        transition={{ type: 'spring', stiffness: 260, damping: 24 }}
+        className="relative w-full max-w-lg rounded-[28px] p-5 sm:p-7"
+        style={{
+          background: 'linear-gradient(160deg, #ffffff 0%, #f4f8ff 100%)',
+          boxShadow: '0 30px 80px rgba(20,30,60,0.45), inset 0 1px 0 rgba(255,255,255,0.9)',
+          border: '1px solid rgba(255,255,255,0.7)',
+        }}
+      >
+        {/* header */}
+        <div className="mb-3 flex items-center gap-3">
+          <div
+            className="flex h-12 w-12 items-center justify-center rounded-2xl text-2xl"
+            style={{ background: accent, boxShadow: `0 6px 18px ${accent}66` }}
+          >
+            {emoji}
+          </div>
+          <div className="flex-1">
+            <div className="flex items-center gap-2">
+              <h2 className="text-lg font-extrabold text-slate-800">{title}</h2>
+              <span className="rounded-full px-2 py-0.5 text-xs font-bold text-white" style={{ background: accent }}>
+                Level {level}
+              </span>
+            </div>
+            <ProgressDots step={step} total={total} accent={accent} />
+          </div>
+          <button
+            onClick={onExit}
+            className="flex h-9 w-9 items-center justify-center rounded-full bg-slate-100 text-slate-500 transition hover:bg-slate-200"
+            aria-label="Leave activity"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* First → Then board (evidence-based visual support) */}
+        {firstThen && (
+          <div className="mb-3 flex items-stretch gap-2 rounded-2xl bg-slate-50 p-2 text-center text-xs font-bold">
+            <div className="flex-1 rounded-xl bg-white px-2 py-2 text-slate-600 shadow-sm">
+              <div className="text-[10px] uppercase tracking-wide text-slate-400">First</div>
+              {firstThen.first}
+            </div>
+            <div className="flex items-center text-slate-300">➜</div>
+            <div className="flex-1 rounded-xl px-2 py-2 text-slate-700 shadow-sm" style={{ background: `${accent}22` }}>
+              <div className="text-[10px] uppercase tracking-wide text-slate-400">Then</div>
+              {firstThen.then}
+            </div>
+          </div>
+        )}
+
+        {/* literal instruction + read-aloud */}
+        {instruction && (
+          <div className="mb-3 flex items-center gap-2 rounded-2xl bg-amber-50 px-3 py-2">
+            <button
+              onClick={onSpeak}
+              className="flex h-8 w-8 flex-none items-center justify-center rounded-full bg-white text-base shadow-sm transition active:scale-90"
+              aria-label="Read aloud"
+            >
+              🔊
+            </button>
+            <p className="text-sm font-semibold text-slate-700">{instruction}</p>
+          </div>
+        )}
+
+        {children}
+
+        <p className="mt-4 text-center text-xs font-medium text-slate-400">
+          🐘 Belu is learning right alongside you · take all the time you need
+        </p>
+      </motion.div>
+    </motion.div>
+  );
+}
+
+function ProgressDots({ step, total, accent }: { step: number; total: number; accent: string }) {
+  return (
+    <div className="mt-1 flex gap-1.5">
+      {Array.from({ length: total }).map((_, i) => (
+        <div
+          key={i}
+          className="h-2 rounded-full transition-all duration-300"
+          style={{ width: i === step ? 22 : 10, background: i <= step ? accent : '#d8e0ec' }}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function ChoiceButton({
+  onClick,
+  shake,
+  children,
+  accent,
+  big,
+}: {
+  onClick: () => void;
+  shake?: boolean;
+  children: React.ReactNode;
+  accent: string;
+  big?: boolean;
+}) {
+  return (
+    <motion.button
+      onClick={onClick}
+      whileTap={{ scale: 0.94 }}
+      animate={shake ? { x: [0, -8, 8, -6, 6, 0] } : {}}
+      transition={{ duration: 0.4 }}
+      className={`flex items-center justify-center gap-2 rounded-2xl border-2 bg-white px-4 text-center font-bold text-slate-700 transition ${
+        big ? 'min-h-[84px] py-4 text-lg' : 'min-h-[64px] py-3 text-base'
+      }`}
+      style={{ borderColor: `${accent}55`, boxShadow: '0 4px 14px rgba(30,40,70,0.08)' }}
+    >
+      {children}
+    </motion.button>
+  );
+}
+
+// Big friendly emoji-face for the feelings + language activities.
+export function FaceCard({ emoji, label, size = 120 }: { emoji: string; label?: string; size?: number }) {
+  return (
+    <div className="flex flex-col items-center">
+      <motion.div
+        initial={{ scale: 0.8 }}
+        animate={{ scale: [1, 1.04, 1] }}
+        transition={{ duration: 2.4, repeat: Infinity }}
+        style={{ fontSize: size, lineHeight: 1 }}
+      >
+        {emoji}
+      </motion.div>
+      {label && <div className="mt-1 text-sm font-semibold text-slate-500">{label}</div>}
+    </div>
+  );
+}

--- a/components/game/BelusWorld/belu/dialogue.ts
+++ b/components/game/BelusWorld/belu/dialogue.ts
@@ -1,0 +1,242 @@
+import type { BeluMemory } from './memory';
+
+export interface DialogueContext {
+  memory: BeluMemory;
+  zone?: string;
+  trigger?: string;
+}
+
+type Line = string | ((ctx: DialogueContext) => string);
+
+function pick<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function resolve(line: Line, ctx: DialogueContext): string {
+  return typeof line === 'function' ? line(ctx) : line;
+}
+
+const name = (ctx: DialogueContext) => ctx.memory.playerName ?? 'friend';
+
+// Dialogue database — keyed by event, then personality stage (0=shy 1=curious 2=confident 3=playful)
+const DB: Record<string, Partial<Record<0 | 1 | 2 | 3, Line[]>>> = {
+
+  greeting_first: {
+    0: [
+      "Oh! H-hello... I didn't know anyone else knew about this island.",
+      "Um... hi. I'm Belu. This is Harmony Island. I... I'm glad you found it.",
+    ],
+  },
+
+  greeting_return: {
+    0: [
+      ctx => `Oh! ${name(ctx)}! You came back...`,
+      "You came back. I was hoping you would.",
+    ],
+    1: [
+      ctx => `${name(ctx)}! I was just exploring. Want to come?`,
+      "You're here! I found something I want to show you today!",
+    ],
+    2: [
+      ctx => `${name(ctx)}! Perfect timing. I was just thinking about you.`,
+      ctx => ctx.memory.recentMoments[0] ? `I keep thinking about ${ctx.memory.recentMoments[0]}. That was great.` : "You always show up when I need an adventure partner.",
+    ],
+    3: [
+      ctx => `${name(ctx)}! My favorite explorer! Ready to make today amazing?`,
+      ctx => ctx.memory.preferredZone ? `I saved something special in the ${ctx.memory.preferredZone} just for you!` : "The island has been waiting for you. Literally. The trees told me.",
+    ],
+  },
+
+  belu_mistake: {
+    0: [
+      "Oh... um. That was wrong, wasn't it. I... I'm still learning too.",
+      "Wait — that's not right. I get confused sometimes. Sorry.",
+    ],
+    1: [
+      "Oops! I mixed that up. Happens to me all the time!",
+      "Wait wait wait — let me think again... I got it wrong the first time.",
+    ],
+    2: [
+      "Ha! Completely wrong. Good thing we're learning together!",
+      "I STILL mix up confused and worried. Thanks for helping me figure it out.",
+    ],
+    3: [
+      "And THAT is why you should never ask an elephant about feelings. We're terrible at it.",
+      "Wrong! Don't put that on my record. I'm great at everything else.",
+    ],
+  },
+
+  encouragement: {
+    0: [
+      "That's... good. Really good.",
+      "Oh! You got it right.",
+    ],
+    1: [
+      "Yes! Exactly right!",
+      "That's it! How did you know that?",
+      "Wonderful! I'm learning so much from you.",
+    ],
+    2: [
+      "Of course you got that. You're brilliant at this.",
+      "That's it! Honestly, you're better at this than I am.",
+      "Yes! I knew we'd figure it out together.",
+    ],
+    3: [
+      ctx => `KNEW you'd get that, ${name(ctx)}! Never doubted it.`,
+      "Perfect! You and me — completely unstoppable.",
+      "That's my explorer! Right on the first try!",
+    ],
+  },
+
+  gentle_redirect: {
+    0: [
+      "Hmm... maybe let's try again? Together?",
+      "That's a good try. I think there might be another way...",
+    ],
+    1: [
+      "Interesting! Want to look again? I think something's hiding.",
+      "Hmm, I'm not sure about that one either. Let's look more carefully.",
+    ],
+    2: [
+      "You know, I was thinking the same thing at first! Let's look again together.",
+      "The island is hinting at something different. Let's listen to it.",
+    ],
+    3: [
+      "Classic explorer move — try a different path!",
+      "Hmm. My trunk is tingling. That means we should look again.",
+    ],
+  },
+
+  zone_meadow: {
+    0: [
+      "This is... the Feelings Meadow. Animals here have lots of big feelings.",
+      "The animals here feel all kinds of things. Can you help me figure out what they're feeling?",
+    ],
+    1: [
+      "The Feelings Meadow! I love it here. Every animal feels something different today.",
+      "See all these animals? Each one is feeling something. Let's be feeling detectives!",
+    ],
+    2: [
+      "Ah, the Feelings Meadow. I've gotten much better at this since we first came here together.",
+      "I still mix up 'nervous' and 'excited' sometimes. They feel so similar in my tummy.",
+    ],
+    3: [
+      "My favorite meadow! The butterfly gets grumpy if you wake her. Fair warning.",
+      ctx => ctx.memory.zonesVisited.includes('meadow') ? "The rabbit has a NEW feeling to share today. She's been practicing." : "First time in the meadow? The animals can't wait to meet you!",
+    ],
+  },
+
+  zone_mountain: {
+    0: [
+      "This is Morning Mountain. I... always forget what to do first in the morning.",
+      "We can help figure out the right order to do things here.",
+    ],
+    1: [
+      "Morning Mountain! I need a reminder every single morning.",
+      "Did you know I once tried to put my shoes on before my socks? True story.",
+    ],
+    2: [
+      "Morning Mountain! I'm much better at routines now — mostly because we practiced here together.",
+      "I still sometimes forget breakfast though. My tummy reminds me eventually.",
+    ],
+    3: [
+      "Morning Mountain! Where I famously arrived at school in my pajamas. ONCE. Never again.",
+      "True confession: I forgot my backpack seven times before I started using a checklist. Seven.",
+    ],
+  },
+
+  zone_cove: {
+    0: [
+      "The Calm Cove... this is where I come when everything feels like too much.",
+      "It's very quiet here. I like it a lot.",
+    ],
+    1: [
+      "The Calm Cove! The best place when feelings get really big.",
+      "The sound of the water here helps my brain slow down. Want to try the breathing bubbles?",
+    ],
+    2: [
+      "Ahh, the Calm Cove. My reset button. I didn't know I needed this place until we found it together.",
+      "The breathing bubbles we learned here? I use them every single day now.",
+    ],
+    3: [
+      "The Calm Cove — my secret superpower location. Don't tell the storm clouds.",
+      "I came here this morning actually. Mondays are hard even for elephants.",
+    ],
+  },
+
+  zone_forest: {
+    0: [
+      "The Friendship Forest. There are animals here who want to talk... to each other. It's complicated.",
+      "I'm not very good at conversations yet. Maybe we can practice together?",
+    ],
+    1: [
+      "The Friendship Forest! I love coming here now. Conversations are actually really interesting.",
+      "I used to find talking to others really hard. Want to see how much better I've gotten?",
+    ],
+    2: [
+      "Friendship Forest! My social skills are SO much better from all our visits here.",
+      "I still forget to let the other person finish sometimes. Working on it.",
+    ],
+    3: [
+      "The Friendship Forest — where I learned that listening is the most important part of talking.",
+      "The fox here taught me a conversation trick. Remind me to show you.",
+    ],
+  },
+
+  explorer_mode: {
+    0: ["We can just... walk around? And see things?", "I like exploring. It feels calmer than having a plan."],
+    1: ["Explorer mode! Let's see what we discover together.", "Who knows what we'll find? I love not knowing."],
+    2: ["Explorer mode activated. I've hidden a few surprises around the island lately.", "Let's wander. The best discoveries don't follow a map."],
+    3: ["EXPLORER MODE. Trunk up, ears open, adventure ON!", ctx => `I hid something near the cove, ${name(ctx)}. See if you can find it.`],
+  },
+
+  story_mode: {
+    0: ["There's a... small adventure today. If you want to help.", "The animals need some help. Do you want to try?"],
+    1: ["Today's story is about someone feeling left out. Sound good?", "I have a story for us today! It's a good one."],
+    2: ["Today's adventure: the animals of the meadow have a misunderstanding. Classic. Ready?", "I picked today's story based on what we've been practicing. I think you'll like it."],
+    3: [ctx => `Today's challenge: triple-difficulty emotion detective mission. You're ready, ${name(ctx)}.`, "Story mode! I picked today's story especially because of what we learned last time."],
+  },
+
+  simulator_mode: {
+    0: ["We can... practice something? Like what to do in a tricky moment?", "Practicing helps me feel less scared about real situations."],
+    1: ["Simulator mode! We pick a situation and practice together. I like this mode.", "Let's practice! What kind of situation should we try?"],
+    2: ["Simulator mode! These scenarios get easier every time we practice them.", "I used to freeze in tricky situations. Practice really does help."],
+    3: [ctx => `Simulator mode, ${name(ctx)}! Let's build some real-life superpowers.`, "The more we practice here, the easier it gets out there."],
+  },
+
+  achievement: {
+    0: ["You did something really good today.", "That was... really nice of you to help."],
+    1: ["Amazing! You figured that out so well!", "You just learned something really important! So did I."],
+    2: ["That's an achievement worth celebrating! Look how far you've come.", "Remember when that felt hard? Look at you now."],
+    3: [ctx => `${name(ctx)}, that was genuinely incredible. I am SO proud of us.`, "Achievement unlocked! And you made it look easy."],
+  },
+
+  overwhelmed_response: {
+    0: ["Oh... is it too much? It's okay. We can go slow."],
+    1: ["Hey, it's okay if this feels like a lot. We can take a break at the Calm Cove."],
+    2: ["I get overwhelmed sometimes too. Want to visit the Calm Cove? It always helps me."],
+    3: ["Hey. Breathe. We've got all the time in the world. Calm Cove is right there whenever you need it."],
+  },
+
+};
+
+export function getDialogue(key: string, ctx: DialogueContext): string {
+  const entry = DB[key];
+  if (!entry) return "...";
+  const stage = ctx.memory.personalityStage;
+  for (let s = stage; s >= 0; s--) {
+    const lines = entry[s as 0 | 1 | 2 | 3];
+    if (lines?.length) return resolve(pick(lines), ctx);
+  }
+  return "...";
+}
+
+export function getZoneDialogue(zone: string, ctx: DialogueContext): string {
+  const keyMap: Record<string, string> = {
+    meadow: 'zone_meadow',
+    mountain: 'zone_mountain',
+    cove: 'zone_cove',
+    forest: 'zone_forest',
+  };
+  return getDialogue(keyMap[zone] ?? 'zone_meadow', ctx);
+}

--- a/components/game/BelusWorld/belu/feedback.ts
+++ b/components/game/BelusWorld/belu/feedback.ts
@@ -1,0 +1,111 @@
+// ---------------------------------------------------------------------------
+// Gentle audio feedback + read-aloud narration. No audio files — everything is
+// synthesised (Web Audio API) or spoken (Web Speech API), so there's nothing to
+// download and nothing to break the strict asset policy.
+//
+// Research note: sound is a likeability "juice" win, but autistic kids can be
+// sound-sensitive — so every sound is SOFT and fully toggleable, and narration
+// (text-to-speech) supports non-readers and literal-instruction needs.
+// ---------------------------------------------------------------------------
+
+let ctx: AudioContext | null = null;
+
+function audio(): AudioContext | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    if (!ctx) {
+      const AC = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+      ctx = new AC();
+    }
+    if (ctx.state === 'suspended') void ctx.resume();
+    return ctx;
+  } catch {
+    return null;
+  }
+}
+
+/** A soft sine "ping". freq in Hz, when = offset seconds, dur seconds. */
+function ping(freq: number, when: number, dur: number, gain: number) {
+  const ac = audio();
+  if (!ac) return;
+  const osc = ac.createOscillator();
+  const g = ac.createGain();
+  osc.type = 'sine';
+  osc.frequency.value = freq;
+  const t0 = ac.currentTime + when;
+  g.gain.setValueAtTime(0, t0);
+  g.gain.linearRampToValueAtTime(gain, t0 + 0.02);
+  g.gain.exponentialRampToValueAtTime(0.0001, t0 + dur);
+  osc.connect(g);
+  g.connect(ac.destination);
+  osc.start(t0);
+  osc.stop(t0 + dur + 0.02);
+}
+
+export type Sound = 'tap' | 'correct' | 'star' | 'levelup' | 'growup';
+
+export function playSound(kind: Sound, enabled: boolean) {
+  if (!enabled) return;
+  switch (kind) {
+    case 'tap':
+      ping(440, 0, 0.12, 0.05);
+      break;
+    case 'correct':
+      ping(587.33, 0, 0.16, 0.07); // D5
+      ping(880, 0.08, 0.18, 0.06); // A5
+      break;
+    case 'star':
+      ping(659.25, 0, 0.14, 0.07); // E5
+      ping(987.77, 0.1, 0.2, 0.06); // B5
+      break;
+    case 'levelup':
+      [523.25, 659.25, 783.99, 1046.5].forEach((f, i) => ping(f, i * 0.11, 0.22, 0.06));
+      break;
+    case 'growup':
+      [392, 523.25, 659.25, 783.99, 1046.5].forEach((f, i) => ping(f, i * 0.13, 0.3, 0.07));
+      break;
+  }
+}
+
+// ---- text-to-speech ----
+
+let voice: SpeechSynthesisVoice | null = null;
+
+function pickVoice(): SpeechSynthesisVoice | null {
+  if (typeof window === 'undefined' || !window.speechSynthesis) return null;
+  if (voice) return voice;
+  const voices = window.speechSynthesis.getVoices();
+  if (!voices.length) return null;
+  // prefer a warm English voice if available
+  voice =
+    voices.find((v) => /en/i.test(v.lang) && /(female|samantha|karen|moira|tessa|google uk english female)/i.test(v.name)) ||
+    voices.find((v) => /en/i.test(v.lang)) ||
+    voices[0];
+  return voice;
+}
+
+export function speakAloud(text: string, enabled: boolean) {
+  if (!enabled || typeof window === 'undefined' || !window.speechSynthesis) return;
+  try {
+    window.speechSynthesis.cancel();
+    const u = new SpeechSynthesisUtterance(text);
+    const v = pickVoice();
+    if (v) u.voice = v;
+    u.rate = 0.95; // a touch slower — clearer for kids
+    u.pitch = 1.15; // friendly
+    u.volume = 0.9;
+    window.speechSynthesis.speak(u);
+  } catch {
+    /* speech not available — silent */
+  }
+}
+
+export function stopSpeaking() {
+  if (typeof window !== 'undefined' && window.speechSynthesis) {
+    try {
+      window.speechSynthesis.cancel();
+    } catch {
+      /* ignore */
+    }
+  }
+}

--- a/components/game/BelusWorld/belu/memory.ts
+++ b/components/game/BelusWorld/belu/memory.ts
@@ -1,0 +1,95 @@
+export interface BeluMemory {
+  playerName: string | null;
+  visitCount: number;
+  lastVisit: string | null;
+  zonesVisited: string[];
+  lastZone: string | null;
+  skillsPracticed: { zone: string; count: number }[];
+  personalityStage: 0 | 1 | 2 | 3;
+  preferredZone: string | null;
+  totalInteractions: number;
+  achievements: string[];
+  recentMoments: string[];
+  beluMistakeCount: number;
+}
+
+const KEY = 'belus_world_memory_v1';
+
+const defaults: BeluMemory = {
+  playerName: null,
+  visitCount: 0,
+  lastVisit: null,
+  zonesVisited: [],
+  lastZone: null,
+  skillsPracticed: [],
+  personalityStage: 0,
+  preferredZone: null,
+  totalInteractions: 0,
+  achievements: [],
+  recentMoments: [],
+  beluMistakeCount: 0,
+};
+
+export function loadMemory(): BeluMemory {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return { ...defaults };
+    return { ...defaults, ...JSON.parse(raw) };
+  } catch {
+    return { ...defaults };
+  }
+}
+
+export function saveMemory(m: BeluMemory): void {
+  try { localStorage.setItem(KEY, JSON.stringify(m)); } catch { /* silent */ }
+}
+
+export function recordVisit(m: BeluMemory): BeluMemory {
+  const visitCount = m.visitCount + 1;
+  const personalityStage: 0 | 1 | 2 | 3 =
+    visitCount >= 16 ? 3 : visitCount >= 8 ? 2 : visitCount >= 3 ? 1 : 0;
+  const updated = { ...m, visitCount, personalityStage, lastVisit: new Date().toISOString() };
+  saveMemory(updated);
+  return updated;
+}
+
+export function recordZoneVisit(m: BeluMemory, zone: string): BeluMemory {
+  const zonesVisited = m.zonesVisited.includes(zone) ? m.zonesVisited : [...m.zonesVisited, zone];
+  const skillsPracticed = [...m.skillsPracticed];
+  const entry = skillsPracticed.find(s => s.zone === zone);
+  if (entry) entry.count++;
+  else skillsPracticed.push({ zone, count: 1 });
+  const preferredZone = skillsPracticed.reduce(
+    (best, curr) => !best || curr.count > (skillsPracticed.find(s => s.zone === best)?.count ?? 0) ? curr.zone : best,
+    m.preferredZone
+  );
+  const updated = { ...m, zonesVisited, lastZone: zone, skillsPracticed, preferredZone, totalInteractions: m.totalInteractions + 1 };
+  saveMemory(updated);
+  return updated;
+}
+
+export function recordMoment(m: BeluMemory, moment: string): BeluMemory {
+  const recentMoments = [moment, ...m.recentMoments].slice(0, 5);
+  const updated = { ...m, recentMoments };
+  saveMemory(updated);
+  return updated;
+}
+
+export function recordMistake(m: BeluMemory): BeluMemory {
+  const updated = { ...m, beluMistakeCount: m.beluMistakeCount + 1 };
+  saveMemory(updated);
+  return updated;
+}
+
+export function addAchievement(m: BeluMemory, achievement: string): BeluMemory {
+  if (m.achievements.includes(achievement)) return m;
+  const updated = { ...m, achievements: [...m.achievements, achievement] };
+  saveMemory(updated);
+  return updated;
+}
+
+export function setPlayerName(m: BeluMemory, name: string): BeluMemory {
+  const updated = { ...m, playerName: name.trim() || null };
+  saveMemory(updated);
+  return updated;
+}

--- a/components/game/BelusWorld/belu/progress.ts
+++ b/components/game/BelusWorld/belu/progress.ts
@@ -1,0 +1,201 @@
+// ---------------------------------------------------------------------------
+// Progress + leveling.
+// Every island has MAX_LEVEL levels. Finishing a level earns 1–3 stars (best
+// score is kept — you can always replay to improve, never to lose). Stars feed
+// two *visible* things the child strives for:
+//   1. each island visibly BLOOMS as its levels are completed, and
+//   2. Belu visibly GROWS UP as total stars rise (baby → child → teen → grown).
+// No timers, no losing, no farming the same level past 3 stars.
+// ---------------------------------------------------------------------------
+
+export type ActivityZone = 'meadow' | 'mountain' | 'cove' | 'forest';
+
+export const ZONES: ActivityZone[] = ['meadow', 'mountain', 'cove', 'forest'];
+export const MAX_LEVEL = 5;
+export const MAX_STARS_PER_LEVEL = 3;
+export const MAX_STARS_PER_ISLAND = MAX_LEVEL * MAX_STARS_PER_LEVEL; // 15
+export const MAX_TOTAL_STARS = MAX_STARS_PER_ISLAND * ZONES.length; // 60
+
+export interface IslandProgress {
+  /** best stars earned on each level (index 0..MAX_LEVEL-1); 0 = not completed */
+  levelStars: number[];
+}
+
+export interface GameProgress {
+  islands: Record<ActivityZone, IslandProgress>;
+  /** cosmetic accessories the child has unlocked for Belu */
+  unlocked: string[];
+}
+
+const KEY = 'belus_world_progress_v1';
+
+function emptyIsland(): IslandProgress {
+  return { levelStars: Array(MAX_LEVEL).fill(0) };
+}
+
+function defaults(): GameProgress {
+  return {
+    islands: {
+      meadow: emptyIsland(),
+      mountain: emptyIsland(),
+      cove: emptyIsland(),
+      forest: emptyIsland(),
+    },
+    unlocked: [],
+  };
+}
+
+export function loadProgress(): GameProgress {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return defaults();
+    const parsed = JSON.parse(raw) as Partial<GameProgress>;
+    const base = defaults();
+    if (parsed.islands) {
+      for (const z of ZONES) {
+        const ip = parsed.islands[z];
+        if (ip && Array.isArray(ip.levelStars)) {
+          // tolerate older saves with a different MAX_LEVEL
+          base.islands[z].levelStars = Array.from(
+            { length: MAX_LEVEL },
+            (_, i) => ip.levelStars[i] ?? 0,
+          );
+        }
+      }
+    }
+    if (Array.isArray(parsed.unlocked)) base.unlocked = parsed.unlocked;
+    return base;
+  } catch {
+    return defaults();
+  }
+}
+
+export function saveProgress(p: GameProgress): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(p));
+  } catch {
+    /* private mode / quota — fail silently, game still playable */
+  }
+}
+
+// ---- per-island derived values ----
+
+export function islandStars(p: GameProgress, zone: ActivityZone): number {
+  return p.islands[zone].levelStars.reduce((a, b) => a + b, 0);
+}
+
+/** how many levels have been completed (≥1 star) — drives the bloom stage */
+export function completedLevels(p: GameProgress, zone: ActivityZone): number {
+  return p.islands[zone].levelStars.filter((s) => s > 0).length;
+}
+
+/** the next level to play (1-based). Levels unlock in order. */
+export function nextLevel(p: GameProgress, zone: ActivityZone): number {
+  return Math.min(completedLevels(p, zone) + 1, MAX_LEVEL);
+}
+
+/** is a given level (1-based) unlocked / playable? */
+export function isLevelUnlocked(p: GameProgress, zone: ActivityZone, level: number): boolean {
+  return level <= nextLevel(p, zone);
+}
+
+export function isIslandComplete(p: GameProgress, zone: ActivityZone): boolean {
+  return completedLevels(p, zone) >= MAX_LEVEL;
+}
+
+// ---- totals ----
+
+export function totalStars(p: GameProgress): number {
+  return ZONES.reduce((sum, z) => sum + islandStars(p, z), 0);
+}
+
+export function totalCompletedLevels(p: GameProgress): number {
+  return ZONES.reduce((sum, z) => sum + completedLevels(p, z), 0);
+}
+
+// ---- Belu growth (the headline reward) ----
+
+export type GrowthStage = 0 | 1 | 2 | 3;
+
+export interface GrowthInfo {
+  stage: GrowthStage;
+  /** kid-facing name of this stage */
+  label: string;
+  /** total stars needed to reach the NEXT stage, or null if fully grown */
+  nextAt: number | null;
+  /** 0..1 toward the next stage (1 if grown) */
+  progress: number;
+  /** visual scale to apply to the 3D model */
+  scale: number;
+}
+
+// star thresholds for each growth stage
+const GROWTH_THRESHOLDS = [0, 12, 28, 48];
+const GROWTH_LABELS = ['Baby Belu', 'Little Belu', 'Big Belu', 'Grown-Up Belu'];
+const GROWTH_SCALES = [0.7, 0.85, 1.0, 1.15];
+
+export function growthFromStars(stars: number): GrowthInfo {
+  let stage: GrowthStage = 0;
+  for (let i = GROWTH_THRESHOLDS.length - 1; i >= 0; i--) {
+    if (stars >= GROWTH_THRESHOLDS[i]) {
+      stage = i as GrowthStage;
+      break;
+    }
+  }
+  const nextAt = stage < 3 ? GROWTH_THRESHOLDS[stage + 1] : null;
+  const base = GROWTH_THRESHOLDS[stage];
+  const progress = nextAt === null ? 1 : (stars - base) / (nextAt - base);
+  return {
+    stage,
+    label: GROWTH_LABELS[stage],
+    nextAt,
+    progress: Math.max(0, Math.min(1, progress)),
+    scale: GROWTH_SCALES[stage],
+  };
+}
+
+export function getGrowth(p: GameProgress): GrowthInfo {
+  return growthFromStars(totalStars(p));
+}
+
+// ---- mutations (return a new object) ----
+
+export interface AwardResult {
+  progress: GameProgress;
+  /** did this play complete a brand-new level? */
+  newLevel: boolean;
+  /** did Belu just advance a growth stage? */
+  grewUp: boolean;
+  growthBefore: GrowthStage;
+  growthAfter: GrowthStage;
+}
+
+/** Record a finished level. levelIdx is 0-based. stars is 1..3. Keeps the best. */
+export function awardLevel(
+  p: GameProgress,
+  zone: ActivityZone,
+  levelIdx: number,
+  stars: number,
+): AwardResult {
+  const growthBefore = getGrowth(p).stage;
+  const next: GameProgress = {
+    ...p,
+    islands: { ...p.islands, [zone]: { levelStars: [...p.islands[zone].levelStars] } },
+  };
+  const prevBest = next.islands[zone].levelStars[levelIdx] ?? 0;
+  const wasIncomplete = prevBest === 0;
+  next.islands[zone].levelStars[levelIdx] = Math.max(prevBest, Math.min(MAX_STARS_PER_LEVEL, stars));
+  const growthAfter = getGrowth(next).stage;
+  return {
+    progress: next,
+    newLevel: wasIncomplete,
+    grewUp: growthAfter > growthBefore,
+    growthBefore,
+    growthAfter,
+  };
+}
+
+export function unlockAccessory(p: GameProgress, id: string): GameProgress {
+  if (p.unlocked.includes(id)) return p;
+  return { ...p, unlocked: [...p.unlocked, id] };
+}

--- a/components/game/BelusWorld/index.tsx
+++ b/components/game/BelusWorld/index.tsx
@@ -1,0 +1,503 @@
+// ===========================================================================
+// Belu's World — a 3D floating-island adventure for kids on the autism
+// spectrum. The child walks/jumps Belu (a blue elephant) across magical sky
+// islands. Each island teaches one ASD skill area across 5 levels. As the
+// child earns stars, two things VISIBLY happen: Belu grows up (baby → grown)
+// and each island blooms. Belu also remembers the child and grows a
+// personality across visits, learning right alongside them.
+//
+// Designed against evidence-based ASD principles (see project memory):
+// errorless / no-fail, no timers, predictable token rewards, First-Then visual
+// supports, read-aloud narration, and full sensory comfort settings.
+// ===========================================================================
+
+import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import type { BeluEmotion } from './BeluCharacter';
+import type { ZoneId } from './three/worldConfig';
+import { attachKeyboard, input } from './three/input';
+import HUD from './ui/HUD';
+import TouchControls from './ui/TouchControls';
+import LevelSelect from './ui/LevelSelect';
+import GrowthMap from './ui/GrowthMap';
+import { ACTIVITIES } from './activities/registry';
+import {
+  loadMemory,
+  saveMemory,
+  recordVisit,
+  recordZoneVisit,
+  recordMoment,
+  addAchievement,
+  type BeluMemory,
+} from './belu/memory';
+import { getDialogue } from './belu/dialogue';
+import {
+  loadProgress,
+  saveProgress,
+  awardLevel,
+  getGrowth,
+  completedLevels,
+  totalStars,
+  type GameProgress,
+  type ActivityZone,
+  ZONES,
+} from './belu/progress';
+import { speakAloud, playSound, stopSpeaking } from './belu/feedback';
+
+const GameCanvas = lazy(() => import('./three/GameCanvas'));
+
+type Phase = 'intro' | 'world';
+
+interface Settings {
+  reduceMotion: boolean;
+  calmMode: boolean;
+  sound: boolean;
+  narration: boolean;
+}
+
+const STICKER_KEYS: Record<ActivityZone, string> = {
+  meadow: '💛',
+  mountain: '⛰️',
+  cove: '🌊',
+  forest: '🌳',
+};
+
+interface RewardInfo {
+  stars: number;
+  skill: string;
+  levelUp: boolean;
+  grewUp: boolean;
+  growthLabel: string;
+  islandMastered: boolean;
+}
+
+export default function BelusWorldGame() {
+  const [phase, setPhase] = useState<Phase>('intro');
+  const [memory, setMemory] = useState<BeluMemory>(() => loadMemory());
+  const [progress, setProgress] = useState<GameProgress>(() => loadProgress());
+  const [emotion, setEmotion] = useState<BeluEmotion>('happy');
+  const [beluLine, setBeluLine] = useState<string | null>(null);
+  const [nearZone, setNearZone] = useState<ZoneId | null>(null);
+  const [selectZone, setSelectZone] = useState<ActivityZone | null>(null);
+  const [active, setActive] = useState<{ zone: ActivityZone; level: number } | null>(null);
+  const [showSettings, setShowSettings] = useState(false);
+  const [showMap, setShowMap] = useState(false);
+  const [reward, setReward] = useState<RewardInfo | null>(null);
+  const [settings, setSettings] = useState<Settings>({
+    reduceMotion: false,
+    calmMode: false,
+    sound: true,
+    narration: true,
+  });
+
+  const lineTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const settingsRef = useRef(settings);
+  settingsRef.current = settings;
+  const isTouch = useRef(typeof window !== 'undefined' && ('ontouchstart' in window || navigator.maxTouchPoints > 0));
+
+  const growth = useMemo(() => getGrowth(progress), [progress]);
+  const islandLevels = useMemo(
+    () => Object.fromEntries(ZONES.map((z) => [z, completedLevels(progress, z)])) as Partial<Record<ZoneId, number>>,
+    [progress],
+  );
+  const stickers = useMemo(
+    () => ZONES.filter((z) => completedLevels(progress, z) > 0).map((z) => STICKER_KEYS[z]),
+    [progress],
+  );
+
+  // Belu speaks: speech bubble + (optional) read-aloud narration.
+  const speak = useCallback((line: string) => {
+    setBeluLine(line);
+    speakAloud(line, settingsRef.current.narration);
+    if (lineTimer.current) clearTimeout(lineTimer.current);
+    lineTimer.current = setTimeout(() => setBeluLine(null), 5000);
+  }, []);
+
+  function start() {
+    const m = recordVisit(memory);
+    saveMemory(m);
+    setMemory(m);
+    setPhase('world');
+    const greetKey = m.visitCount <= 1 ? 'greeting_first' : 'greeting_return';
+    setTimeout(() => speak(getDialogue(greetKey, { memory: m })), 700);
+  }
+
+  useEffect(() => {
+    if (phase !== 'world') return;
+    const detach = attachKeyboard();
+    return () => {
+      detach();
+      stopSpeaking();
+      if (lineTimer.current) clearTimeout(lineTimer.current);
+    };
+  }, [phase]);
+
+  const paused = active !== null || selectZone !== null || showSettings || showMap || reward !== null;
+
+  const handleProximity = useCallback(
+    (zone: ZoneId | null) => {
+      setNearZone(zone);
+      if (zone && zone !== 'home') {
+        setEmotion('curious');
+        speak(`Ooh, the ${ACTIVITIES[zone as ActivityZone].title}! Want to learn here with me?`);
+      }
+    },
+    [speak],
+  );
+
+  const handleEnter = useCallback((zone: ZoneId) => {
+    if (zone === 'home') return;
+    stopSpeaking();
+    setSelectZone(zone as ActivityZone);
+  }, []);
+
+  const handlePlay = useCallback(
+    (level: number) => {
+      if (!selectZone) return;
+      playSound('tap', settingsRef.current.sound);
+      setActive({ zone: selectZone, level });
+      setSelectZone(null);
+    },
+    [selectZone],
+  );
+
+  const handleComplete = useCallback(
+    (zone: ActivityZone, level: number, stars: number, moment: string) => {
+      const res = awardLevel(progress, zone, level - 1, stars);
+      saveProgress(res.progress);
+      setProgress(res.progress);
+
+      // personality memory (separate from leveling)
+      let m = recordZoneVisit(memory, zone);
+      m = recordMoment(m, moment);
+      m = addAchievement(m, `${ACTIVITIES[zone].skill} L${level}`);
+      saveMemory(m);
+      setMemory(m);
+
+      const mastered = completedLevels(res.progress, zone) >= 5;
+      setActive(null);
+      setEmotion('excited');
+      playSound(res.grewUp ? 'growup' : res.newLevel ? 'levelup' : 'star', settingsRef.current.sound);
+      setReward({
+        stars,
+        skill: ACTIVITIES[zone].skill,
+        levelUp: res.newLevel,
+        grewUp: res.grewUp,
+        growthLabel: getGrowth(res.progress).label,
+        islandMastered: mastered,
+      });
+    },
+    [progress, memory],
+  );
+
+  const ActivityComp = active ? ACTIVITIES[active.zone].component : null;
+
+  if (phase === 'intro') {
+    return <IntroScreen memory={memory} growthLabel={growth.label} onStart={start} />;
+  }
+
+  return (
+    <div className="relative h-screen w-full overflow-hidden" style={{ background: '#bfe2ff' }}>
+      <Suspense fallback={<LoadingWorld />}>
+        <GameCanvas
+          emotion={emotion}
+          paused={paused}
+          reduceMotion={settings.reduceMotion}
+          calmMode={settings.calmMode}
+          activeZone={nearZone}
+          growthScale={growth.scale}
+          growthStage={growth.stage}
+          islandLevels={islandLevels}
+          onProximity={handleProximity}
+          onEnter={handleEnter}
+        />
+      </Suspense>
+
+      <HUD
+        beluLine={beluLine}
+        nearZone={active || selectZone ? null : nearZone}
+        stickers={stickers}
+        totalStars={totalStars(progress)}
+        isTouch={isTouch.current}
+        onOpenSettings={() => setShowSettings(true)}
+        onOpenMap={() => setShowMap(true)}
+        onPlayNear={() => nearZone && handleEnter(nearZone)}
+      />
+
+      {isTouch.current && !paused && <TouchControls />}
+
+      {/* Level select (destination entry) */}
+      <AnimatePresence>
+        {selectZone && (
+          <LevelSelect
+            meta={ACTIVITIES[selectZone]}
+            levelStars={progress.islands[selectZone].levelStars}
+            onPlay={handlePlay}
+            onClose={() => setSelectZone(null)}
+          />
+        )}
+      </AnimatePresence>
+
+      {/* Learning activity */}
+      <AnimatePresence>
+        {ActivityComp && active && (
+          <ActivityComp
+            key={`${active.zone}-${active.level}`}
+            level={active.level}
+            speak={speak}
+            onBeluEmotion={setEmotion}
+            onComplete={(r) => handleComplete(active.zone, active.level, r.stars, r.moment)}
+            onExit={() => {
+              setActive(null);
+              input.interactQueued = false;
+            }}
+          />
+        )}
+      </AnimatePresence>
+
+      {/* Reward / celebration */}
+      <AnimatePresence>
+        {reward && <RewardToast reward={reward} onClose={() => setReward(null)} />}
+      </AnimatePresence>
+
+      {/* Growth map */}
+      <AnimatePresence>{showMap && <GrowthMap progress={progress} onClose={() => setShowMap(false)} />}</AnimatePresence>
+
+      {/* Settings */}
+      <AnimatePresence>
+        {showSettings && (
+          <SettingsPanel settings={settings} onChange={setSettings} onClose={() => setShowSettings(false)} />
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+function IntroScreen({ memory, growthLabel, onStart }: { memory: BeluMemory; growthLabel: string; onStart: () => void }) {
+  const returning = memory.visitCount > 0;
+  return (
+    <div
+      className="relative flex h-screen w-full flex-col items-center justify-center overflow-hidden p-6 text-center"
+      style={{ background: 'linear-gradient(180deg,#aee0ff 0%,#d8f0ff 55%,#fff6e0 100%)' }}
+    >
+      {[0, 1, 2].map((i) => (
+        <motion.div
+          key={i}
+          className="absolute text-6xl opacity-80"
+          style={{ top: `${12 + i * 22}%` }}
+          initial={{ left: '-20%' }}
+          animate={{ left: '120%' }}
+          transition={{ duration: 30 + i * 10, repeat: Infinity, ease: 'linear' }}
+        >
+          ☁️
+        </motion.div>
+      ))}
+
+      <motion.div
+        initial={{ scale: 0, rotate: -10 }}
+        animate={{ scale: 1, rotate: 0 }}
+        transition={{ type: 'spring', stiffness: 200, damping: 14 }}
+        className="text-[110px] leading-none drop-shadow-lg"
+      >
+        🐘
+      </motion.div>
+
+      <motion.h1
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.2 }}
+        className="mt-2 text-5xl font-black text-sky-700 drop-shadow-sm"
+      >
+        Belu's World
+      </motion.h1>
+      <motion.p
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.4 }}
+        className="mt-2 max-w-md text-lg font-semibold text-sky-900/70"
+      >
+        {returning
+          ? `Welcome back! ${growthLabel} is waiting on the sky islands. Earn stars to help Belu grow!`
+          : 'Explore floating islands, learn amazing skills, and help baby Belu grow up big and strong!'}
+      </motion.p>
+
+      <motion.button
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.6 }}
+        whileHover={{ scale: 1.05 }}
+        whileTap={{ scale: 0.95 }}
+        onClick={onStart}
+        className="mt-8 rounded-full bg-gradient-to-b from-amber-400 to-orange-500 px-12 py-4 text-2xl font-black text-white shadow-xl"
+      >
+        {returning ? 'Continue ✨' : 'Start Adventure ✨'}
+      </motion.button>
+
+      <p className="mt-6 text-sm font-medium text-sky-900/50">
+        Move with arrow keys or the joystick · Jump to explore · No way to lose 💙
+      </p>
+    </div>
+  );
+}
+
+function LoadingWorld() {
+  return (
+    <div className="flex h-screen w-full flex-col items-center justify-center" style={{ background: '#bfe2ff' }}>
+      <motion.div animate={{ y: [0, -14, 0] }} transition={{ duration: 1.2, repeat: Infinity }} className="text-7xl">
+        🐘
+      </motion.div>
+      <p className="mt-4 text-lg font-bold text-sky-700">Floating up to the islands…</p>
+    </div>
+  );
+}
+
+function RewardToast({ reward, onClose }: { reward: RewardInfo; onClose: () => void }) {
+  const headline = reward.grewUp ? 'Belu Grew Up!' : reward.levelUp ? 'Level Complete!' : 'Great Job!';
+  const hero = reward.grewUp ? '🐘✨' : reward.islandMastered ? '🌷' : '⭐';
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      className="fixed inset-0 z-50 flex items-center justify-center p-6"
+      style={{ background: 'rgba(20,28,46,0.5)', backdropFilter: 'blur(6px)' }}
+      onClick={onClose}
+    >
+      <motion.div
+        initial={{ scale: 0.6, y: 40 }}
+        animate={{ scale: 1, y: 0 }}
+        exit={{ scale: 0.8 }}
+        transition={{ type: 'spring', stiffness: 240, damping: 18 }}
+        className="relative rounded-[28px] bg-white px-8 py-8 text-center shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {Array.from({ length: 16 }).map((_, i) => {
+          const a = (i / 16) * Math.PI * 2;
+          return (
+            <motion.span
+              key={i}
+              className="absolute left-1/2 top-12 text-xl"
+              initial={{ x: 0, y: 0, opacity: 1 }}
+              animate={{ x: Math.cos(a) * 140, y: Math.sin(a) * 140, opacity: 0 }}
+              transition={{ duration: 1.2, delay: 0.1 }}
+            >
+              {['✨', '⭐', '🌟'][i % 3]}
+            </motion.span>
+          );
+        })}
+
+        <motion.div
+          animate={{ scale: [1, 1.18, 1], rotate: reward.grewUp ? [0, 6, -6, 0] : 0 }}
+          transition={{ duration: 1.4, repeat: Infinity }}
+          className="text-7xl"
+        >
+          {hero}
+        </motion.div>
+
+        <h2 className="mt-3 text-2xl font-black text-slate-800">{headline}</h2>
+
+        {/* stars earned */}
+        <div className="mt-2 flex justify-center gap-1.5">
+          {[0, 1, 2].map((i) => (
+            <motion.span
+              key={i}
+              initial={{ scale: 0, rotate: -40 }}
+              animate={{ scale: i < reward.stars ? 1 : 0.6, rotate: 0 }}
+              transition={{ delay: 0.2 + i * 0.15, type: 'spring' }}
+              className="text-3xl"
+              style={{ filter: i < reward.stars ? 'none' : 'grayscale(1) opacity(0.4)' }}
+            >
+              ⭐
+            </motion.span>
+          ))}
+        </div>
+
+        <p className="mt-2 font-semibold text-slate-500">You grew your “{reward.skill}” skill 🌱</p>
+
+        {reward.grewUp && (
+          <p className="mt-3 rounded-2xl bg-sky-100 px-4 py-2 text-sm font-bold text-sky-700">
+            🎉 Belu is now {reward.growthLabel}! You helped Belu grow.
+          </p>
+        )}
+        {reward.islandMastered && !reward.grewUp && (
+          <p className="mt-3 rounded-2xl bg-amber-100 px-4 py-2 text-sm font-bold text-amber-700">
+            🌷 You fully bloomed this island!
+          </p>
+        )}
+
+        <button
+          onClick={onClose}
+          className="mt-5 rounded-full bg-sky-500 px-8 py-3 text-lg font-bold text-white shadow-lg transition active:scale-95"
+        >
+          Keep exploring →
+        </button>
+      </motion.div>
+    </motion.div>
+  );
+}
+
+function SettingsPanel({
+  settings,
+  onChange,
+  onClose,
+}: {
+  settings: Settings;
+  onChange: (s: Settings) => void;
+  onClose: () => void;
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      className="fixed inset-0 z-50 flex items-center justify-center p-6"
+      style={{ background: 'rgba(20,28,46,0.5)', backdropFilter: 'blur(8px)' }}
+    >
+      <motion.div
+        initial={{ scale: 0.9, y: 20 }}
+        animate={{ scale: 1, y: 0 }}
+        exit={{ scale: 0.92 }}
+        className="w-full max-w-sm rounded-[24px] bg-white p-6 shadow-2xl"
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-xl font-extrabold text-slate-800">Comfort Settings</h2>
+          <button onClick={onClose} className="flex h-9 w-9 items-center justify-center rounded-full bg-slate-100 text-slate-500">
+            ✕
+          </button>
+        </div>
+        <p className="mb-4 text-sm text-slate-500">Make Belu's World feel just right for you. 💙</p>
+
+        <Toggle label="Calm mode" hint="Softer glow, gentler colors" on={settings.calmMode} onClick={() => onChange({ ...settings, calmMode: !settings.calmMode })} />
+        <Toggle label="Reduce motion" hint="Slow down drifting clouds & effects" on={settings.reduceMotion} onClick={() => onChange({ ...settings, reduceMotion: !settings.reduceMotion })} />
+        <Toggle label="Sounds" hint="Gentle chimes for stars & success" on={settings.sound} onClick={() => onChange({ ...settings, sound: !settings.sound })} />
+        <Toggle label="Read aloud" hint="Belu speaks her words out loud" on={settings.narration} onClick={() => onChange({ ...settings, narration: !settings.narration })} />
+
+        <button
+          onClick={onClose}
+          className="mt-5 w-full rounded-full bg-sky-500 py-3 text-lg font-bold text-white shadow-lg transition active:scale-95"
+        >
+          Done
+        </button>
+      </motion.div>
+    </motion.div>
+  );
+}
+
+function Toggle({ label, hint, on, onClick }: { label: string; hint: string; on: boolean; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="mb-3 flex w-full items-center justify-between rounded-2xl border-2 border-slate-100 bg-slate-50 px-4 py-3 text-left"
+    >
+      <span>
+        <span className="block font-bold text-slate-700">{label}</span>
+        <span className="block text-xs text-slate-400">{hint}</span>
+      </span>
+      <span className="relative h-7 w-12 flex-none rounded-full transition" style={{ background: on ? '#5fa8e8' : '#cbd5e1' }}>
+        <span className="absolute top-0.5 h-6 w-6 rounded-full bg-white shadow transition-all" style={{ left: on ? 22 : 2 }} />
+      </span>
+    </button>
+  );
+}

--- a/components/game/BelusWorld/three/Belu3D.tsx
+++ b/components/game/BelusWorld/three/Belu3D.tsx
@@ -1,0 +1,280 @@
+// ---------------------------------------------------------------------------
+// Belu — the blue elephant, modelled from primitives so there's nothing to
+// download. Soft rounded forms, big friendly eyes, expressive ears + trunk.
+// All animation is driven by a mutable MotionRef the Player controller updates
+// each frame (speed + airborne), so this component never re-renders mid-walk.
+// ---------------------------------------------------------------------------
+
+import { useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import type { BeluEmotion } from '../BeluCharacter';
+
+export interface MotionRef {
+  speed: number; // 0..1 how fast Belu is moving on the ground
+  airborne: boolean;
+  vy: number; // vertical velocity, for squash/stretch
+}
+
+interface Props {
+  motion: React.MutableRefObject<MotionRef>;
+  emotion: BeluEmotion;
+  /** overall size from Belu's growth (0.7 baby → 1.15 grown) */
+  growthScale?: number;
+  /** 0 baby, 1 little, 2 big, 3 grown — gates visible features */
+  growthStage?: number;
+}
+
+const BODY = '#5fa8e8';
+const BODY_DARK = '#4a8fd0';
+const BELLY = '#bfe0ff';
+const EAR_IN = '#ffb3d9';
+const CHEEK = '#ff9ec7';
+
+// Emotion → eye + glow tuning. Kept gentle: ASD kids read big, clear shapes.
+const EMOTION_GLOW: Record<BeluEmotion, string> = {
+  happy: '#ffe27a',
+  excited: '#ffd166',
+  calm: '#9be7ff',
+  curious: '#b8ff9b',
+  sad: '#9fb8d6',
+  scared: '#c9b8ff',
+  overwhelmed: '#ffb3b3',
+};
+
+function Leg({ x, z, swing }: { x: number; z: number; swing: React.MutableRefObject<number> }) {
+  const ref = useRef<THREE.Group>(null);
+  useFrame(() => {
+    if (ref.current) ref.current.rotation.x = swing.current * (x + z > 0 ? 1 : -1);
+  });
+  return (
+    <group position={[x, -0.55, z]} ref={ref}>
+      <mesh castShadow position={[0, -0.35, 0]}>
+        <cylinderGeometry args={[0.26, 0.3, 0.7, 16]} />
+        <meshStandardMaterial color={BODY_DARK} roughness={0.7} />
+      </mesh>
+      <mesh position={[0, -0.72, 0]}>
+        <sphereGeometry args={[0.3, 16, 12]} />
+        <meshStandardMaterial color="#cfd8e3" roughness={0.6} />
+      </mesh>
+    </group>
+  );
+}
+
+export default function Belu3D({ motion, emotion, growthScale = 1, growthStage = 2 }: Props) {
+  const root = useRef<THREE.Group>(null);
+  const bodyGrp = useRef<THREE.Group>(null);
+  const head = useRef<THREE.Group>(null);
+  const earL = useRef<THREE.Group>(null);
+  const earR = useRef<THREE.Group>(null);
+  const trunk = useRef<THREE.Group>(null);
+  const legSwing = useRef(0);
+  const t = useRef(0);
+
+  useFrame((_, dt) => {
+    t.current += dt;
+    const m = motion.current;
+    const sp = m.speed;
+    const walkF = t.current * (6 + sp * 8);
+
+    // leg swing amplitude scales with speed
+    legSwing.current = Math.sin(walkF) * (0.15 + sp * 0.5);
+
+    // body bob — gentle when idle, bouncier when walking
+    if (bodyGrp.current) {
+      const bob = Math.sin(walkF * 2) * (0.02 + sp * 0.08) + Math.sin(t.current * 1.4) * 0.02;
+      bodyGrp.current.position.y = bob;
+      bodyGrp.current.rotation.z = Math.sin(walkF) * sp * 0.04;
+    }
+
+    // ears flap — faster with speed, plus a slow idle drift
+    const flap = Math.sin(walkF * 1.5) * (0.12 + sp * 0.35) + 0.25;
+    if (earL.current) earL.current.rotation.y = -0.5 - flap;
+    if (earR.current) earR.current.rotation.y = 0.5 + flap;
+
+    // trunk sway
+    if (trunk.current) {
+      trunk.current.rotation.z = Math.sin(t.current * 1.8) * 0.12;
+      trunk.current.rotation.x = -0.2 + Math.sin(t.current * 1.2) * 0.08;
+    }
+
+    // head: slight look-up when excited/curious, droop when sad
+    if (head.current) {
+      const tilt = emotion === 'sad' || emotion === 'overwhelmed' ? 0.18 : emotion === 'excited' ? -0.12 : 0;
+      head.current.rotation.x = THREE.MathUtils.lerp(head.current.rotation.x, tilt, 0.1);
+    }
+
+    // squash & stretch in the air
+    if (root.current) {
+      let sx = 1, sy = 1;
+      if (m.airborne) {
+        sy = 1 + Math.max(-0.12, Math.min(0.18, m.vy * 0.04));
+        sx = 1 - (sy - 1) * 0.6;
+      }
+      root.current.scale.x = THREE.MathUtils.lerp(root.current.scale.x, sx, 0.3);
+      root.current.scale.y = THREE.MathUtils.lerp(root.current.scale.y, sy, 0.3);
+      root.current.scale.z = THREE.MathUtils.lerp(root.current.scale.z, sx, 0.3);
+    }
+  });
+
+  const glow = EMOTION_GLOW[emotion];
+  const eyeNarrow = emotion === 'happy' || emotion === 'excited';
+  const eyeWide = emotion === 'scared' || emotion === 'curious' || emotion === 'overwhelmed';
+  const eyeScaleY = eyeNarrow ? 0.6 : eyeWide ? 1.25 : 1;
+
+  return (
+   <group scale={growthScale}>
+    <group ref={root}>
+      <group ref={bodyGrp}>
+        {/* main body */}
+        <mesh castShadow position={[0, 0.1, 0]} scale={[1.15, 1, 1.35]}>
+          <sphereGeometry args={[1, 22, 16]} />
+          <meshStandardMaterial color={BODY} roughness={0.55} metalness={0.02} />
+        </mesh>
+        {/* belly */}
+        <mesh position={[0, -0.35, 0.25]} scale={[0.95, 0.7, 1]}>
+          <sphereGeometry args={[0.8, 24, 18]} />
+          <meshStandardMaterial color={BELLY} roughness={0.6} />
+        </mesh>
+
+        {/* explorer's satchel — appears once Belu is all grown up */}
+        {growthStage >= 3 && (
+          <group position={[0.95, -0.1, 0]} rotation={[0, 0, -0.2]}>
+            <mesh castShadow>
+              <boxGeometry args={[0.35, 0.4, 0.5]} />
+              <meshStandardMaterial color="#c98a4b" roughness={0.7} />
+            </mesh>
+            <mesh position={[0, 0.05, 0.26]}>
+              <boxGeometry args={[0.37, 0.18, 0.04]} />
+              <meshStandardMaterial color="#a06a32" roughness={0.7} />
+            </mesh>
+          </group>
+        )}
+
+        {/* legs */}
+        <Leg x={-0.6} z={0.55} swing={legSwing} />
+        <Leg x={0.6} z={0.55} swing={legSwing} />
+        <Leg x={-0.6} z={-0.55} swing={legSwing} />
+        <Leg x={0.6} z={-0.55} swing={legSwing} />
+
+        {/* tail */}
+        <mesh position={[0, 0.1, -1.35]} rotation={[0.5, 0, 0]}>
+          <cylinderGeometry args={[0.05, 0.07, 0.7, 8]} />
+          <meshStandardMaterial color={BODY_DARK} />
+        </mesh>
+
+        {/* head */}
+        <group ref={head} position={[0, 0.55, 1.0]}>
+          <mesh castShadow scale={[1, 0.95, 0.9]}>
+            <sphereGeometry args={[0.85, 22, 16]} />
+            <meshStandardMaterial color={BODY} roughness={0.55} />
+          </mesh>
+
+          {/* forehead glow patch — subtle emotion tint */}
+          <mesh position={[0, 0.45, 0.55]} scale={[0.5, 0.4, 0.2]}>
+            <sphereGeometry args={[0.4, 16, 12]} />
+            <meshStandardMaterial color={glow} emissive={glow} emissiveIntensity={0.5} roughness={0.4} />
+          </mesh>
+
+          {/* ears */}
+          <group ref={earL} position={[-0.8, 0.1, 0]}>
+            <mesh castShadow scale={[0.25, 1, 1]} rotation={[0, 0, 0]} position={[-0.15, 0, 0]}>
+              <sphereGeometry args={[0.6, 24, 18]} />
+              <meshStandardMaterial color={BODY} roughness={0.6} side={THREE.DoubleSide} />
+            </mesh>
+            <mesh scale={[0.18, 0.78, 0.78]} position={[-0.2, 0, 0.02]}>
+              <sphereGeometry args={[0.6, 20, 16]} />
+              <meshStandardMaterial color={EAR_IN} roughness={0.6} side={THREE.DoubleSide} />
+            </mesh>
+          </group>
+          <group ref={earR} position={[0.8, 0.1, 0]}>
+            <mesh castShadow scale={[0.25, 1, 1]} position={[0.15, 0, 0]}>
+              <sphereGeometry args={[0.6, 24, 18]} />
+              <meshStandardMaterial color={BODY} roughness={0.6} side={THREE.DoubleSide} />
+            </mesh>
+            <mesh scale={[0.18, 0.78, 0.78]} position={[0.2, 0, 0.02]}>
+              <sphereGeometry args={[0.6, 20, 16]} />
+              <meshStandardMaterial color={EAR_IN} roughness={0.6} side={THREE.DoubleSide} />
+            </mesh>
+          </group>
+
+          {/* cheeks */}
+          <mesh position={[-0.42, -0.18, 0.62]} scale={[1, 0.8, 0.4]}>
+            <sphereGeometry args={[0.18, 12, 10]} />
+            <meshStandardMaterial color={CHEEK} roughness={0.7} transparent opacity={0.8} />
+          </mesh>
+          <mesh position={[0.42, -0.18, 0.62]} scale={[1, 0.8, 0.4]}>
+            <sphereGeometry args={[0.18, 12, 10]} />
+            <meshStandardMaterial color={CHEEK} roughness={0.7} transparent opacity={0.8} />
+          </mesh>
+
+          {/* eyes */}
+          <group position={[-0.3, 0.12, 0.68]} scale={[1, eyeScaleY, 1]}>
+            <mesh>
+              <sphereGeometry args={[0.17, 20, 16]} />
+              <meshStandardMaterial color="#ffffff" roughness={0.3} />
+            </mesh>
+            <mesh position={[0.02, 0, 0.12]}>
+              <sphereGeometry args={[0.09, 16, 12]} />
+              <meshStandardMaterial color="#26334d" roughness={0.2} />
+            </mesh>
+            <mesh position={[0.05, 0.05, 0.19]}>
+              <sphereGeometry args={[0.03, 10, 8]} />
+              <meshStandardMaterial color="#ffffff" emissive="#ffffff" emissiveIntensity={0.4} />
+            </mesh>
+          </group>
+          <group position={[0.3, 0.12, 0.68]} scale={[1, eyeScaleY, 1]}>
+            <mesh>
+              <sphereGeometry args={[0.17, 20, 16]} />
+              <meshStandardMaterial color="#ffffff" roughness={0.3} />
+            </mesh>
+            <mesh position={[-0.02, 0, 0.12]}>
+              <sphereGeometry args={[0.09, 16, 12]} />
+              <meshStandardMaterial color="#26334d" roughness={0.2} />
+            </mesh>
+            <mesh position={[0.01, 0.05, 0.19]}>
+              <sphereGeometry args={[0.03, 10, 8]} />
+              <meshStandardMaterial color="#ffffff" emissive="#ffffff" emissiveIntensity={0.4} />
+            </mesh>
+          </group>
+
+          {/* trunk */}
+          <group ref={trunk} position={[0, -0.35, 0.7]}>
+            <mesh castShadow position={[0, -0.05, 0.05]} rotation={[0.4, 0, 0]}>
+              <cylinderGeometry args={[0.2, 0.17, 0.55, 16]} />
+              <meshStandardMaterial color={BODY} roughness={0.55} />
+            </mesh>
+            <mesh castShadow position={[0, -0.42, 0.18]} rotation={[0.9, 0, 0]}>
+              <cylinderGeometry args={[0.17, 0.14, 0.5, 16]} />
+              <meshStandardMaterial color={BODY} roughness={0.55} />
+            </mesh>
+            <mesh castShadow position={[0, -0.66, 0.42]} rotation={[1.4, 0, 0]}>
+              <cylinderGeometry args={[0.14, 0.12, 0.4, 16]} />
+              <meshStandardMaterial color={BODY_DARK} roughness={0.55} />
+            </mesh>
+            {/* nostril tip */}
+            <mesh position={[0, -0.74, 0.62]}>
+              <torusGeometry args={[0.08, 0.04, 10, 16]} />
+              <meshStandardMaterial color={BODY_DARK} />
+            </mesh>
+          </group>
+
+          {/* tusks — grow in as Belu grows up (baby has none) */}
+          {growthStage >= 1 && (
+            <>
+              <mesh position={[-0.22, -0.45, 0.7]} rotation={[0.6, 0, 0.2]} scale={0.7 + growthStage * 0.15}>
+                <coneGeometry args={[0.05, 0.28, 10]} />
+                <meshStandardMaterial color="#fffaf0" roughness={0.3} />
+              </mesh>
+              <mesh position={[0.22, -0.45, 0.7]} rotation={[0.6, 0, -0.2]} scale={0.7 + growthStage * 0.15}>
+                <coneGeometry args={[0.05, 0.28, 10]} />
+                <meshStandardMaterial color="#fffaf0" roughness={0.3} />
+              </mesh>
+            </>
+          )}
+        </group>
+      </group>
+    </group>
+   </group>
+  );
+}

--- a/components/game/BelusWorld/three/GameCanvas.tsx
+++ b/components/game/BelusWorld/three/GameCanvas.tsx
@@ -1,0 +1,144 @@
+// ---------------------------------------------------------------------------
+// The R3F canvas: camera, realistic lighting, procedural sky, soft shadows and
+// a gentle bloom pass that gives the world its magical glow. "Calm mode" dials
+// the bloom right down for sensory-sensitive players.
+//
+// Performance: device-pixel-ratio is capped and auto-scaled by a
+// PerformanceMonitor (drops to 1x on weak GPUs), only Belu casts a shadow, the
+// shadow map is modest, and the composer runs without extra multisampling.
+// ---------------------------------------------------------------------------
+
+import { Suspense, useRef, useState } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { Sky, PerformanceMonitor } from '@react-three/drei';
+import { EffectComposer, Bloom } from '@react-three/postprocessing';
+import * as THREE from 'three';
+import Player, { type PlayerHandle } from './Player';
+import World from './World';
+import { PLAYER_SPAWN, type ZoneId } from './worldConfig';
+import type { BeluEmotion } from '../BeluCharacter';
+
+interface Props {
+  emotion: BeluEmotion;
+  paused: boolean;
+  reduceMotion: boolean;
+  calmMode: boolean;
+  /** the zone whose crystal should glow (Belu is near it) */
+  activeZone: ZoneId | null;
+  /** Belu's current size + growth stage (visible "growing up") */
+  growthScale: number;
+  growthStage: number;
+  /** completed-level count per zone island (drives the bloom) */
+  islandLevels: Partial<Record<ZoneId, number>>;
+  onProximity: (zone: ZoneId | null) => void;
+  onEnter: (zone: ZoneId) => void;
+}
+
+function Lighting({ calmMode }: { calmMode: boolean }) {
+  return (
+    <>
+      <hemisphereLight args={['#cfe8ff', '#8fae7a', 0.9]} />
+      <ambientLight intensity={0.4} />
+      <directionalLight
+        position={[28, 40, 18]}
+        intensity={calmMode ? 1.6 : 2.1}
+        color="#fff4e0"
+        castShadow
+        shadow-mapSize-width={1024}
+        shadow-mapSize-height={1024}
+        shadow-camera-near={1}
+        shadow-camera-far={130}
+        shadow-camera-left={-55}
+        shadow-camera-right={55}
+        shadow-camera-top={55}
+        shadow-camera-bottom={-55}
+        shadow-bias={-0.0005}
+      />
+      {/* warm rim fill from the opposite side for soft toy-like shading */}
+      <directionalLight position={[-25, 16, -20]} intensity={0.5} color="#ffd9b8" />
+    </>
+  );
+}
+
+export default function GameCanvas({
+  emotion,
+  paused,
+  reduceMotion,
+  calmMode,
+  activeZone,
+  growthScale,
+  growthStage,
+  islandLevels,
+  onProximity,
+  onEnter,
+}: Props) {
+  const player = useRef<PlayerHandle>(null);
+  // start at a safe-ish ratio and let the monitor scale it to the device
+  const [dpr, setDpr] = useState(1.25);
+
+  return (
+    <Canvas
+      shadows
+      dpr={dpr}
+      gl={{
+        antialias: false, // the composer + dpr handle edges; saves fill-rate
+        powerPreference: 'high-performance',
+        toneMapping: THREE.ACESFilmicToneMapping,
+        toneMappingExposure: 1.05,
+      }}
+      camera={{
+        fov: 50,
+        near: 0.1,
+        far: 400,
+        position: [PLAYER_SPAWN.x, PLAYER_SPAWN.y + 13.5, PLAYER_SPAWN.z + 17],
+      }}
+    >
+      <PerformanceMonitor
+        onDecline={() => setDpr(1)}
+        onIncline={() => setDpr(1.5)}
+        flipflops={3}
+        onFallback={() => setDpr(1)}
+      />
+
+      {/* atmospheric depth */}
+      <fog attach="fog" args={['#bfe2ff', 70, 160]} />
+      <Sky
+        distance={450000}
+        sunPosition={[28, 30, 18]}
+        inclination={0.52}
+        azimuth={0.25}
+        turbidity={4}
+        rayleigh={1.2}
+        mieCoefficient={0.004}
+        mieDirectionalG={0.85}
+      />
+
+      <Lighting calmMode={calmMode} />
+
+      <Suspense fallback={null}>
+        <World activeZone={activeZone} reduceMotion={reduceMotion} islandLevels={islandLevels} />
+        <Player
+          ref={player}
+          emotion={emotion}
+          paused={paused}
+          onProximity={onProximity}
+          onEnter={onEnter}
+          reduceMotion={reduceMotion}
+          growthScale={growthScale}
+          growthStage={growthStage}
+        />
+      </Suspense>
+
+      {!calmMode && (
+        <EffectComposer multisampling={0}>
+          <Bloom
+            intensity={0.6}
+            luminanceThreshold={0.65}
+            luminanceSmoothing={0.3}
+            mipmapBlur
+          />
+        </EffectComposer>
+      )}
+    </Canvas>
+  );
+}

--- a/components/game/BelusWorld/three/Player.tsx
+++ b/components/game/BelusWorld/three/Player.tsx
@@ -1,0 +1,178 @@
+// ---------------------------------------------------------------------------
+// Player controller. Owns Belu's transform and the follow-camera.
+// Movement is world-relative against a FIXED-angle camera — deliberately
+// predictable for ASD players: "up on screen" is always the same direction,
+// the camera never spins on its own. Up/down comes from jumping + the islands
+// sitting at different heights. Falling off is impossible to "lose" at: you
+// gently float back to home.
+// ---------------------------------------------------------------------------
+
+import { useImperativeHandle, useRef, forwardRef } from 'react';
+import { useFrame, useThree } from '@react-three/fiber';
+import * as THREE from 'three';
+import Belu3D, { type MotionRef } from './Belu3D';
+import { sampleGround } from './worldMath';
+import { input } from './input';
+import { ISLANDS, ZONE_ISLANDS, INTERACT_RADIUS, PLAYER_SPAWN, type ZoneId } from './worldConfig';
+import type { BeluEmotion } from '../BeluCharacter';
+
+const SPEED = 7.5;
+const GRAVITY = 24;
+const JUMP_V = 9;
+const FALL_LIMIT = -5;
+const CAM_OFFSET = new THREE.Vector3(0, 13.5, 17);
+
+export interface PlayerHandle {
+  position: THREE.Vector3;
+  respawn: () => void;
+}
+
+interface Props {
+  emotion: BeluEmotion;
+  paused: boolean;
+  onProximity: (zone: ZoneId | null) => void;
+  onEnter: (zone: ZoneId) => void;
+  reduceMotion: boolean;
+  growthScale: number;
+  growthStage: number;
+}
+
+const Player = forwardRef<PlayerHandle, Props>(function Player(
+  { emotion, paused, onProximity, onEnter, reduceMotion, growthScale, growthStage },
+  ref,
+) {
+  const group = useRef<THREE.Group>(null);
+  const motion = useRef<MotionRef>({ speed: 0, airborne: false, vy: 0 });
+  const vel = useRef(new THREE.Vector3());
+  const pos = useRef(new THREE.Vector3(PLAYER_SPAWN.x, PLAYER_SPAWN.y, PLAYER_SPAWN.z));
+  const vy = useRef(0);
+  const grounded = useRef(true);
+  const facing = useRef(0);
+  const nearZone = useRef<ZoneId | null>(null);
+  const camInit = useRef(false);
+
+  const { camera } = useThree();
+
+  useImperativeHandle(ref, () => ({
+    position: pos.current,
+    respawn: () => {
+      pos.current.set(PLAYER_SPAWN.x, PLAYER_SPAWN.y, PLAYER_SPAWN.z);
+      vy.current = 0;
+      vel.current.set(0, 0, 0);
+    },
+  }));
+
+  useFrame((_, rawDt) => {
+    const dt = Math.min(rawDt, 0.05); // clamp big frame gaps
+
+    // ---- consume interact edge ----
+    if (input.interactQueued) {
+      input.interactQueued = false;
+      if (nearZone.current) onEnter(nearZone.current);
+    }
+
+    if (paused) {
+      motion.current.speed = 0;
+      // keep camera trained on Belu while a panel is open
+      followCamera(0.06);
+      input.jumpQueued = false;
+      return;
+    }
+
+    // ---- horizontal movement (world-relative, camera is fixed-angle) ----
+    const ix = input.moveX;
+    const iz = input.moveZ;
+    const target = new THREE.Vector3(ix, 0, iz);
+    if (target.lengthSq() > 1) target.normalize();
+    vel.current.x = target.x * SPEED;
+    vel.current.z = target.z * SPEED;
+
+    pos.current.x += vel.current.x * dt;
+    pos.current.z += vel.current.z * dt;
+
+    // ---- jump + gravity ----
+    if (input.jumpQueued) {
+      input.jumpQueued = false;
+      if (grounded.current) {
+        vy.current = JUMP_V;
+        grounded.current = false;
+      }
+    }
+    vy.current -= GRAVITY * dt;
+    pos.current.y += vy.current * dt;
+
+    // ---- ground collision ----
+    const g = sampleGround(pos.current.x, pos.current.z);
+    const footY = g.y + 0.05;
+    if (pos.current.y <= footY) {
+      pos.current.y = footY;
+      vy.current = 0;
+      grounded.current = true;
+    } else {
+      grounded.current = false;
+    }
+
+    // ---- off-world: gentle float-home, never a fail ----
+    if (pos.current.y < FALL_LIMIT) {
+      pos.current.set(PLAYER_SPAWN.x, sampleGround(PLAYER_SPAWN.x, PLAYER_SPAWN.z).y + 0.5, PLAYER_SPAWN.z);
+      vy.current = 0;
+    }
+
+    // ---- facing direction ----
+    const speed2 = Math.hypot(vel.current.x, vel.current.z);
+    if (speed2 > 0.3) {
+      const want = Math.atan2(vel.current.x, vel.current.z);
+      let diff = want - facing.current;
+      while (diff > Math.PI) diff -= Math.PI * 2;
+      while (diff < -Math.PI) diff += Math.PI * 2;
+      facing.current += diff * Math.min(1, dt * 12);
+    }
+
+    // ---- write transform + motion for the model ----
+    if (group.current) {
+      group.current.position.copy(pos.current);
+      group.current.rotation.y = facing.current;
+    }
+    motion.current.speed = Math.min(1, speed2 / SPEED);
+    motion.current.airborne = !grounded.current;
+    motion.current.vy = vy.current;
+
+    // ---- zone proximity for the "Play!" prompt ----
+    let found: ZoneId | null = null;
+    let bestD = INTERACT_RADIUS;
+    for (const z of ZONE_ISLANDS) {
+      const isl = ISLANDS[z];
+      const d = Math.hypot(pos.current.x - isl.cx, pos.current.z - isl.cz);
+      if (d < bestD) {
+        bestD = d;
+        found = z;
+      }
+    }
+    if (found !== nearZone.current) {
+      nearZone.current = found;
+      onProximity(found);
+    }
+
+    // ---- camera ----
+    followCamera(reduceMotion ? 0.12 : 0.08);
+  });
+
+  function followCamera(lerp: number) {
+    const desired = pos.current.clone().add(CAM_OFFSET);
+    if (!camInit.current) {
+      camera.position.copy(desired);
+      camInit.current = true;
+    } else {
+      camera.position.lerp(desired, lerp);
+    }
+    camera.lookAt(pos.current.x, pos.current.y + 1.4, pos.current.z);
+  }
+
+  return (
+    <group ref={group}>
+      <Belu3D motion={motion} emotion={emotion} growthScale={growthScale} growthStage={growthStage} />
+    </group>
+  );
+});
+
+export default Player;

--- a/components/game/BelusWorld/three/Scenery.tsx
+++ b/components/game/BelusWorld/three/Scenery.tsx
@@ -1,0 +1,183 @@
+// ---------------------------------------------------------------------------
+// Reusable scenery props: trees, flowers, clouds, waterfalls, the interaction
+// crystal beacon. All procedural primitives — nothing to download.
+// ---------------------------------------------------------------------------
+
+import { useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { Float, Sparkles } from '@react-three/drei';
+import * as THREE from 'three';
+
+// Tiny seeded RNG so island layouts are stable across renders (no hydration
+// surprises, no flicker between frames).
+export function makeRng(seed: number) {
+  let s = seed % 2147483647;
+  if (s <= 0) s += 2147483646;
+  return () => {
+    s = (s * 16807) % 2147483647;
+    return (s - 1) / 2147483646;
+  };
+}
+
+export function Tree({ position, scale = 1, leaf = '#5fae54' }: { position: [number, number, number]; scale?: number; leaf?: string }) {
+  return (
+    <group position={position} scale={scale}>
+      <mesh position={[0, 0.7, 0]}>
+        <cylinderGeometry args={[0.18, 0.26, 1.4, 8]} />
+        <meshStandardMaterial color="#8a5a3b" roughness={0.9} />
+      </mesh>
+      <mesh position={[0, 1.7, 0]}>
+        <sphereGeometry args={[0.85, 14, 10]} />
+        <meshStandardMaterial color={leaf} roughness={0.8} />
+      </mesh>
+      <mesh position={[0.45, 2.1, 0.2]}>
+        <sphereGeometry args={[0.55, 12, 8]} />
+        <meshStandardMaterial color={leaf} roughness={0.8} />
+      </mesh>
+      <mesh position={[-0.4, 2.2, -0.1]}>
+        <sphereGeometry args={[0.5, 12, 8]} />
+        <meshStandardMaterial color={leaf} roughness={0.8} />
+      </mesh>
+    </group>
+  );
+}
+
+export function Flower({ position, color }: { position: [number, number, number]; color: string }) {
+  return (
+    <group position={position}>
+      <mesh position={[0, 0.2, 0]}>
+        <cylinderGeometry args={[0.03, 0.03, 0.4, 6]} />
+        <meshStandardMaterial color="#5fae54" />
+      </mesh>
+      {[0, 1, 2, 3, 4].map((i) => {
+        const a = (i / 5) * Math.PI * 2;
+        return (
+          <mesh key={i} position={[Math.cos(a) * 0.12, 0.42, Math.sin(a) * 0.12]}>
+            <sphereGeometry args={[0.08, 10, 8]} />
+            <meshStandardMaterial color={color} roughness={0.6} emissive={color} emissiveIntensity={0.12} />
+          </mesh>
+        );
+      })}
+      <mesh position={[0, 0.44, 0]}>
+        <sphereGeometry args={[0.07, 10, 8]} />
+        <meshStandardMaterial color="#ffd166" emissive="#ffd166" emissiveIntensity={0.3} />
+      </mesh>
+    </group>
+  );
+}
+
+// A glowing crystal that hovers over a zone island — this is the "play here"
+// beacon. It pulses brighter when Belu is near.
+export function Crystal({ position, color, active }: { position: [number, number, number]; color: string; active: boolean }) {
+  const mesh = useRef<THREE.Mesh>(null);
+  const t = useRef(0);
+  useFrame((_, dt) => {
+    t.current += dt;
+    if (mesh.current) {
+      mesh.current.rotation.y = t.current * 0.8;
+      mesh.current.position.y = Math.sin(t.current * 1.6) * 0.25;
+    }
+  });
+  return (
+    <group position={position}>
+      <Float speed={2} rotationIntensity={0.4} floatIntensity={0.6}>
+        <mesh ref={mesh}>
+          <octahedronGeometry args={[active ? 0.85 : 0.7, 0]} />
+          <meshStandardMaterial
+            color={color}
+            emissive={color}
+            emissiveIntensity={active ? 1.4 : 0.8}
+            roughness={0.1}
+            metalness={0.3}
+            transparent
+            opacity={0.92}
+          />
+        </mesh>
+      </Float>
+      {/* the active crystal gets a real light; the others rely on emissive +
+          bloom, so we never carry more than one dynamic point light at a time */}
+      {active && <pointLight color={color} intensity={3} distance={12} position={[0, 0.5, 0]} />}
+      <Sparkles count={active ? 14 : 6} scale={3} size={4} speed={0.4} color={color} position={[0, 0.5, 0]} />
+      {/* base ring on the ground */}
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -1.5, 0]}>
+        <ringGeometry args={[1.1, 1.5, 32]} />
+        <meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.6} transparent opacity={0.5} side={THREE.DoubleSide} />
+      </mesh>
+    </group>
+  );
+}
+
+// A translucent waterfall sheet pouring off an island edge into mist below.
+export function Waterfall({ position }: { position: [number, number, number] }) {
+  const mat = useRef<THREE.MeshStandardMaterial>(null);
+  const t = useRef(0);
+  useFrame((_, dt) => {
+    t.current += dt;
+    if (mat.current) mat.current.opacity = 0.45 + Math.sin(t.current * 6) * 0.08;
+  });
+  return (
+    <group position={position}>
+      <mesh>
+        <planeGeometry args={[2.4, 6, 1, 1]} />
+        <meshStandardMaterial
+          ref={mat}
+          color="#bfefff"
+          emissive="#9fe6ff"
+          emissiveIntensity={0.4}
+          transparent
+          opacity={0.5}
+          side={THREE.DoubleSide}
+          roughness={0.2}
+        />
+      </mesh>
+      {/* mist puff at the bottom */}
+      <mesh position={[0, -3, 0]}>
+        <sphereGeometry args={[1.4, 16, 12]} />
+        <meshStandardMaterial color="#ffffff" transparent opacity={0.35} />
+      </mesh>
+      <Sparkles count={10} scale={[2.4, 6, 1]} size={3} speed={1} color="#dffaff" />
+    </group>
+  );
+}
+
+// Slow-drifting cloud puffs scattered under and around the islands.
+export function Clouds({ reduceMotion }: { reduceMotion: boolean }) {
+  const grp = useRef<THREE.Group>(null);
+  const puffs = useMemo(() => {
+    const rng = makeRng(91);
+    return Array.from({ length: 14 }, () => ({
+      x: (rng() - 0.5) * 120,
+      y: -6 - rng() * 10,
+      z: (rng() - 0.5) * 120,
+      s: 2 + rng() * 3,
+      speed: 0.2 + rng() * 0.4,
+    }));
+  }, []);
+  useFrame((_, dt) => {
+    if (reduceMotion || !grp.current) return;
+    grp.current.children.forEach((c, i) => {
+      c.position.x += puffs[i].speed * dt;
+      if (c.position.x > 70) c.position.x = -70;
+    });
+  });
+  return (
+    <group ref={grp}>
+      {puffs.map((p, i) => (
+        <group key={i} position={[p.x, p.y, p.z]} scale={p.s}>
+          <mesh>
+            <sphereGeometry args={[1, 14, 10]} />
+            <meshStandardMaterial color="#ffffff" roughness={1} transparent opacity={0.9} />
+          </mesh>
+          <mesh position={[0.9, -0.1, 0]}>
+            <sphereGeometry args={[0.7, 14, 10]} />
+            <meshStandardMaterial color="#ffffff" roughness={1} transparent opacity={0.9} />
+          </mesh>
+          <mesh position={[-0.8, -0.15, 0.2]}>
+            <sphereGeometry args={[0.6, 14, 10]} />
+            <meshStandardMaterial color="#f3f8ff" roughness={1} transparent opacity={0.9} />
+          </mesh>
+        </group>
+      ))}
+    </group>
+  );
+}

--- a/components/game/BelusWorld/three/World.tsx
+++ b/components/game/BelusWorld/three/World.tsx
@@ -1,0 +1,240 @@
+// ---------------------------------------------------------------------------
+// The world: assembles the floating islands, rainbow bridges and all the
+// per-zone scenery from worldConfig. Stateless except for the "active zone"
+// (which crystal is glowing because Belu is near it).
+// ---------------------------------------------------------------------------
+
+import { useMemo } from 'react';
+import * as THREE from 'three';
+import { ISLAND_LIST, ISLANDS, BRIDGES, type ZoneId, type IslandDef } from './worldConfig';
+import { BRIDGE_SEGMENTS } from './worldMath';
+import { Tree, Flower, Crystal, Waterfall, Clouds, makeRng } from './Scenery';
+
+function Island({ isl }: { isl: IslandDef }) {
+  return (
+    <group position={[isl.cx, 0, isl.cz]}>
+      {/* grass top — flat enough to stand on, top face at isl.top */}
+      <mesh receiveShadow position={[0, isl.top - 0.7, 0]}>
+        <cylinderGeometry args={[isl.radius, isl.radius * 0.94, 1.4, 48]} />
+        <meshStandardMaterial color={isl.grass} roughness={0.85} />
+      </mesh>
+      {/* soft grassy rim cap so the edge reads round */}
+      <mesh position={[0, isl.top - 0.1, 0]}>
+        <cylinderGeometry args={[isl.radius * 0.99, isl.radius, 0.5, 48]} />
+        <meshStandardMaterial color={isl.grass} roughness={0.85} />
+      </mesh>
+      {/* rocky underside spike */}
+      <mesh position={[0, isl.top - 1.4 - isl.radius * 0.7, 0]}>
+        <coneGeometry args={[isl.radius * 0.95, isl.radius * 1.7, 24]} />
+        <meshStandardMaterial color={isl.rock} roughness={0.95} />
+      </mesh>
+      {/* a couple of boulders clinging to the underside */}
+      <mesh position={[isl.radius * 0.5, isl.top - 2.2, isl.radius * 0.3]}>
+        <dodecahedronGeometry args={[1.1, 0]} />
+        <meshStandardMaterial color={isl.rock} roughness={1} />
+      </mesh>
+      <mesh position={[-isl.radius * 0.4, isl.top - 2.8, -isl.radius * 0.4]}>
+        <dodecahedronGeometry args={[0.8, 0]} />
+        <meshStandardMaterial color={isl.rock} roughness={1} />
+      </mesh>
+    </group>
+  );
+}
+
+function RainbowBridges() {
+  const planks = useMemo(() => {
+    const all: { pos: [number, number, number]; rot: number; color: string; w: number }[] = [];
+    BRIDGE_SEGMENTS.forEach((s, bi) => {
+      const colors = BRIDGES[bi].colors;
+      const SEGS = 14;
+      const dx = s.bx - s.ax;
+      const dz = s.bz - s.az;
+      const rot = Math.atan2(dx, dz);
+      for (let i = 0; i < SEGS; i++) {
+        const t = (i + 0.5) / SEGS;
+        const x = s.ax + dx * t;
+        const z = s.az + dz * t;
+        const y = s.ay + (s.by - s.ay) * t + Math.sin(t * Math.PI) * 0.8 - 0.15;
+        all.push({ pos: [x, y, z], rot, color: colors[i % colors.length], w: s.halfWidth * 2 });
+      }
+    });
+    return all;
+  }, []);
+
+  return (
+    <group>
+      {planks.map((p, i) => (
+        <mesh key={i} position={p.pos} rotation={[0, p.rot, 0]} receiveShadow>
+          <boxGeometry args={[p.w, 0.28, 1.3]} />
+          <meshStandardMaterial
+            color={p.color}
+            roughness={0.5}
+            emissive={p.color}
+            emissiveIntensity={0.15}
+          />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+const MAX_BLOOM = 5;
+
+function ZoneDecor({ isl, bloom }: { isl: IslandDef; bloom: number }) {
+  const allItems = useMemo(() => {
+    const rng = makeRng(isl.cx * 31 + isl.cz * 17 + 7);
+    const out: { x: number; z: number; r: number }[] = [];
+    const n = 7;
+    for (let i = 0; i < n; i++) {
+      const a = rng() * Math.PI * 2;
+      const r = (0.35 + rng() * 0.5) * isl.radius;
+      out.push({ x: Math.cos(a) * r, z: Math.sin(a) * r, r: rng() });
+    }
+    return out;
+  }, [isl]);
+
+  // The island visibly fills in as the child completes its levels (the "bloom").
+  const count = Math.max(1, Math.ceil((bloom / MAX_BLOOM) * allItems.length));
+  const items = allItems.slice(0, count);
+  const fullyBloomed = bloom >= MAX_BLOOM;
+  const y = isl.top;
+
+  if (isl.id === 'meadow') {
+    const palette = ['#ff8fc8', '#ffd166', '#a78bfa', '#ff7b7b', '#6ee7b7'];
+    return (
+      <group position={[isl.cx, 0, isl.cz]}>
+        {items.map((it, i) => (
+          <Flower key={i} position={[it.x, y, it.z]} color={palette[i % palette.length]} />
+        ))}
+        <Tree position={[isl.radius * 0.5, y, -isl.radius * 0.3]} scale={0.8} leaf="#7fd06a" />
+      </group>
+    );
+  }
+  if (isl.id === 'forest') {
+    return (
+      <group position={[isl.cx, 0, isl.cz]}>
+        {items.map((it, i) => (
+          <Tree key={i} position={[it.x, y, it.z]} scale={0.7 + it.r * 0.6} leaf={i % 2 ? '#5fae54' : '#4f9e6a'} />
+        ))}
+      </group>
+    );
+  }
+  if (isl.id === 'mountain') {
+    return (
+      <group position={[isl.cx, 0, isl.cz]}>
+        <mesh position={[0, y + 1.8, -1]}>
+          <coneGeometry args={[3, 4.5, 5]} />
+          <meshStandardMaterial color="#9aa6b5" roughness={0.9} />
+        </mesh>
+        <mesh position={[0, y + 3.4, -1]}>
+          <coneGeometry args={[1.3, 1.6, 5]} />
+          <meshStandardMaterial color="#ffffff" roughness={0.7} />
+        </mesh>
+        {items.slice(0, 3).map((it, i) => (
+          <mesh key={i} position={[it.x, y + 0.2, it.z]}>
+            <dodecahedronGeometry args={[0.5 + it.r * 0.4, 0]} />
+            <meshStandardMaterial color="#aeb8c4" roughness={1} />
+          </mesh>
+        ))}
+      </group>
+    );
+  }
+  // cove — a calm pool + waterfall off the rim
+  return (
+    <group position={[isl.cx, 0, isl.cz]}>
+      <mesh position={[0, y + 0.05, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <circleGeometry args={[isl.radius * 0.55, 36]} />
+        <meshStandardMaterial color="#4fc3e0" transparent opacity={0.8} roughness={0.1} metalness={0.2} emissive="#2a9fc0" emissiveIntensity={0.2} />
+      </mesh>
+      <Waterfall position={[0, y - 2.5, isl.radius - 0.5]} />
+      <mesh position={[-isl.radius * 0.55, y + 0.2, isl.radius * 0.3]}>
+        <dodecahedronGeometry args={[0.7, 0]} />
+        <meshStandardMaterial color="#8aa0b0" roughness={1} />
+      </mesh>
+    </group>
+  );
+}
+
+function HomeDecor() {
+  const isl = ISLANDS.home;
+  const y = isl.top;
+  return (
+    <group position={[isl.cx, 0, isl.cz]}>
+      {/* cozy hut */}
+      <mesh position={[0, y + 0.9, -2]}>
+        <boxGeometry args={[3, 1.8, 2.6]} />
+        <meshStandardMaterial color="#ffe0a3" roughness={0.8} />
+      </mesh>
+      <mesh position={[0, y + 2.2, -2]} rotation={[0, Math.PI / 4, 0]}>
+        <coneGeometry args={[2.4, 1.4, 4]} />
+        <meshStandardMaterial color="#e8736b" roughness={0.7} />
+      </mesh>
+      <mesh position={[0, y + 0.55, -0.68]}>
+        <boxGeometry args={[0.8, 1.1, 0.1]} />
+        <meshStandardMaterial color="#9a5a3b" roughness={0.8} />
+      </mesh>
+      {/* welcome flowers + trees */}
+      <Tree position={[3.5, y, 1]} scale={0.9} />
+      <Tree position={[-3.8, y, 0.5]} scale={0.8} leaf="#6ec6a8" />
+      <Flower position={[1.6, y, 2.2]} color="#ff8fc8" />
+      <Flower position={[-1.6, y, 2.4]} color="#ffd166" />
+      <Flower position={[0.4, y, 3]} color="#a78bfa" />
+    </group>
+  );
+}
+
+function Landmark({ isl }: { isl: IslandDef }) {
+  // A glowing victory totem that appears once an island is fully bloomed —
+  // a clear, permanent, ownable marker of mastery the child earned.
+  return (
+    <group position={[isl.cx, isl.top, isl.cz - isl.radius * 0.55]}>
+      <mesh position={[0, 1.2, 0]}>
+        <cylinderGeometry args={[0.18, 0.22, 2.4, 8]} />
+        <meshStandardMaterial color="#caa46a" roughness={0.6} />
+      </mesh>
+      <mesh position={[0, 2.7, 0]}>
+        <octahedronGeometry args={[0.6, 0]} />
+        <meshStandardMaterial color={isl.accent} emissive={isl.accent} emissiveIntensity={1.2} roughness={0.1} />
+      </mesh>
+      <pointLight color={isl.accent} intensity={2} distance={10} position={[0, 2.7, 0]} />
+      {/* little flag */}
+      <mesh position={[0.45, 1.9, 0]}>
+        <boxGeometry args={[0.7, 0.45, 0.04]} />
+        <meshStandardMaterial color={isl.accent} roughness={0.5} side={THREE.DoubleSide} />
+      </mesh>
+    </group>
+  );
+}
+
+interface Props {
+  activeZone: ZoneId | null;
+  reduceMotion: boolean;
+  islandLevels: Partial<Record<ZoneId, number>>;
+}
+
+export default function World({ activeZone, reduceMotion, islandLevels }: Props) {
+  return (
+    <group>
+      <Clouds reduceMotion={reduceMotion} />
+      <RainbowBridges />
+      {ISLAND_LIST.map((isl) => (
+        <Island key={isl.id} isl={isl} />
+      ))}
+      <HomeDecor />
+      {ISLAND_LIST.filter((i) => i.id !== 'home').map((isl) => {
+        const bloom = islandLevels[isl.id] ?? 0;
+        return (
+          <group key={isl.id}>
+            <ZoneDecor isl={isl} bloom={bloom} />
+            {bloom >= MAX_BLOOM && <Landmark isl={isl} />}
+            <Crystal
+              position={[isl.cx, isl.top + 2.2, isl.cz]}
+              color={isl.accent}
+              active={activeZone === isl.id}
+            />
+          </group>
+        );
+      })}
+    </group>
+  );
+}

--- a/components/game/BelusWorld/three/input.ts
+++ b/components/game/BelusWorld/three/input.ts
@@ -1,0 +1,106 @@
+// ---------------------------------------------------------------------------
+// Unified input. A single mutable object the render loop reads every frame, fed
+// by both the keyboard and the on-screen touch joystick. Kept outside React
+// state on purpose — input changes 60x/second and must never trigger re-renders.
+// ---------------------------------------------------------------------------
+
+export interface InputState {
+  /** -1..1 left/right */
+  moveX: number;
+  /** -1..1 forward/back (forward = -1, i.e. away from camera / up the screen) */
+  moveZ: number;
+  /** edge-triggered jump request; the player controller consumes it */
+  jumpQueued: boolean;
+  /** edge-triggered interact request (E / tap action) */
+  interactQueued: boolean;
+}
+
+export const input: InputState = {
+  moveX: 0,
+  moveZ: 0,
+  jumpQueued: false,
+  interactQueued: false,
+};
+
+const keys = new Set<string>();
+
+function recompute() {
+  let x = 0;
+  let z = 0;
+  if (keys.has('KeyW') || keys.has('ArrowUp')) z -= 1;
+  if (keys.has('KeyS') || keys.has('ArrowDown')) z += 1;
+  if (keys.has('KeyA') || keys.has('ArrowLeft')) x -= 1;
+  if (keys.has('KeyD') || keys.has('ArrowRight')) x += 1;
+  // normalise diagonals so you don't move faster on the slant
+  const len = Math.hypot(x, z);
+  if (len > 0) {
+    x /= len;
+    z /= len;
+  }
+  // keyboard overrides joystick only when a key is actually pressed
+  if (keys.size > 0) {
+    input.moveX = x;
+    input.moveZ = z;
+  }
+}
+
+function onKeyDown(e: KeyboardEvent) {
+  const code = e.code;
+  if (
+    code === 'KeyW' || code === 'KeyA' || code === 'KeyS' || code === 'KeyD' ||
+    code === 'ArrowUp' || code === 'ArrowDown' || code === 'ArrowLeft' || code === 'ArrowRight'
+  ) {
+    if (!keys.has(code)) keys.add(code);
+    recompute();
+    e.preventDefault();
+  } else if (code === 'Space') {
+    input.jumpQueued = true;
+    e.preventDefault();
+  } else if (code === 'KeyE' || code === 'Enter') {
+    input.interactQueued = true;
+  }
+}
+
+function onKeyUp(e: KeyboardEvent) {
+  const code = e.code;
+  if (keys.delete(code)) {
+    if (keys.size === 0) {
+      input.moveX = 0;
+      input.moveZ = 0;
+    } else {
+      recompute();
+    }
+    e.preventDefault();
+  }
+}
+
+let attached = false;
+export function attachKeyboard() {
+  if (attached) return () => {};
+  attached = true;
+  window.addEventListener('keydown', onKeyDown);
+  window.addEventListener('keyup', onKeyUp);
+  return () => {
+    window.removeEventListener('keydown', onKeyDown);
+    window.removeEventListener('keyup', onKeyUp);
+    keys.clear();
+    input.moveX = 0;
+    input.moveZ = 0;
+    attached = false;
+  };
+}
+
+/** Joystick feeds an analog vector. Magnitude already 0..1. */
+export function setJoystick(x: number, z: number) {
+  input.moveX = x;
+  input.moveZ = z;
+}
+export function clearJoystick() {
+  if (keys.size === 0) {
+    input.moveX = 0;
+    input.moveZ = 0;
+  }
+}
+export function queueJump() {
+  input.jumpQueued = true;
+}

--- a/components/game/BelusWorld/three/worldConfig.ts
+++ b/components/game/BelusWorld/three/worldConfig.ts
@@ -1,0 +1,119 @@
+// ---------------------------------------------------------------------------
+// Belu's World — 3D world configuration
+// A cluster of floating sky-islands connected by rainbow bridges.
+// Everything the world needs to lay itself out lives here so the geometry,
+// the ground-collision math, and the gameplay all read from one source.
+// ---------------------------------------------------------------------------
+
+export type ZoneId = 'home' | 'meadow' | 'mountain' | 'cove' | 'forest';
+
+export interface IslandDef {
+  id: ZoneId;
+  /** world-space centre on the XZ plane */
+  cx: number;
+  cz: number;
+  /** flat radius the player can stand on */
+  radius: number;
+  /** height of the island's walkable top */
+  top: number;
+  /** primary grass / surface colour */
+  grass: string;
+  /** rock / cliff colour for the underside */
+  rock: string;
+  /** soft accent glow used by crystals + signposts on this island */
+  accent: string;
+  /** the learning zone this island hosts (home has none) */
+  label: string;
+  emoji: string;
+}
+
+export interface BridgeDef {
+  from: ZoneId;
+  to: ZoneId;
+  /** half-width of the walkable plank surface */
+  halfWidth: number;
+  colors: string[];
+}
+
+// The home hub sits at the centre; the four learning islands orbit it at
+// different heights so the kid genuinely travels up and down, not just across.
+export const ISLANDS: Record<ZoneId, IslandDef> = {
+  home: {
+    id: 'home',
+    cx: 0,
+    cz: 0,
+    radius: 11,
+    top: 0,
+    grass: '#7ec850',
+    rock: '#8a6b4f',
+    accent: '#ffd166',
+    label: "Belu's Home",
+    emoji: '🏡',
+  },
+  meadow: {
+    id: 'meadow',
+    cx: -38,
+    cz: -8,
+    radius: 9.5,
+    top: 2.5,
+    grass: '#9ad86a',
+    rock: '#9c7a59',
+    accent: '#ff8fc8',
+    label: 'Feelings Meadow',
+    emoji: '🌸',
+  },
+  mountain: {
+    id: 'mountain',
+    cx: 36,
+    cz: -14,
+    radius: 9.5,
+    top: 4.5,
+    grass: '#bfe3a0',
+    rock: '#7f8a99',
+    accent: '#7cc6ff',
+    label: 'Morning Mountain',
+    emoji: '⛰️',
+  },
+  cove: {
+    id: 'cove',
+    cx: -28,
+    cz: 30,
+    radius: 9.5,
+    top: -2,
+    grass: '#86d6c0',
+    rock: '#6f8aa0',
+    accent: '#5fd0e0',
+    label: 'Calm Cove',
+    emoji: '🌊',
+  },
+  forest: {
+    id: 'forest',
+    cx: 32,
+    cz: 30,
+    radius: 9.5,
+    top: 1,
+    grass: '#6fbf73',
+    rock: '#7a6b4a',
+    accent: '#c6a0ff',
+    label: 'Friendship Forest',
+    emoji: '🌳',
+  },
+};
+
+export const ISLAND_LIST = Object.values(ISLANDS);
+
+export const BRIDGES: BridgeDef[] = [
+  { from: 'home', to: 'meadow', halfWidth: 2.2, colors: ['#ff6b6b', '#ffd166', '#7ec850', '#5fd0e0', '#8a7bff'] },
+  { from: 'home', to: 'mountain', halfWidth: 2.2, colors: ['#ff6b6b', '#ffd166', '#7ec850', '#5fd0e0', '#8a7bff'] },
+  { from: 'home', to: 'cove', halfWidth: 2.2, colors: ['#ff6b6b', '#ffd166', '#7ec850', '#5fd0e0', '#8a7bff'] },
+  { from: 'home', to: 'forest', halfWidth: 2.2, colors: ['#ff6b6b', '#ffd166', '#7ec850', '#5fd0e0', '#8a7bff'] },
+];
+
+// The zone islands that host a learning activity (everything except home).
+export const ZONE_ISLANDS: ZoneId[] = ['meadow', 'mountain', 'cove', 'forest'];
+
+// Where the interaction crystal sits on each zone island (offset from centre)
+// and how close Belu must be to trigger the "Play!" prompt.
+export const INTERACT_RADIUS = 4.5;
+
+export const PLAYER_SPAWN = { x: 0, y: 0.4, z: 6 };

--- a/components/game/BelusWorld/three/worldMath.ts
+++ b/components/game/BelusWorld/three/worldMath.ts
@@ -1,0 +1,95 @@
+// ---------------------------------------------------------------------------
+// Ground sampling + bridge geometry.
+// Instead of a physics engine we use a lightweight height-field: given an XZ
+// position we figure out which island top or bridge plank the player is over
+// and return its height. This is cheap, deterministic and — importantly for an
+// ASD audience — completely predictable. No tunnelling, no jitter.
+// ---------------------------------------------------------------------------
+
+import { ISLAND_LIST, BRIDGES, ISLANDS, type ZoneId } from './worldConfig';
+
+export interface GroundSample {
+  /** ground height at this point */
+  y: number;
+  /** is the point actually over a walkable surface? */
+  onSurface: boolean;
+  /** the zone whose island we're standing on, if any */
+  zone: ZoneId | null;
+}
+
+interface Segment {
+  ax: number;
+  az: number;
+  ay: number;
+  bx: number;
+  bz: number;
+  by: number;
+  halfWidth: number;
+}
+
+// Precompute bridge segments (island-edge to island-edge) once.
+export const BRIDGE_SEGMENTS: Segment[] = BRIDGES.map((b) => {
+  const A = ISLANDS[b.from];
+  const B = ISLANDS[b.to];
+  const dx = B.cx - A.cx;
+  const dz = B.cz - A.cz;
+  const len = Math.hypot(dx, dz) || 1;
+  const ux = dx / len;
+  const uz = dz / len;
+  // Pull the endpoints in to each island's rim so the plank meets the grass.
+  const ax = A.cx + ux * (A.radius - 1.5);
+  const az = A.cz + uz * (A.radius - 1.5);
+  const bx = B.cx - ux * (B.radius - 1.5);
+  const bz = B.cz - uz * (B.radius - 1.5);
+  return { ax, az, ay: A.top, bx, bz, by: B.top, halfWidth: b.halfWidth };
+});
+
+const EDGE_FALLOFF = 1.4; // soft margin past the rim before you actually fall
+
+/** Smooth dome so island centres sit slightly higher than rims — feels natural. */
+function islandHeightAt(distFromCentre: number, radius: number, top: number): number {
+  const t = Math.min(distFromCentre / radius, 1);
+  // gentle dome: +0.6 at centre easing to 0 at rim
+  return top + 0.6 * (1 - t * t);
+}
+
+/** Sample the ground at an XZ position. Returns the highest surface under it. */
+export function sampleGround(x: number, z: number): GroundSample {
+  let best: GroundSample = { y: -Infinity, onSurface: false, zone: null };
+
+  // Islands
+  for (const isl of ISLAND_LIST) {
+    const d = Math.hypot(x - isl.cx, z - isl.cz);
+    if (d <= isl.radius + EDGE_FALLOFF) {
+      const y = islandHeightAt(Math.min(d, isl.radius), isl.radius, isl.top);
+      if (y > best.y) best = { y, onSurface: d <= isl.radius + EDGE_FALLOFF, zone: isl.id };
+    }
+  }
+
+  // Bridges
+  for (const s of BRIDGE_SEGMENTS) {
+    const dx = s.bx - s.ax;
+    const dz = s.bz - s.az;
+    const len2 = dx * dx + dz * dz || 1;
+    let t = ((x - s.ax) * dx + (z - s.az) * dz) / len2;
+    t = Math.max(0, Math.min(1, t));
+    const px = s.ax + dx * t;
+    const pz = s.az + dz * t;
+    const perp = Math.hypot(x - px, z - pz);
+    if (perp <= s.halfWidth + 0.3) {
+      // gentle arch on the bridge: lift the middle a touch
+      const arch = Math.sin(t * Math.PI) * 0.8;
+      const y = s.ay + (s.by - s.ay) * t + arch;
+      if (y > best.y) best = { y, onSurface: true, zone: best.zone };
+    }
+  }
+
+  if (best.y === -Infinity) return { y: -8, onSurface: false, zone: null };
+  return best;
+}
+
+/** Distance from an XZ point to the centre of a zone island. */
+export function distToIsland(x: number, z: number, zone: ZoneId): number {
+  const isl = ISLANDS[zone];
+  return Math.hypot(x - isl.cx, z - isl.cz);
+}

--- a/components/game/BelusWorld/ui/GrowthMap.tsx
+++ b/components/game/BelusWorld/ui/GrowthMap.tsx
@@ -1,0 +1,128 @@
+// ---------------------------------------------------------------------------
+// The Growth Map — a single screen where the child SEES their progress:
+//   • how grown-up Belu is, with a meter to the next growth,
+//   • how much each island has bloomed (levels completed),
+//   • total stars collected, and a sticker gallery.
+// This is the recognizable thing the child strives for — concrete, additive,
+// never punishing.
+// ---------------------------------------------------------------------------
+
+import { motion } from 'framer-motion';
+import { ACTIVITIES } from '../activities/registry';
+import {
+  type GameProgress,
+  ZONES,
+  MAX_LEVEL,
+  MAX_STARS_PER_ISLAND,
+  getGrowth,
+  islandStars,
+  completedLevels,
+  totalStars,
+} from '../belu/progress';
+
+const GROWTH_EMOJI = ['🐣', '🐘', '🐘', '🐘']; // baby vs grown handled by scale below
+const GROWTH_SCALE = [44, 60, 78, 96];
+
+export default function GrowthMap({ progress, onClose }: { progress: GameProgress; onClose: () => void }) {
+  const growth = getGrowth(progress);
+  const stars = totalStars(progress);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: 'rgba(20,28,46,0.55)', backdropFilter: 'blur(10px)' }}
+    >
+      <motion.div
+        initial={{ scale: 0.92, y: 20 }}
+        animate={{ scale: 1, y: 0 }}
+        exit={{ scale: 0.92 }}
+        transition={{ type: 'spring', stiffness: 260, damping: 24 }}
+        className="relative max-h-[90vh] w-full max-w-md overflow-y-auto rounded-[28px] bg-white p-6"
+        style={{ boxShadow: '0 30px 80px rgba(20,30,60,0.45)' }}
+      >
+        <button
+          onClick={onClose}
+          className="absolute right-4 top-4 flex h-9 w-9 items-center justify-center rounded-full bg-slate-100 text-slate-500"
+          aria-label="Close"
+        >
+          ✕
+        </button>
+
+        <h2 className="mb-1 text-center text-2xl font-black text-slate-800">My Growth Map</h2>
+        <p className="mb-4 text-center text-sm font-semibold text-amber-500">⭐ {stars} stars collected</p>
+
+        {/* Belu growth */}
+        <div className="mb-5 rounded-3xl p-5 text-center" style={{ background: 'linear-gradient(160deg,#eaf6ff,#fff)' }}>
+          <motion.div
+            animate={{ y: [0, -6, 0] }}
+            transition={{ duration: 2.4, repeat: Infinity }}
+            style={{ fontSize: GROWTH_SCALE[growth.stage], lineHeight: 1 }}
+          >
+            {GROWTH_EMOJI[growth.stage]}
+          </motion.div>
+          <div className="mt-1 text-lg font-extrabold text-sky-700">{growth.label}</div>
+          {/* meter */}
+          <div className="mx-auto mt-3 h-4 w-full max-w-[260px] overflow-hidden rounded-full bg-sky-100">
+            <motion.div
+              className="h-full rounded-full"
+              style={{ background: 'linear-gradient(90deg,#7ec0ff,#5fa8e8)' }}
+              initial={{ width: 0 }}
+              animate={{ width: `${growth.progress * 100}%` }}
+              transition={{ duration: 0.8 }}
+            />
+          </div>
+          <p className="mt-2 text-xs font-semibold text-slate-500">
+            {growth.nextAt === null
+              ? 'Belu is all grown up — amazing! 🎉'
+              : `${growth.nextAt - stars} more ⭐ to help Belu grow bigger!`}
+          </p>
+        </div>
+
+        {/* Islands bloom */}
+        <h3 className="mb-2 text-sm font-bold uppercase tracking-wide text-slate-400">Island Gardens</h3>
+        <div className="flex flex-col gap-2.5">
+          {ZONES.map((z) => {
+            const meta = ACTIVITIES[z];
+            const done = completedLevels(progress, z);
+            const s = islandStars(progress, z);
+            const bloomPct = (done / MAX_LEVEL) * 100;
+            return (
+              <div key={z} className="flex items-center gap-3 rounded-2xl border-2 border-slate-100 p-3">
+                <div
+                  className="flex h-11 w-11 flex-none items-center justify-center rounded-xl text-2xl"
+                  style={{ background: `${meta.accent}33` }}
+                >
+                  {meta.emoji}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center justify-between">
+                    <span className="truncate font-bold text-slate-700">{meta.skill}</span>
+                    <span className="ml-2 flex-none text-xs font-bold" style={{ color: meta.accent }}>
+                      {s}/{MAX_STARS_PER_ISLAND} ⭐
+                    </span>
+                  </div>
+                  <div className="mt-1.5 h-2.5 overflow-hidden rounded-full bg-slate-100">
+                    <div className="h-full rounded-full" style={{ width: `${bloomPct}%`, background: meta.accent }} />
+                  </div>
+                  <div className="mt-0.5 text-[11px] text-slate-400">
+                    {done >= MAX_LEVEL ? '🌷 Fully bloomed!' : `${done}/${MAX_LEVEL} levels grown`}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <button
+          onClick={onClose}
+          className="mt-5 w-full rounded-full bg-sky-500 py-3 text-lg font-bold text-white shadow-lg transition active:scale-95"
+        >
+          Back to exploring →
+        </button>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/components/game/BelusWorld/ui/HUD.tsx
+++ b/components/game/BelusWorld/ui/HUD.tsx
@@ -1,0 +1,116 @@
+// ---------------------------------------------------------------------------
+// Heads-up display layered over the 3D canvas: Belu's speech, the sticker
+// collection, the settings gear, the contextual "play here" prompt and the
+// controls hint. The container ignores pointer events; only the buttons catch
+// them, so movement taps still reach the canvas underneath.
+// ---------------------------------------------------------------------------
+
+import { AnimatePresence, motion } from 'framer-motion';
+import { ACTIVITIES } from '../activities/registry';
+import type { ZoneId } from '../three/worldConfig';
+
+interface Props {
+  beluLine: string | null;
+  nearZone: ZoneId | null;
+  stickers: string[];
+  totalStars: number;
+  isTouch: boolean;
+  onOpenSettings: () => void;
+  onOpenMap: () => void;
+  onPlayNear: () => void;
+}
+
+export default function HUD({ beluLine, nearZone, stickers, totalStars, isTouch, onOpenSettings, onOpenMap, onPlayNear }: Props) {
+  const zoneMeta = nearZone && nearZone !== 'home' ? ACTIVITIES[nearZone as Exclude<ZoneId, 'home'>] : null;
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-30">
+      {/* Belu speech — top left */}
+      <div className="absolute left-4 top-4 flex max-w-[78%] items-start gap-2">
+        <div
+          className="flex h-12 w-12 flex-none items-center justify-center rounded-full text-2xl"
+          style={{ background: 'linear-gradient(140deg,#7ec0ff,#5fa8e8)', boxShadow: '0 6px 18px rgba(40,90,160,0.4)' }}
+        >
+          🐘
+        </div>
+        <AnimatePresence>
+          {beluLine && (
+            <motion.div
+              key={beluLine}
+              initial={{ opacity: 0, y: -6, scale: 0.96 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: -6, scale: 0.96 }}
+              className="rounded-2xl rounded-tl-sm bg-white/95 px-4 py-2 text-sm font-semibold text-slate-700 shadow-lg backdrop-blur"
+            >
+              {beluLine}
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+
+      {/* Stars + stickers + map + settings — top right */}
+      <div className="absolute right-4 top-4 flex items-center gap-2">
+        <div className="flex items-center gap-1 rounded-full bg-white/90 px-3 py-1.5 shadow-lg backdrop-blur">
+          <span className="text-sm">⭐</span>
+          <span className="text-sm font-bold text-slate-700">{totalStars}</span>
+          {stickers.length > 0 && (
+            <span className="ml-1 flex gap-0.5">
+              {stickers.map((s, i) => (
+                <span key={i} className="text-base">{s}</span>
+              ))}
+            </span>
+          )}
+        </div>
+        <button
+          onClick={onOpenMap}
+          className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg shadow-lg backdrop-blur transition hover:bg-white"
+          aria-label="Growth map"
+        >
+          🗺️
+        </button>
+        <button
+          onClick={onOpenSettings}
+          className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg shadow-lg backdrop-blur transition hover:bg-white"
+          aria-label="Settings"
+        >
+          ⚙️
+        </button>
+      </div>
+
+      {/* Proximity prompt — center bottom-ish */}
+      <AnimatePresence>
+        {zoneMeta && (
+          <motion.button
+            key={zoneMeta.zone}
+            initial={{ opacity: 0, y: 20, scale: 0.9 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 20, scale: 0.9 }}
+            onClick={onPlayNear}
+            className="pointer-events-auto absolute left-1/2 top-[64%] -translate-x-1/2 rounded-3xl px-6 py-4 text-center shadow-2xl"
+            style={{ background: `linear-gradient(140deg, #ffffff, ${zoneMeta.accent}33)`, border: `2px solid ${zoneMeta.accent}` }}
+          >
+            <div className="text-2xl">{zoneMeta.emoji}</div>
+            <div className="text-base font-extrabold text-slate-800">{zoneMeta.title}</div>
+            <div className="mb-1 text-xs font-semibold" style={{ color: '#7a6' }}>
+              {zoneMeta.skill}
+            </div>
+            <div
+              className="mt-1 inline-block rounded-full px-4 py-1.5 text-sm font-bold text-white"
+              style={{ background: zoneMeta.accent }}
+            >
+              {isTouch ? 'Tap to play ✋' : 'Press E to play ▶'}
+            </div>
+          </motion.button>
+        )}
+      </AnimatePresence>
+
+      {/* Controls hint — desktop only, bottom center */}
+      {!isTouch && (
+        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full bg-black/35 px-4 py-2 text-xs font-medium text-white backdrop-blur">
+          <span className="font-bold">WASD</span> / arrows to move · <span className="font-bold">Space</span> to jump ·{' '}
+          <span className="font-bold">E</span> to play
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/game/BelusWorld/ui/LevelSelect.tsx
+++ b/components/game/BelusWorld/ui/LevelSelect.tsx
@@ -1,0 +1,133 @@
+// ---------------------------------------------------------------------------
+// Destination entry screen. Shown when Belu reaches an island. Presents the
+// skill, a First→Then frame, and a visible LEVEL PATH (1..5) the child climbs.
+// Each node shows the stars earned; the next level pulses invitingly; future
+// levels are gently locked (unlock in order — predictable, no surprises).
+// This screen IS the per-island progress display + the "selectable" choice.
+// ---------------------------------------------------------------------------
+
+import { motion } from 'framer-motion';
+import type { ActivityMeta } from '../activities/registry';
+import { MAX_LEVEL } from '../belu/progress';
+
+interface Props {
+  meta: ActivityMeta;
+  /** best stars per level (length MAX_LEVEL), 0 = not done */
+  levelStars: number[];
+  onPlay: (level: number) => void;
+  onClose: () => void;
+}
+
+function Stars({ n, accent }: { n: number; accent: string }) {
+  return (
+    <span className="flex gap-0.5">
+      {[0, 1, 2].map((i) => (
+        <span key={i} style={{ color: i < n ? accent : '#d8e0ec' }}>★</span>
+      ))}
+    </span>
+  );
+}
+
+export default function LevelSelect({ meta, levelStars, onPlay, onClose }: Props) {
+  const completed = levelStars.filter((s) => s > 0).length;
+  const nextLevel = Math.min(completed + 1, MAX_LEVEL);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      className="fixed inset-0 z-40 flex items-center justify-center p-4"
+      style={{ background: 'rgba(20,28,46,0.55)', backdropFilter: 'blur(10px)' }}
+    >
+      <motion.div
+        initial={{ scale: 0.92, y: 20 }}
+        animate={{ scale: 1, y: 0 }}
+        exit={{ scale: 0.92 }}
+        transition={{ type: 'spring', stiffness: 260, damping: 24 }}
+        className="relative w-full max-w-md rounded-[28px] p-6"
+        style={{
+          background: `linear-gradient(160deg, #ffffff 0%, ${meta.accent}18 100%)`,
+          boxShadow: '0 30px 80px rgba(20,30,60,0.45)',
+        }}
+      >
+        <button
+          onClick={onClose}
+          className="absolute right-4 top-4 flex h-9 w-9 items-center justify-center rounded-full bg-slate-100 text-slate-500 transition hover:bg-slate-200"
+          aria-label="Back to the world"
+        >
+          ✕
+        </button>
+
+        {/* header */}
+        <div className="mb-1 flex items-center gap-3">
+          <div
+            className="flex h-14 w-14 items-center justify-center rounded-2xl text-3xl"
+            style={{ background: meta.accent, boxShadow: `0 6px 18px ${meta.accent}66` }}
+          >
+            {meta.emoji}
+          </div>
+          <div>
+            <h2 className="text-xl font-extrabold text-slate-800">{meta.title}</h2>
+            <p className="text-sm font-semibold" style={{ color: '#888' }}>
+              {meta.skill}
+            </p>
+          </div>
+        </div>
+        <p className="mb-4 text-sm text-slate-500">{meta.tagline}</p>
+
+        {/* level path */}
+        <div className="flex flex-col gap-2.5">
+          {Array.from({ length: MAX_LEVEL }).map((_, i) => {
+            const lvl = i + 1;
+            const stars = levelStars[i] ?? 0;
+            const done = stars > 0;
+            const unlocked = lvl <= nextLevel;
+            const isNext = lvl === nextLevel && !done;
+            return (
+              <motion.button
+                key={lvl}
+                disabled={!unlocked}
+                onClick={() => unlocked && onPlay(lvl)}
+                whileTap={unlocked ? { scale: 0.97 } : {}}
+                animate={isNext ? { scale: [1, 1.025, 1] } : {}}
+                transition={isNext ? { duration: 1.6, repeat: Infinity } : {}}
+                className="flex items-center gap-3 rounded-2xl border-2 px-4 py-3 text-left transition"
+                style={{
+                  borderColor: unlocked ? `${meta.accent}66` : '#e6ebf2',
+                  background: unlocked ? '#fff' : '#f5f7fa',
+                  opacity: unlocked ? 1 : 0.6,
+                  boxShadow: isNext ? `0 6px 20px ${meta.accent}44` : '0 2px 8px rgba(30,40,70,0.05)',
+                }}
+              >
+                <div
+                  className="flex h-10 w-10 flex-none items-center justify-center rounded-full text-lg font-black text-white"
+                  style={{ background: done ? meta.accent : unlocked ? `${meta.accent}aa` : '#c2cbd6' }}
+                >
+                  {unlocked ? lvl : '🔒'}
+                </div>
+                <div className="flex-1">
+                  <div className="font-bold text-slate-700">{meta.levelNames[i]}</div>
+                  <div className="text-xs text-slate-400">Level {lvl}</div>
+                </div>
+                {done ? (
+                  <Stars n={stars} accent={meta.accent} />
+                ) : isNext ? (
+                  <span className="rounded-full px-3 py-1 text-xs font-bold text-white" style={{ background: meta.accent }}>
+                    Play ▶
+                  </span>
+                ) : null}
+              </motion.button>
+            );
+          })}
+        </div>
+
+        {completed >= MAX_LEVEL && (
+          <p className="mt-4 rounded-2xl bg-amber-100 px-4 py-2 text-center text-sm font-bold text-amber-700">
+            🎉 Island mastered! It has fully bloomed.
+          </p>
+        )}
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/components/game/BelusWorld/ui/TouchControls.tsx
+++ b/components/game/BelusWorld/ui/TouchControls.tsx
@@ -1,0 +1,135 @@
+// ---------------------------------------------------------------------------
+// On-screen controls for touch devices: a thumb-joystick (move) plus jump and
+// action buttons. Feeds the same global `input` object the keyboard uses, so
+// the player controller doesn't care where movement came from.
+// ---------------------------------------------------------------------------
+
+import { useRef, useState } from 'react';
+import { setJoystick, clearJoystick, queueJump, input } from '../three/input';
+
+const BASE = 130; // px diameter of the joystick base
+const KNOB = 58;
+const MAXR = (BASE - KNOB) / 2;
+
+export default function TouchControls() {
+  const baseRef = useRef<HTMLDivElement>(null);
+  const center = useRef({ x: 0, y: 0 });
+  const pointerId = useRef<number | null>(null);
+  const [knob, setKnob] = useState({ x: 0, y: 0 });
+
+  function start(e: React.PointerEvent) {
+    const rect = baseRef.current!.getBoundingClientRect();
+    center.current = { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+    pointerId.current = e.pointerId;
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    move(e);
+  }
+
+  function move(e: React.PointerEvent) {
+    if (pointerId.current !== e.pointerId) return;
+    let dx = e.clientX - center.current.x;
+    let dy = e.clientY - center.current.y;
+    const dist = Math.hypot(dx, dy);
+    if (dist > MAXR) {
+      dx = (dx / dist) * MAXR;
+      dy = (dy / dist) * MAXR;
+    }
+    setKnob({ x: dx, y: dy });
+    // normalise to -1..1; screen-up (negative dy) = forward (negative z)
+    setJoystick(dx / MAXR, dy / MAXR);
+  }
+
+  function end(e: React.PointerEvent) {
+    if (pointerId.current !== e.pointerId) return;
+    pointerId.current = null;
+    setKnob({ x: 0, y: 0 });
+    clearJoystick();
+  }
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-20 select-none">
+      {/* joystick — bottom left */}
+      <div
+        ref={baseRef}
+        onPointerDown={start}
+        onPointerMove={move}
+        onPointerUp={end}
+        onPointerCancel={end}
+        className="pointer-events-auto absolute touch-none"
+        style={{
+          left: 24,
+          bottom: 28,
+          width: BASE,
+          height: BASE,
+          borderRadius: '50%',
+          background: 'radial-gradient(circle at 50% 40%, rgba(255,255,255,0.35), rgba(255,255,255,0.12))',
+          border: '2px solid rgba(255,255,255,0.5)',
+          backdropFilter: 'blur(8px)',
+          boxShadow: '0 8px 30px rgba(0,0,0,0.25), inset 0 2px 10px rgba(255,255,255,0.4)',
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            left: '50%',
+            top: '50%',
+            width: KNOB,
+            height: KNOB,
+            marginLeft: -KNOB / 2,
+            marginTop: -KNOB / 2,
+            transform: `translate(${knob.x}px, ${knob.y}px)`,
+            borderRadius: '50%',
+            background: 'radial-gradient(circle at 40% 35%, #ffffff, #cfe4ff)',
+            boxShadow: '0 4px 14px rgba(0,0,0,0.3)',
+          }}
+        />
+      </div>
+
+      {/* jump button — bottom right */}
+      <button
+        onPointerDown={(e) => {
+          e.preventDefault();
+          queueJump();
+        }}
+        className="pointer-events-auto absolute touch-none active:scale-90 transition-transform"
+        style={{
+          right: 28,
+          bottom: 96,
+          width: 84,
+          height: 84,
+          borderRadius: '50%',
+          background: 'radial-gradient(circle at 40% 35%, #b6f0a8, #6fcf6a)',
+          border: '2px solid rgba(255,255,255,0.7)',
+          boxShadow: '0 8px 22px rgba(0,0,0,0.25)',
+          fontSize: 30,
+        }}
+        aria-label="Jump"
+      >
+        ⬆️
+      </button>
+
+      {/* action button — bottom right lower */}
+      <button
+        onPointerDown={(e) => {
+          e.preventDefault();
+          input.interactQueued = true;
+        }}
+        className="pointer-events-auto absolute touch-none active:scale-90 transition-transform"
+        style={{
+          right: 120,
+          bottom: 32,
+          width: 72,
+          height: 72,
+          borderRadius: '50%',
+          background: 'radial-gradient(circle at 40% 35%, #ffe08a, #ffb74d)',
+          border: '2px solid rgba(255,255,255,0.7)',
+          boxShadow: '0 8px 22px rgba(0,0,0,0.25)',
+          fontSize: 28,
+        }}
+        aria-label="Action"
+      >
+        ✋
+      </button>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "abe-website",
       "version": "1.0.0",
       "dependencies": {
+        "@react-three/drei": "^10.7.7",
+        "@react-three/fiber": "^9.6.1",
+        "@react-three/postprocessing": "^3.0.4",
         "@supabase/supabase-js": "^2.97.0",
         "appwrite": "^24.1.1",
         "csv-parse": "^6.2.1",
@@ -17,13 +20,15 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-intersection-observer": "^10.0.3",
-        "react-router-dom": "^7.9.6"
+        "react-router-dom": "^7.9.6",
+        "three": "^0.170.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.2.2",
         "@types/node": "^22.14.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@types/three": "^0.170.0",
         "@vitejs/plugin-react": "^5.0.0",
         "autoprefixer": "^10.4.27",
         "express": "^5.2.1",
@@ -280,6 +285,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -822,6 +836,24 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
     "node_modules/@puppeteer/browsers": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
@@ -855,6 +887,120 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@react-three/drei": {
+      "version": "10.7.7",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.7.tgz",
+      "integrity": "sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^3.1.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.8.3",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.4",
+        "tunnel-rat": "^0.1.2",
+        "use-sync-external-store": "^1.4.0",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19",
+        "react-dom": "^19",
+        "three": ">=0.159"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
+      "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.27.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=19 <19.3",
+        "react-dom": ">=19 <19.3",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/postprocessing": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@react-three/postprocessing/-/postprocessing-3.0.4.tgz",
+      "integrity": "sha512-e4+F5xtudDYvhxx3y0NtWXpZbwvQ0x1zdOXWTbXMK6fFLVDd4qucN90YaaStanZGS4Bd5siQm0lGL/5ogf8iDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "maath": "^0.6.0",
+        "n8ao": "^1.9.4",
+        "postprocessing": "^6.36.6"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19.0",
+        "three": ">= 0.156.0"
+      }
+    },
+    "node_modules/@react-three/postprocessing/node_modules/maath": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.6.0.tgz",
+      "integrity": "sha512-dSb2xQuP7vDnaYqfoKzlApeRcR2xtN8/f7WV/TMAkBC8552TwTLtOO0JTcSygkYMjNDPoo6V01jTw/aPi4JrMw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.144.0",
+        "three": ">=0.144.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1572,6 +1718,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1617,6 +1769,12 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1633,6 +1791,12 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/phoenix": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
@@ -1643,7 +1807,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1658,6 +1821,41 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-CUm2uckq+zkCY7ZbFpviRttY+6f9fvwm6YqSqPfA5K22s9w7R4VnA3rzJse8kHVvuzLcTx+CjNCs2NYe0QFAyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -1677,6 +1875,24 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1699,6 +1915,12 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.71",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.71.tgz",
+      "integrity": "sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -1924,6 +2146,26 @@
         "bare-path": "^3.0.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -1942,6 +2184,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/bignumber.js": {
@@ -2012,6 +2263,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -2071,6 +2346,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.2.tgz",
+      "integrity": "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2224,11 +2512,42 @@
         }
       }
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/csv-parse": {
@@ -2290,6 +2609,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2306,6 +2634,12 @@
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2675,6 +3009,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -2886,6 +3226,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2931,6 +3277,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -3007,6 +3359,32 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3074,6 +3452,24 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -3145,6 +3541,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -3434,6 +3839,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3476,6 +3891,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
@@ -3532,6 +3962,16 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/n8ao": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/n8ao/-/n8ao-1.10.2.tgz",
+      "integrity": "sha512-gh4i0xFP8DiRaNoX75kPiG3kGl7PmX9SW/OIn3Sv/YZmHrA8faLdSU1MM6M4gKtfKpxDnZagodu8FKob5URCVw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "postprocessing": ">=6.30.0",
+        "three": ">=0.137"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -3707,6 +4147,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
@@ -3781,6 +4230,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/postprocessing": {
+      "version": "6.39.1",
+      "resolved": "https://registry.npmjs.org/postprocessing/-/postprocessing-6.39.1.tgz",
+      "integrity": "sha512-R2dG2zy+BAx3USl5EHw+PvnrlbT5PKnZVp3se0HCR0pWH8WQdh742yNG4YWOsq6c0bFpffk0Gd2RqPeoP/wKng==",
+      "license": "Zlib",
+      "peerDependencies": {
+        "three": ">= 0.168.0 < 0.185.0"
+      }
+    },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -3790,6 +4254,22 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
+      }
+    },
+    "node_modules/promise-worker-transferable/node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -4020,11 +4500,35 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4195,6 +4699,27 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -4333,6 +4858,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -4381,6 +4926,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
       }
     },
     "node_modules/tailwindcss": {
@@ -4452,6 +5006,44 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.8.3.tgz",
+      "integrity": "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4478,6 +5070,36 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/troika-three-text": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -4989,6 +5611,43 @@
         "@esbuild/win32-x64": "0.27.7"
       }
     },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -5070,6 +5729,24 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/vary": {
@@ -5163,6 +5840,32 @@
       "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -5275,6 +5978,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.6.1",
+    "@react-three/postprocessing": "^3.0.4",
     "@supabase/supabase-js": "^2.97.0",
     "appwrite": "^24.1.1",
     "csv-parse": "^6.2.1",
@@ -20,13 +23,15 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-intersection-observer": "^10.0.3",
-    "react-router-dom": "^7.9.6"
+    "react-router-dom": "^7.9.6",
+    "three": "^0.170.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.2",
     "@types/node": "^22.14.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@types/three": "^0.170.0",
     "@vitejs/plugin-react": "^5.0.0",
     "autoprefixer": "^10.4.27",
     "express": "^5.2.1",

--- a/pages/BelusWorld.tsx
+++ b/pages/BelusWorld.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import BelusWorldGame from '../components/game/BelusWorld';
+
+const BelusWorld: React.FC = () => {
+  return (
+    <div className="min-h-screen">
+      <BelusWorldGame />
+    </div>
+  );
+};
+
+export default BelusWorld;

--- a/pages/Dashboard.tsx
+++ b/pages/Dashboard.tsx
@@ -397,13 +397,14 @@ const Dashboard: React.FC = () => {
         
         // Always Visible (at the end)
         { id: 'buddy-up', label: 'Summer Buddy Up', icon: Users, role: 'all', path: '/circle-of-friends?tab=summer-buddy-up' },
+        { id: 'belus-world', label: "Belu's World", icon: Gamepad2, role: 'all', path: '/belus-world' },
         { id: 'wheel', label: 'Wheel of Fun', icon: Star, role: 'all' },
         { id: 'blockcraft', label: "Aaria's Block Craft 3D", icon: Gamepad2, role: 'all' },
         { id: 'roadsafety', label: 'Road Safety Heroes', icon: Bike, role: 'all' },
         { id: 'doughlab', label: 'Dough Lab', icon: Cookie, role: 'all' },
     ].filter(item => {
         // Special case for the games/fun sections and buddy-up - always show
-        if (item.id === 'wheel' || item.id === 'blockcraft' || item.id === 'roadsafety' || item.id === 'doughlab' || item.id === 'buddy-up') return true;
+        if (item.id === 'wheel' || item.id === 'blockcraft' || item.id === 'roadsafety' || item.id === 'doughlab' || item.id === 'buddy-up' || item.id === 'belus-world') return true;
         
         // For Board members: only show management tools and designated donor paths
         // For Board members: show management tools AND global views (Overview, Wheel, etc.)


### PR DESCRIPTION
## Belu's World 🐘

A 3D floating-island adventure for kids on the autism spectrum, embedded at **/belus-world** and linked from the Dashboard sidebar.

### What's in it
- **Real 3D world** (react-three-fiber): walk/jump Belu the blue elephant across magical sky islands joined by rainbow bridges. WASD/arrows + jump on desktop, touch joystick on mobile. The 3D canvas is **lazy-loaded** so it never weighs down the rest of the site.
- **4 ASD skill areas, each with 5 evidence-based levels**: Reading Emotions, Expressive Language, Life Skills, Self-Regulation. Errorless / no-fail / no-timers, First→Then boards, literal instructions.
- **Visible progress kids strive for**: Belu *grows up* (baby→grown), islands visibly *bloom*, and a Growth Map dashboard with stars + sticker gallery.
- **Accessibility**: read-aloud narration (Web Speech), gentle synthesized chimes, and full sensory comfort settings (Calm mode, Reduce motion, Sounds, Read-aloud).
- **Performance-tuned**: capped device-pixel-ratio with an auto-scaler, single shadow caster, lightweight bloom.

### Dashboard
Adds a "Belu's World" entry to the Dashboard sidebar (always visible), alongside the other games.

### Verification
- `npx tsc --noEmit` — clean
- `npx vite build` — succeeds (3D bundle is a lazy chunk)

Design is grounded in 3 web-research passes on evidence-based ASD game design (see project notes): positive-only predictable rewards, avatar-growth motivation, world-bloom progression; avoids leaderboards, random rewards, and overstimulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)