### PR TITLE
Belu's World: guidance panel, fullscreen, solid mountain

### DIFF
--- a/components/game/BelusWorld/index.tsx
+++ b/components/game/BelusWorld/index.tsx
@@ -19,6 +19,7 @@ import { attachKeyboard } from './three/input';
 import HUD from './ui/HUD';
 import TouchControls from './ui/TouchControls';
 import GrowthMap from './ui/GrowthMap';
+import type { QuestStatus } from './three/quest/QuestLayer';
 import {
   loadMemory,
   saveMemory,
@@ -77,6 +78,7 @@ export default function BelusWorldGame() {
   const [emotion, setEmotion] = useState<BeluEmotion>('happy');
   const [beluLine, setBeluLine] = useState<string | null>(null);
   const [nearZone, setNearZone] = useState<ZoneId | null>(null);
+  const [questStatus, setQuestStatus] = useState<QuestStatus | null>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [showMap, setShowMap] = useState(false);
   const [reward, setReward] = useState<RewardInfo | null>(null);
@@ -87,6 +89,7 @@ export default function BelusWorldGame() {
     narration: true,
   });
 
+  const rootRef = useRef<HTMLDivElement>(null);
   const lineTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const settingsRef = useRef(settings);
   settingsRef.current = settings;
@@ -145,6 +148,13 @@ export default function BelusWorldGame() {
     playSound(kind, settingsRef.current.sound);
   }, []);
 
