### PR TITLE
Belu's World: Feelings Meadow = caring play (not a quiz) + menu fullscreen

### DIFF
--- a/components/game/BelusWorld/index.tsx
+++ b/components/game/BelusWorld/index.tsx
@@ -149,10 +149,13 @@ export default function BelusWorldGame() {
   }, []);
 
   const toggleFullscreen = useCallback(() => {
-    const el = rootRef.current;
-    if (!el) return;
-    if (document.fullscreenElement) document.exitFullscreen?.();
-    else el.requestFullscreen?.().catch(() => {});
+    if (document.fullscreenElement) {
+      document.exitFullscreen?.();
+      return;
+    }
+    // rootRef exists in the world; on the intro menu fall back to the whole page
+    const el = rootRef.current ?? document.documentElement;
+    el.requestFullscreen?.().catch(() => {});
   }, []);
 
   const handleQuestComplete = useCallback(
@@ -184,7 +187,7 @@ export default function BelusWorldGame() {
   );
 
   if (phase === 'intro') {
-    return <IntroScreen memory={memory} growthLabel={growth.label} onStart={start} />;
+    return <IntroScreen memory={memory} growthLabel={growth.label} onStart={start} onToggleFullscreen={toggleFullscreen} />;
   }
 
   return (
@@ -249,7 +252,7 @@ export default function BelusWorldGame() {
 
 // ---------------------------------------------------------------------------
 
-function IntroScreen({ memory, growthLabel, onStart }: { memory: BeluMemory; growthLabel: string; onStart: () => void }) {
+function IntroScreen({ memory, growthLabel, onStart, onToggleFullscreen }: { memory: BeluMemory; growthLabel: string; onStart: () => void; onToggleFullscreen: () => void }) {
   const returning = memory.visitCount > 0;
   return (
     <div
@@ -348,6 +351,17 @@ function IntroScreen({ memory, growthLabel, onStart }: { memory: BeluMemory; gro
         className="mt-7 rounded-full bg-gradient-to-b from-amber-400 to-orange-500 px-12 py-4 text-2xl font-black text-white shadow-xl"
       >
         {returning ? 'Continue ✨' : 'Calling all friends of Aaria ✨'}
+      </motion.button>
+
+      <motion.button
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.7 }}
+        whileTap={{ scale: 0.95 }}
+        onClick={onToggleFullscreen}
+        className="mt-3 rounded-full border-2 border-sky-300 bg-white/70 px-7 py-2.5 text-base font-bold text-sky-700 shadow-md"
+      >
+        ⛶ Full Screen
       </motion.button>
 
       <p className="mt-5 text-sm font-medium text-sky-900/50">

--- a/components/game/BelusWorld/index.tsx
+++ b/components/game/BelusWorld/index.tsx
@@ -424,7 +424,7 @@ function QuestPanel({ status }: { status: QuestStatus }) {
 
         {!correct && (
           <p className="mt-1 text-xs font-semibold text-slate-500">
-            Walk Belu into the matching glowing orb 🫧 (or tap it)
+            {status.hint ?? 'Walk Belu into the matching glowing orb 🫧 (or tap it)'}
           </p>
         )}
       </div>

--- a/components/game/BelusWorld/three/GameCanvas.tsx
+++ b/components/game/BelusWorld/three/GameCanvas.tsx
@@ -16,6 +16,7 @@ import * as THREE from 'three';
 import Player, { type PlayerHandle } from './Player';
 import World from './World';
 import QuestLayer, { type QuestStatus } from './quest/QuestLayer';
+import StoryLayer from './quest/StoryLayer';
 import { PLAYER_SPAWN, type ZoneId } from './worldConfig';
 import type { BeluEmotion } from '../BeluCharacter';
 import type { ActivityZone } from '../belu/progress';
@@ -142,8 +143,20 @@ export default function GameCanvas({
           growthScale={growthScale}
           growthStage={growthStage}
         />
+        {/* Feelings Meadow is caring-play (StoryLayer); the other islands use
+            the quest/orb layer. */}
+        <StoryLayer
+          level={islandNextLevel.meadow}
+          paused={paused}
+          speak={speak}
+          setEmotion={setEmotion}
+          playSound={playSound}
+          onComplete={onQuestComplete}
+          onStatus={onQuestStatus}
+        />
         <QuestLayer
           islandNextLevel={islandNextLevel}
+          zones={['mountain', 'cove', 'forest']}
           paused={paused}
           reduceMotion={reduceMotion}
           sound={sound}

--- a/components/game/BelusWorld/three/quest/QuestLayer.tsx
+++ b/components/game/BelusWorld/three/quest/QuestLayer.tsx
@@ -21,7 +21,7 @@ import AnswerOrb, { type OrbStatus } from './AnswerOrb';
 import QuestNPC, { type Mood } from './QuestNPC';
 import BreatheOrb from './BreatheOrb';
 
-const ZONES: ActivityZone[] = ['meadow', 'mountain', 'cove', 'forest'];
+const ALL_ZONES: ActivityZone[] = ['meadow', 'mountain', 'cove', 'forest'];
 
 // idle "host" friends so each island feels inhabited before you arrive
 const HOSTS: Record<ActivityZone, { face: string; mood: Mood }> = {
@@ -104,6 +104,8 @@ export interface QuestStatus {
   step: number;
   total: number;
   phase: 'question' | 'correct';
+  /** optional override for the small hint line under the instruction */
+  hint?: string;
 }
 
 interface Props {
@@ -116,11 +118,14 @@ interface Props {
   playSound: (kind: 'tap' | 'correct' | 'star' | 'levelup' | 'growup') => void;
   onComplete: (zone: ActivityZone, level: number, stars: number, moment: string) => void;
   onStatus: (s: QuestStatus | null) => void;
+  /** which islands this layer owns (others are handled elsewhere, e.g. StoryLayer) */
+  zones?: ActivityZone[];
 }
 
 export default function QuestLayer(props: Props) {
   const [, force] = useState(0);
   const bump = () => force((v) => (v + 1) % 1_000_000);
+  const zones = props.zones ?? ALL_ZONES;
 
   const S = useRef<State>({
     clock: 0, zone: null, level: 1, roundIdx: 0, slips: 0,
@@ -312,7 +317,7 @@ export default function QuestLayer(props: Props) {
     // which zone island is Belu standing on?
     let onZone: ActivityZone | null = null;
     let onDist = Infinity;
-    for (const z of ZONES) {
+    for (const z of zones) {
       const isl = ISLANDS[z];
       const d = Math.hypot(beluPos.x - isl.cx, beluPos.z - isl.cz);
       if (d < isl.radius * 0.82 && d < onDist) {
@@ -397,7 +402,7 @@ export default function QuestLayer(props: Props) {
       <Ticker fnRef={frame} />
 
       {/* idle host friends on islands you're not currently questing */}
-      {ZONES.map((z) => {
+      {zones.map((z) => {
         if (S.current.zone === z) return null;
         const p = npcPosition(z);
         const host = HOSTS[z];

--- a/components/game/BelusWorld/three/quest/StoryLayer.tsx
+++ b/components/game/BelusWorld/three/quest/StoryLayer.tsx
@@ -1,0 +1,242 @@
+// ---------------------------------------------------------------------------
+// Feelings Meadow as CARING PLAY (no questions, no orbs).
+//
+// Friends sit under weather clouds that show their feeling. The child walks
+// Belu up to a friend and just stays close — Belu comforts them, their cloud
+// clears (🌧️→🌥️→☀️), flowers burst open, and they cheer. Help everyone and the
+// whole meadow blooms. Pure cause-and-effect kindness; the feeling is read by
+// seeing the cloud + body language and hearing Belu name it.
+// ---------------------------------------------------------------------------
+
+import { useRef, useState } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { Sparkles } from '@react-three/drei';
+import * as THREE from 'three';
+import { ISLANDS } from '../worldConfig';
+import { beluPos } from '../playerState';
+import type { BeluEmotion } from '../../BeluCharacter';
+import QuestNPC from './QuestNPC';
+import { Flower } from '../Scenery';
+import { makeLabelTexture } from './emojiTexture';
+import { MEADOW_STORY } from './storyContent';
+import type { QuestStatus } from './QuestLayer';
+
+const ZONE = 'meadow' as const;
+const CARE_RADIUS = 2.4; // how close Belu must be to comfort a friend
+const CARE_STEP = 0.7; // seconds between each cloud-clearing step
+
+interface FriendRT {
+  careStage: number; // 0..clouds.length-1 ; last = sunny/healed
+  healed: boolean;
+  named: boolean;
+  lastCareAt: number;
+  healedAt: number;
+}
+
+interface Props {
+  level: number;
+  paused: boolean;
+  speak: (line: string) => void;
+  setEmotion: (e: BeluEmotion) => void;
+  playSound: (kind: 'tap' | 'correct' | 'star' | 'levelup' | 'growup') => void;
+  onComplete: (zone: 'meadow', level: number, stars: number, moment: string) => void;
+  onStatus: (s: QuestStatus | null) => void;
+}
+
+interface State {
+  clock: number;
+  active: boolean;
+  level: number;
+  friends: FriendRT[];
+  helped: number;
+  disarmed: boolean;
+  pendingSayAt: number;
+  pendingSay: string | null;
+  finishAt: number; // >0 → complete the level at this clock time (lets the last bloom show)
+}
+
+function freshFriends(level: number): FriendRT[] {
+  const lvl = MEADOW_STORY[Math.max(0, Math.min(MEADOW_STORY.length - 1, level - 1))];
+  return lvl.friends.map(() => ({ careStage: 0, healed: false, named: false, lastCareAt: -99, healedAt: -99 }));
+}
+
+export default function StoryLayer(props: Props) {
+  const [, force] = useState(0);
+  const bump = () => force((v) => (v + 1) % 1_000_000);
+  const S = useRef<State>({
+    clock: 0, active: false, level: props.level, friends: freshFriends(props.level),
+    helped: 0, disarmed: false, pendingSayAt: 0, pendingSay: null, finishAt: 0,
+  });
+  const frame = useRef<(dt: number) => void>(() => {});
+
+  const isl = ISLANDS[ZONE];
+  const lvlDef = MEADOW_STORY[Math.max(0, Math.min(MEADOW_STORY.length - 1, S.current.level - 1))];
+
+  function emitStatus(phase: 'question' | 'correct', instruction: string) {
+    props.onStatus({
+      zone: ZONE, title: isl.label, emoji: isl.emoji, accent: isl.accent,
+      level: S.current.level, instruction, step: S.current.helped,
+      total: lvlDef.friends.length, phase,
+      hint: phase === 'question' ? 'Walk up to a cloudy friend and stay close to help 💛' : undefined,
+    });
+  }
+
+  function startStory() {
+    S.current.active = true;
+    S.current.level = props.level;
+    S.current.friends = freshFriends(props.level);
+    S.current.helped = 0;
+    const lvl = MEADOW_STORY[Math.max(0, Math.min(MEADOW_STORY.length - 1, props.level - 1))];
+    props.setEmotion('curious');
+    props.speak(lvl.intro);
+    emitStatus('question', lvl.intro);
+    bump();
+  }
+
+  function stopStory() {
+    S.current.active = false;
+    props.setEmotion('happy');
+    props.onStatus(null);
+    bump();
+  }
+
+  function finish() {
+    const lvl = MEADOW_STORY[Math.max(0, Math.min(MEADOW_STORY.length - 1, S.current.level - 1))];
+    props.onComplete(ZONE, S.current.level, 3, lvl.moment);
+    props.speak(lvl.outro);
+    S.current.active = false;
+    S.current.disarmed = true;
+    props.onStatus(null);
+    bump();
+  }
+
+  frame.current = (dt: number) => {
+    const st = S.current;
+    if (props.paused) return;
+    st.clock += dt;
+
+    if (st.pendingSay && st.clock >= st.pendingSayAt) {
+      props.speak(st.pendingSay);
+      st.pendingSay = null;
+    }
+
+    if (st.finishAt > 0 && st.clock >= st.finishAt) {
+      st.finishAt = 0;
+      finish();
+      return;
+    }
+
+    const dCenter = Math.hypot(beluPos.x - isl.cx, beluPos.z - isl.cz);
+    const onIsland = dCenter < isl.radius * 0.82;
+
+    // re-arm after Belu wanders off a finished meadow
+    if (st.disarmed && dCenter > isl.radius + 1.5) {
+      st.disarmed = false;
+      bump();
+    }
+
+    if (!st.active) {
+      if (onIsland && !st.disarmed) startStory();
+      return;
+    }
+    if (dCenter > isl.radius + 1.5) {
+      stopStory();
+      return;
+    }
+
+    // comfort the nearest cloudy friend Belu is standing with
+    const defs = MEADOW_STORY[Math.max(0, Math.min(MEADOW_STORY.length - 1, st.level - 1))].friends;
+    for (let i = 0; i < defs.length; i++) {
+      const rt = st.friends[i];
+      if (rt.healed) continue;
+      const wx = isl.cx + defs[i].pos[0];
+      const wz = isl.cz + defs[i].pos[1];
+      const d = Math.hypot(beluPos.x - wx, beluPos.z - wz);
+      if (d > CARE_RADIUS) continue;
+
+      if (!rt.named) {
+        rt.named = true;
+        props.speak(`This friend feels ${defs[i].feeling}. Stay close — you're helping! 💛`);
+        props.setEmotion('curious');
+      }
+      if (st.clock - rt.lastCareAt >= CARE_STEP) {
+        rt.lastCareAt = st.clock;
+        rt.careStage += 1;
+        props.playSound('tap');
+        props.setEmotion('happy');
+        if (rt.careStage >= defs[i].clouds.length - 1) {
+          rt.healed = true;
+          rt.healedAt = st.clock;
+          st.helped += 1;
+          props.playSound('star');
+          props.setEmotion('excited');
+          emitStatus('correct', `Yay! Your ${defs[i].feeling} friend feels sunny now! ☀️`);
+          if (st.helped >= defs.length) st.finishAt = st.clock + 1.4; // let the last bloom show
+        } else {
+          emitStatus('question', `You're cheering up your ${defs[i].feeling} friend… keep going!`);
+        }
+        bump();
+      }
+      break; // only comfort one friend at a time
+    }
+  };
+
+  // ---- render ----
+  const defs = lvlDef.friends;
+  return (
+    <group>
+      <Ticker fnRef={frame} />
+      {defs.map((fr, i) => {
+        const rt = S.current.friends[i] ?? { careStage: 0, healed: false, healedAt: -99 };
+        const wx = isl.cx + fr.pos[0];
+        const wz = isl.cz + fr.pos[1];
+        const cloud = fr.clouds[Math.min(rt.careStage, fr.clouds.length - 1)];
+        const justHealed = rt.healed && S.current.clock - rt.healedAt < 2.5;
+        return (
+          <group key={`${S.current.level}-${i}`}>
+            <QuestNPC
+              position={[wx, isl.top, wz]}
+              face={fr.face}
+              mood={rt.healed ? 'happy' : fr.mood}
+              color={isl.accent}
+              beckon={!rt.healed && S.current.active}
+              seed={i * 1.7}
+            />
+            {/* weather cloud showing the feeling, above the friend */}
+            <CloudSprite emoji={cloud} position={[wx, isl.top + 2.1, wz]} />
+            {/* kindness bursts when a friend turns sunny */}
+            {justHealed && (
+              <Sparkles count={20} scale={3} size={6} speed={0.6} color="#ffd166" position={[wx, isl.top + 1.2, wz]} />
+            )}
+            {rt.healed && (
+              <>
+                <Flower position={[wx + 1.1, isl.top, wz + 0.6]} color="#ff8fc8" />
+                <Flower position={[wx - 1.0, isl.top, wz + 0.8]} color="#ffd166" />
+                <Flower position={[wx + 0.5, isl.top, wz - 1.1]} color="#a78bfa" />
+              </>
+            )}
+          </group>
+        );
+      })}
+    </group>
+  );
+}
+
+function CloudSprite({ emoji, position }: { emoji: string; position: [number, number, number] }) {
+  const tex = useRef<THREE.CanvasTexture>(makeLabelTexture(emoji));
+  // update texture when the emoji changes
+  if ((tex.current as unknown as { __e?: string }).__e !== emoji) {
+    tex.current = makeLabelTexture(emoji);
+    (tex.current as unknown as { __e?: string }).__e = emoji;
+  }
+  return (
+    <sprite position={position} scale={[1.5, 1.5, 1]} renderOrder={12}>
+      <spriteMaterial map={tex.current} transparent depthWrite={false} depthTest={false} />
+    </sprite>
+  );
+}
+
+function Ticker({ fnRef }: { fnRef: React.MutableRefObject<(dt: number) => void> }) {
+  useFrame((_, dt) => fnRef.current(Math.min(dt, 0.05)));
+  return null;
+}

--- a/components/game/BelusWorld/three/quest/storyContent.ts
+++ b/components/game/BelusWorld/three/quest/storyContent.ts
@@ -1,0 +1,102 @@
+// ---------------------------------------------------------------------------
+// Feelings Meadow — reshaped as CARING PLAY, not a quiz.
+//
+// Friends sit in the meadow under a little weather cloud that shows how they
+// feel (🌧️ sad, ⛈️ scared, ☁️ lonely, 🌥️ worried). There are no questions and
+// no right/wrong answers. The child simply walks Belu up to a friend and stays
+// with them — Belu comforts them, their cloud clears step by step into sunshine,
+// flowers burst open, and when every friend is sunny the whole meadow blooms.
+//
+// The learning (reading emotions) happens by SEEING the feeling and the body
+// language, hearing Belu name it, and watching kindness change their world.
+// ---------------------------------------------------------------------------
+
+import type { Mood } from './QuestNPC';
+
+export interface StoryFriend {
+  face: string;
+  /** kid-facing feeling word — Belu names it on approach */
+  feeling: string;
+  mood: Mood;
+  /** cloud stages from worst → sunny; last is always ☀️. careNeeded = stages-1 */
+  clouds: string[];
+  /** local position on the meadow (offset from the island centre, XZ) */
+  pos: [number, number];
+}
+
+export interface StoryLevel {
+  goal: string;
+  intro: string;
+  outro: string;
+  moment: string;
+  friends: StoryFriend[];
+}
+
+const RAIN = ['🌧️', '🌥️', '☀️'];
+const STORM = ['⛈️', '🌥️', '☀️'];
+const LONELY = ['☁️', '🌤️', '☀️'];
+const WORRY = ['🌥️', '🌤️', '☀️'];
+
+function f(face: string, feeling: string, mood: Mood, clouds: string[], x: number, z: number): StoryFriend {
+  return { face, feeling, mood, clouds, pos: [x, z] };
+}
+
+export const MEADOW_STORY: StoryLevel[] = [
+  {
+    goal: 'Cheer up 2 friends',
+    intro: "Some meadow friends feel cloudy today. Walk up close and Belu will help them feel better!",
+    outro: 'You made the whole meadow sunny! You are such a kind friend. ☀️',
+    moment: 'cheered up friends in the meadow',
+    friends: [
+      f('🐰', 'sad', 'sad', RAIN, -2, -1),
+      f('🦊', 'scared', 'scared', STORM, 3, 1),
+    ],
+  },
+  {
+    goal: 'Help 3 friends feel sunny',
+    intro: "More friends feel cloudy. Go be with each one until their sunshine comes back!",
+    outro: 'Every friend is smiling now. You helped the sun come out! 🌈',
+    moment: 'cheered up friends in the meadow',
+    friends: [
+      f('🐻', 'sad', 'sad', RAIN, -3, 2),
+      f('🐥', 'scared', 'scared', STORM, 3, -2),
+      f('🐰', 'lonely', 'sad', LONELY, 0, 3),
+    ],
+  },
+  {
+    goal: 'Warm up 3 cloudy friends',
+    intro: "Look at how each friend's body looks. Stay close and help their cloud clear away.",
+    outro: 'You noticed how everyone felt and helped. The meadow is glowing! ☀️',
+    moment: 'cheered up friends in the meadow',
+    friends: [
+      f('🦊', 'worried', 'disappointed', WORRY, -3, -2),
+      f('🐻', 'sad', 'sad', RAIN, 3, 2),
+      f('🐱', 'scared', 'scared', STORM, -2, 3),
+    ],
+  },
+  {
+    goal: 'Bring sunshine to 4 friends',
+    intro: "Lots of friends need a kind buddy today. Visit every one of them!",
+    outro: 'Four happy friends! You turned the whole sky sunny. 🌻',
+    moment: 'cheered up friends in the meadow',
+    friends: [
+      f('🐰', 'sad', 'sad', RAIN, -4, 0),
+      f('🐦', 'lonely', 'sad', LONELY, 4, 0),
+      f('🐻', 'worried', 'disappointed', WORRY, 0, -3),
+      f('🦊', 'scared', 'scared', STORM, 0, 3),
+    ],
+  },
+  {
+    goal: 'Be everyone’s kind friend',
+    intro: "The whole meadow is feeling big feelings. You know just what to do — go spread kindness!",
+    outro: 'You are the kindest friend in all the sky islands. The meadow is in full bloom! 🌷',
+    moment: 'spread kindness across the meadow',
+    friends: [
+      f('🐻', 'sad', 'sad', RAIN, -4, -2),
+      f('🐱', 'scared', 'scared', STORM, 4, -2),
+      f('🐰', 'lonely', 'sad', LONELY, -3, 3),
+      f('🦊', 'worried', 'disappointed', WORRY, 3, 3),
+      f('🐥', 'sad', 'sad', RAIN, 0, 0),
+    ],
+  },
+];


### PR DESCRIPTION
## Reshape: stop quizzing, start playing
Owner feedback: "instead of flashcards you have orbs — that's not innovation. Think like a kid." Fair. **Feelings Meadow** is rebuilt as cause-and-effect caring play, no questions and no orbs:

- Friends sit under **weather clouds** showing how they feel (🌧️ sad, ⛈️ scared, ☁️ lonely, 🌥️ worried) with matching body language.
- You **walk Belu up to a friend and stay close** → Belu comforts them → their cloud clears 🌧️→🌥️→☀️, flowers burst open, they cheer.
- Help everyone → the whole meadow blooms. Belu names each feeling on approach, so emotion-reading is taught by *seeing + helping*, never by answering.

New `StoryLayer` + `storyContent` (5 levels). `QuestLayer` takes a `zones` prop and skips the meadow; the other 3 islands keep the (fixed-label) orb model for now and will be reshaped next (forest = word-spells, mountain = do-the-routine, cove = calm-the-storm).

Also: **Full Screen button on the intro menu** (like Block Craft), in addition to the in-game one.

## Verify
`tsc` + `vite build` clean. Headless playtest completes Meadow L1 purely by walking up to friends (no orbs) → 3 stars persisted; intro Full Screen button confirmed present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)