### PR TITLE
Belu's World: fix blank answer orbs (labels hidden inside spheres)

### DIFF
--- a/components/game/BelusWorld/three/quest/AnswerOrb.tsx
+++ b/components/game/BelusWorld/three/quest/AnswerOrb.tsx
@@ -87,7 +87,7 @@ export default function AnswerOrb({ position, emoji, caption, color, status, bob
         onPointerOver={() => (document.body.style.cursor = 'pointer')}
         onPointerOut={() => (document.body.style.cursor = 'auto')}
       >
-        <sphereGeometry args={[0.95, 24, 18]} />
+        <sphereGeometry args={[0.85, 24, 18]} />
         <meshStandardMaterial
           color={color}
           emissive={color}
@@ -95,12 +95,13 @@ export default function AnswerOrb({ position, emoji, caption, color, status, bob
           roughness={0.25}
           metalness={0.1}
           transparent
-          opacity={0.55}
+          opacity={0.4}
+          depthWrite={false}
         />
       </mesh>
-      {/* picture + word, always facing the camera */}
-      <sprite position={[0, 0, 0]} scale={[1.7, 1.7, 1]}>
-        <spriteMaterial map={tex} transparent depthWrite={false} />
+      {/* picture + word — always on top of the bubble & facing the camera */}
+      <sprite position={[0, 0, 0]} scale={[1.9, 1.9, 1]} renderOrder={10}>
+        <spriteMaterial map={tex} transparent depthWrite={false} depthTest={false} />
       </sprite>
       {/* soft glow ring under it on the ground */}
       <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -1.05, 0]}>

--- a/components/game/BelusWorld/three/quest/BreatheOrb.tsx
+++ b/components/game/BelusWorld/three/quest/BreatheOrb.tsx
@@ -103,8 +103,8 @@ export default function BreatheOrb({ position, cycles, color, reduceMotion, onDo
           opacity={0.5}
         />
       </mesh>
-      <sprite ref={labelRef} position={[0, 2.6, 0]} scale={[2.4, 2.4, 1]}>
-        <spriteMaterial map={textures[0]} transparent depthWrite={false} />
+      <sprite ref={labelRef} position={[0, 2.6, 0]} scale={[2.4, 2.4, 1]} renderOrder={10}>
+        <spriteMaterial map={textures[0]} transparent depthWrite={false} depthTest={false} />
       </sprite>
       <pointLight color={color} intensity={2} distance={10} />
     </group>

--- a/components/game/BelusWorld/three/quest/QuestNPC.tsx
+++ b/components/game/BelusWorld/three/quest/QuestNPC.tsx
@@ -109,16 +109,16 @@ export default function QuestNPC({ position, face, mood, color, thought, beckon,
           <meshStandardMaterial color={color} roughness={0.7} />
         </mesh>
         {/* face */}
-        <sprite position={[0, 0.7, 0.62]} scale={[0.85, 0.85, 1]}>
-          <spriteMaterial map={faceTex} transparent depthWrite={false} />
+        <sprite position={[0, 0.7, 0.62]} scale={[0.95, 0.95, 1]} renderOrder={11}>
+          <spriteMaterial map={faceTex} transparent depthWrite={false} depthTest={false} />
         </sprite>
       </group>
 
       {/* thought bubble */}
       {thoughtTex && (
         <group position={[0.6, 2.0, 0]}>
-          <sprite scale={[1.5, 1.5, 1]}>
-            <spriteMaterial map={thoughtTex} transparent depthWrite={false} />
+          <sprite scale={[1.5, 1.5, 1]} renderOrder={12}>
+            <spriteMaterial map={thoughtTex} transparent depthWrite={false} depthTest={false} />
           </sprite>
           <mesh position={[-0.55, -0.7, 0]}>
             <sphereGeometry args={[0.12, 12, 10]} />


### PR DESCRIPTION
**Critical playability fix.** The answer orbs were rendering completely blank (no picture, no word) — and NPC faces too — which made the game unreadable and feel worse than flashcards (you couldn't tell the orbs apart).

**Cause:** the emoji+word label sprite was positioned at the orb's centre, so the translucent sphere's surface depth-occluded it (the label was hidden *inside* the ball).

**Fix:** labels render on top (`depthTest:false` + `renderOrder`), sphere opacity 0.55→0.4 with `depthWrite:false`, label slightly larger. Applied to answer orbs, NPC faces, thought bubbles, and the breathing cue.

Verified by screenshot: orbs now clearly show ⚽ "ball", 👟 "shoes", 😊 feeling faces, etc. `tsc` + `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)