+  const toggleFullscreen = useCallback(() => {
+    const el = rootRef.current;
+    if (!el) return;
+    if (document.fullscreenElement) document.exitFullscreen?.();
+    else el.requestFullscreen?.().catch(() => {});
+  }, []);
+
   const handleQuestComplete = useCallback(
     (zone: ActivityZone, level: number, stars: number, moment: string) => {
       const res = awardLevel(progress, zone, level - 1, stars);
@@ -178,7 +188,7 @@ export default function BelusWorldGame() {
   }
 
   return (
-    <div className="relative h-screen w-full overflow-hidden" style={{ background: '#bfe2ff' }}>
+    <div ref={rootRef} className="relative h-screen w-full overflow-hidden bg-[#bfe2ff]">
       <Suspense fallback={<LoadingWorld />}>
         <GameCanvas
           emotion={emotion}
@@ -196,18 +206,26 @@ export default function BelusWorldGame() {
           setEmotion={setEmotion}
           playSound={sfx}
           onQuestComplete={handleQuestComplete}
+          onQuestStatus={setQuestStatus}
         />
       </Suspense>
 
       <HUD
         beluLine={beluLine}
-        nearZone={nearZone}
+        nearZone={questStatus ? null : nearZone}
         stickers={stickers}
         totalStars={totalStars(progress)}
         isTouch={isTouch.current}
         onOpenSettings={() => setShowSettings(true)}
         onOpenMap={() => setShowMap(true)}
+        onToggleFullscreen={toggleFullscreen}
       />
+
+      <AnimatePresence>
+        {questStatus && !showSettings && !showMap && reward === null && (
+          <QuestPanel status={questStatus} />
+        )}
+      </AnimatePresence>
 
       {!paused && <TouchControls />}
 
@@ -350,6 +368,67 @@ function LoadingWorld() {
       </motion.div>
       <p className="mt-4 text-lg font-bold text-sky-700">Floating up to the islands…</p>
     </div>
+  );
+}
+
+// The persistent "what to do right now" task card, pinned top-center. Keeps the
+// current question + progress on screen so the child always knows the next step.
+function QuestPanel({ status }: { status: QuestStatus }) {
+  const correct = status.phase === 'correct';
+  return (
+    <motion.div
+      key="questpanel"
+      initial={{ opacity: 0, y: -16 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -16 }}
+      className="pointer-events-none fixed left-1/2 top-20 z-30 w-[min(92vw,460px)] -translate-x-1/2"
+    >
+      <div
+        className="rounded-3xl px-5 py-3 text-center shadow-2xl backdrop-blur"
+        style={{
+          background: correct
+            ? 'linear-gradient(140deg,#eafff0,#ffffff)'
+            : `linear-gradient(140deg,#ffffff,${status.accent}22)`,
+          border: `2px solid ${correct ? '#69db7c' : status.accent}`,
+        }}
+      >
+        <div className="flex items-center justify-center gap-2 text-xs font-bold text-slate-500">
+          <span className="text-base">{status.emoji}</span>
+          <span>{status.title}</span>
+          <span className="text-slate-300">·</span>
+          <span>Level {status.level}</span>
+        </div>
+
+        {/* progress dots */}
+        <div className="mt-1 flex justify-center gap-1.5">
+          {Array.from({ length: status.total }).map((_, i) => (
+            <div
+              key={i}
+              className="h-2 rounded-full transition-all"
+              style={{
+                width: i === status.step ? 20 : 8,
+                background: i < status.step || correct ? '#69db7c' : i === status.step ? status.accent : '#d8e0ec',
+              }}
+            />
+          ))}
+        </div>
+
+        <motion.p
+          key={status.instruction}
+          initial={{ opacity: 0, scale: 0.96 }}
+          animate={{ opacity: 1, scale: 1 }}
+          className={`mt-2 font-extrabold ${correct ? 'text-green-600 text-xl' : 'text-slate-800 text-base'}`}
+        >
+          {correct ? '🎉 ' + status.instruction : status.instruction}
+        </motion.p>
+
+        {!correct && (
+          <p className="mt-1 text-xs font-semibold text-slate-500">
+            Walk Belu into the matching glowing orb 🫧 (or tap it)
+          </p>
+        )}
+      </div>
+    </motion.div>
   );
 }
 

--- a/components/game/BelusWorld/three/GameCanvas.tsx
+++ b/components/game/BelusWorld/three/GameCanvas.tsx
@@ -15,7 +15,7 @@ import { EffectComposer, Bloom } from '@react-three/postprocessing';
 import * as THREE from 'three';
 import Player, { type PlayerHandle } from './Player';
 import World from './World';
-import QuestLayer from './quest/QuestLayer';
+import QuestLayer, { type QuestStatus } from './quest/QuestLayer';
 import { PLAYER_SPAWN, type ZoneId } from './worldConfig';
 import type { BeluEmotion } from '../BeluCharacter';
 import type { ActivityZone } from '../belu/progress';
@@ -41,6 +41,7 @@ interface Props {
   setEmotion: (e: BeluEmotion) => void;
   playSound: (kind: Sound) => void;
   onQuestComplete: (zone: ActivityZone, level: number, stars: number, moment: string) => void;
+  onQuestStatus: (s: QuestStatus | null) => void;
 }
 
 function Lighting({ calmMode }: { calmMode: boolean }) {
@@ -85,6 +86,7 @@ export default function GameCanvas({
   setEmotion,
   playSound,
   onQuestComplete,
+  onQuestStatus,
 }: Props) {
   const player = useRef<PlayerHandle>(null);
   // start at a safe-ish ratio and let the monitor scale it to the device
@@ -149,6 +151,7 @@ export default function GameCanvas({
           setEmotion={setEmotion}
           playSound={playSound}
           onComplete={onQuestComplete}
+          onStatus={onQuestStatus}
         />
       </Suspense>
 

--- a/components/game/BelusWorld/three/Player.tsx
+++ b/components/game/BelusWorld/three/Player.tsx
@@ -14,7 +14,7 @@ import Belu3D, { type MotionRef } from './Belu3D';
 import { sampleGround } from './worldMath';
 import { input } from './input';
 import { beluPos, beluState } from './playerState';
-import { ISLANDS, ZONE_ISLANDS, INTERACT_RADIUS, PLAYER_SPAWN, type ZoneId } from './worldConfig';
+import { ISLANDS, ZONE_ISLANDS, INTERACT_RADIUS, PLAYER_SPAWN, OBSTACLES, type ZoneId } from './worldConfig';
 import type { BeluEmotion } from '../BeluCharacter';
 
 const SPEED = 7.5;
@@ -90,6 +90,17 @@ const Player = forwardRef<PlayerHandle, Props>(function Player(
 
     pos.current.x += vel.current.x * dt;
     pos.current.z += vel.current.z * dt;
+
+    // ---- solid obstacles (walk around, not through) ----
+    for (const o of OBSTACLES) {
+      const dx = pos.current.x - o.x;
+      const dz = pos.current.z - o.z;
+      const d = Math.hypot(dx, dz);
+      if (d < o.r && d > 1e-4) {
+        pos.current.x = o.x + (dx / d) * o.r;
+        pos.current.z = o.z + (dz / d) * o.r;
+      }
+    }
 
     // ---- jump + gravity ----
     if (input.jumpQueued) {

--- a/components/game/BelusWorld/three/quest/QuestLayer.tsx
+++ b/components/game/BelusWorld/three/quest/QuestLayer.tsx
@@ -94,6 +94,18 @@ interface State {
   sayAt: number;
 }
 
+export interface QuestStatus {
+  zone: ActivityZone;
+  title: string;
+  emoji: string;
+  accent: string;
+  level: number;
+  instruction: string;
+  step: number;
+  total: number;
+  phase: 'question' | 'correct';
+}
+
 interface Props {
   islandNextLevel: Record<ActivityZone, number>;
   paused: boolean;
@@ -103,6 +115,7 @@ interface Props {
   setEmotion: (e: BeluEmotion) => void;
   playSound: (kind: 'tap' | 'correct' | 'star' | 'levelup' | 'growup') => void;
   onComplete: (zone: ActivityZone, level: number, stars: number, moment: string) => void;
+  onStatus: (s: QuestStatus | null) => void;
 }
 
 export default function QuestLayer(props: Props) {
@@ -130,6 +143,22 @@ export default function QuestLayer(props: Props) {
     S.current.wrongIdx = -1;
   }
 
+  // tell the DOM HUD what the player should be doing right now (persistent card)
+  function emitStatus(phase: 'question' | 'correct', instruction: string) {
+    const z = S.current.zone;
+    if (!z) {
+      props.onStatus(null);
+      return;
+    }
+    const q = getQuest(z, S.current.level);
+    const isl = ISLANDS[z];
+    props.onStatus({
+      zone: z, title: isl.label, emoji: isl.emoji, accent: isl.accent,
+      level: S.current.level, instruction, step: S.current.roundIdx,
+      total: q.rounds.length, phase,
+    });
+  }
+
   function startQuest(zone: ActivityZone) {
     const level = props.islandNextLevel[zone];
     const q = getQuest(zone, level);
@@ -145,6 +174,7 @@ export default function QuestLayer(props: Props) {
     props.speak(q.intro);
     S.current.pendingSay = q.rounds[0].say;
     S.current.sayAt = S.current.clock + 2.6;
+    emitStatus('question', q.rounds[0].say);
     bump();
   }
 
@@ -153,6 +183,7 @@ export default function QuestLayer(props: Props) {
     resetRound();
     S.current.pendingSay = null;
     props.setEmotion('happy');
+    props.onStatus(null);
     bump();
   }
 
@@ -167,6 +198,7 @@ export default function QuestLayer(props: Props) {
     S.current.zone = null;
     resetRound();
     S.current.pendingSay = null;
+    props.onStatus(null);
     bump();
   }
 
@@ -181,6 +213,7 @@ export default function QuestLayer(props: Props) {
     resetRound();
     props.setEmotion(q.rounds[next].kind === 'breathe' ? 'calm' : 'curious');
     props.speak(q.rounds[next].say);
+    emitStatus('question', q.rounds[next].say);
     bump();
   }
 
@@ -189,6 +222,7 @@ export default function QuestLayer(props: Props) {
     props.setEmotion('excited');
     props.playSound('star');
     if (line) props.speak(line);
+    emitStatus('correct', line ?? 'Yes! You got it!');
     S.current.advanceAt = S.current.clock + 1.0;
     S.current.lockUntil = S.current.clock + 1.0;
     bump();

--- a/components/game/BelusWorld/three/worldConfig.ts
+++ b/components/game/BelusWorld/three/worldConfig.ts
@@ -117,3 +117,17 @@ export const ZONE_ISLANDS: ZoneId[] = ['meadow', 'mountain', 'cove', 'forest'];
 export const INTERACT_RADIUS = 4.5;
 
 export const PLAYER_SPAWN = { x: 0, y: 0.4, z: 6 };
+
+// Solid things Belu can't walk through (horizontal keep-out cylinders). The
+// Morning Mountain peak is a real landmark — Belu walks AROUND it, not through.
+// World.tsx renders the peak at this same spot, so visuals and collision agree.
+export interface Obstacle {
+  x: number;
+  z: number;
+  r: number;
+}
+export const OBSTACLES: Obstacle[] = (() => {
+  const m = ISLANDS.mountain;
+  const len = Math.hypot(m.cx, m.cz) || 1;
+  return [{ x: m.cx + (m.cx / len) * 6.5, z: m.cz + (m.cz / len) * 6.5, r: 3.0 }];
+})();

--- a/components/game/BelusWorld/ui/HUD.tsx
+++ b/components/game/BelusWorld/ui/HUD.tsx
@@ -16,9 +16,10 @@ interface Props {
   isTouch: boolean;
   onOpenSettings: () => void;
   onOpenMap: () => void;
+  onToggleFullscreen: () => void;
 }
 
-export default function HUD({ beluLine, nearZone, stickers, totalStars, isTouch, onOpenSettings, onOpenMap }: Props) {
+export default function HUD({ beluLine, nearZone, stickers, totalStars, isTouch, onOpenSettings, onOpenMap, onToggleFullscreen }: Props) {
   const zoneMeta = nearZone && nearZone !== 'home' ? ISLANDS[nearZone] : null;
 
   return (
@@ -65,6 +66,14 @@ export default function HUD({ beluLine, nearZone, stickers, totalStars, isTouch,
           aria-label="Growth map"
         >
           🗺️
+        </button>
+        <button
+          onClick={onToggleFullscreen}
+          className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg shadow-lg backdrop-blur transition hover:bg-white"
+          aria-label="Full screen"
+          title="Full screen"
+        >
+          ⛶
         </button>
         <button
           onClick={onOpenSettings}


### PR DESCRIPTION
Follow-up to #98 from owner playtest feedback.

- **Quest guidance panel** (top-center, persistent): current question + progress dots + "walk into the matching orb" hint, and a clear "Yes! You got it!" on correct. Fixes the "it says you got it but I don't know what happens next" confusion.
- **Fullscreen option** — a ⛶ button in the HUD (Fullscreen API), which also sidesteps the site-nav overlap.
- **Solid Morning Mountain** — the peak is now a real obstacle (shared `OBSTACLES` keep-out resolved in the Player controller); Belu walks around it instead of through it. It's the island's landmark for the Life-Skills zone.

Verified: `tsc` + `vite build` clean; headless checks confirm the panel renders, the fullscreen button exists, and Belu is pushed to the peak edge (r=3.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)