### PR TITLE
Belu's World: 3D animals, observe-and-help play, cosmetic rewards, fullscreen overlay

### DIFF
--- a/components/game/BelusWorld/belu/progress.ts
+++ b/components/game/BelusWorld/belu/progress.ts
@@ -21,10 +21,43 @@ export interface IslandProgress {
   levelStars: number[];
 }
 
+export type CosmeticSlot = 'head' | 'face' | 'back';
+export interface Cosmetic {
+  id: string;
+  name: string;
+  icon: string;
+  slot: CosmeticSlot;
+}
+/** Everything Belu can wear. Earned one per completed level (UNLOCK_ORDER). */
+export const COSMETICS: Cosmetic[] = [
+  { id: 'cap', name: 'Explorer Cap', icon: '🧢', slot: 'head' },
+  { id: 'bow', name: 'Cute Bow', icon: '🎀', slot: 'head' },
+  { id: 'party', name: 'Party Hat', icon: '🥳', slot: 'head' },
+  { id: 'crown', name: 'Golden Crown', icon: '👑', slot: 'head' },
+  { id: 'wizard', name: 'Wizard Hat', icon: '🧙', slot: 'head' },
+  { id: 'glasses', name: 'Cool Shades', icon: '🕶️', slot: 'face' },
+  { id: 'cape', name: 'Hero Cape', icon: '🦸', slot: 'back' },
+  { id: 'wings', name: 'Fairy Wings', icon: '🧚', slot: 'back' },
+];
+/** the order items unlock as the child completes levels */
+export const UNLOCK_ORDER = ['cap', 'bow', 'glasses', 'cape', 'party', 'crown', 'wings', 'wizard'];
+
+export interface EquippedCosmetics {
+  head?: string;
+  face?: string;
+  back?: string;
+}
+
+export function cosmeticById(id: string): Cosmetic | undefined {
+  return COSMETICS.find((c) => c.id === id);
+}
+
 export interface GameProgress {
   islands: Record<ActivityZone, IslandProgress>;
   /** cosmetic accessories the child has unlocked for Belu */
   unlocked: string[];
+  /** which cosmetic is worn in each slot */
+  equipped: EquippedCosmetics;
 }
 
 const KEY = 'belus_world_progress_v1';
@@ -42,6 +75,7 @@ function defaults(): GameProgress {
       forest: emptyIsland(),
     },
     unlocked: [],
+    equipped: {},
   };
 }
 
@@ -64,6 +98,7 @@ export function loadProgress(): GameProgress {
       }
     }
     if (Array.isArray(parsed.unlocked)) base.unlocked = parsed.unlocked;
+    if (parsed.equipped && typeof parsed.equipped === 'object') base.equipped = parsed.equipped;
     return base;
   } catch {
     return defaults();
@@ -168,6 +203,8 @@ export interface AwardResult {
   grewUp: boolean;
   growthBefore: GrowthStage;
   growthAfter: GrowthStage;
+  /** a cosmetic unlocked by finishing this level for the first time, if any */
+  unlockedItem?: Cosmetic;
 }
 
 /** Record a finished level. levelIdx is 0-based. stars is 1..3. Keeps the best. */
@@ -186,16 +223,35 @@ export function awardLevel(
   const wasIncomplete = prevBest === 0;
   next.islands[zone].levelStars[levelIdx] = Math.max(prevBest, Math.min(MAX_STARS_PER_LEVEL, stars));
   const growthAfter = getGrowth(next).stage;
+
+  // first-time level completion unlocks the next cosmetic
+  let unlockedItem: Cosmetic | undefined;
+  if (wasIncomplete) {
+    next.unlocked = [...p.unlocked];
+    const nextId = UNLOCK_ORDER.find((id) => !next.unlocked.includes(id));
+    if (nextId) {
+      next.unlocked.push(nextId);
+      unlockedItem = cosmeticById(nextId);
+      // auto-equip the very first thing they earn so the reward is visible
+      if (!next.equipped[unlockedItem!.slot]) {
+        next.equipped = { ...next.equipped, [unlockedItem!.slot]: nextId };
+      }
+    }
+  }
+
   return {
     progress: next,
     newLevel: wasIncomplete,
     grewUp: growthAfter > growthBefore,
     growthBefore,
     growthAfter,
+    unlockedItem,
   };
 }
 
-export function unlockAccessory(p: GameProgress, id: string): GameProgress {
-  if (p.unlocked.includes(id)) return p;
-  return { ...p, unlocked: [...p.unlocked, id] };
+export function equipCosmetic(p: GameProgress, slot: CosmeticSlot, id: string | null): GameProgress {
+  const equipped = { ...p.equipped };
+  if (id === null) delete equipped[slot];
+  else equipped[slot] = id;
+  return { ...p, equipped };
 }

--- a/components/game/BelusWorld/index.tsx
+++ b/components/game/BelusWorld/index.tsx
@@ -19,6 +19,7 @@ import { attachKeyboard } from './three/input';
 import HUD from './ui/HUD';
 import TouchControls from './ui/TouchControls';
 import GrowthMap from './ui/GrowthMap';
+import Wardrobe from './ui/Wardrobe';
 import type { QuestStatus } from './three/quest/QuestLayer';
 import {
   loadMemory,
@@ -34,12 +35,14 @@ import {
   loadProgress,
   saveProgress,
   awardLevel,
+  equipCosmetic,
   getGrowth,
   completedLevels,
   nextLevel,
   totalStars,
   type GameProgress,
   type ActivityZone,
+  type CosmeticSlot,
   ZONES,
 } from './belu/progress';
 import { speakAloud, playSound, stopSpeaking } from './belu/feedback';
@@ -69,6 +72,7 @@ interface RewardInfo {
   grewUp: boolean;
   growthLabel: string;
   islandMastered: boolean;
+  unlockedItem?: { name: string; icon: string };
 }
 
 export default function BelusWorldGame() {
@@ -80,6 +84,7 @@ export default function BelusWorldGame() {
   const [nearZone, setNearZone] = useState<ZoneId | null>(null);
   const [questStatus, setQuestStatus] = useState<QuestStatus | null>(null);
   const [showSettings, setShowSettings] = useState(false);
+  const [showWardrobe, setShowWardrobe] = useState(false);
   const [showMap, setShowMap] = useState(false);
   const [reward, setReward] = useState<RewardInfo | null>(null);
   const [settings, setSettings] = useState<Settings>({
@@ -136,7 +141,7 @@ export default function BelusWorldGame() {
     };
   }, [phase]);
 
-  const paused = showSettings || showMap || reward !== null;
+  const paused = showSettings || showMap || reward !== null || showWardrobe;
 
   const handleProximity = useCallback((zone: ZoneId | null) => {
     setNearZone(zone);
@@ -146,6 +151,15 @@ export default function BelusWorldGame() {
   // a sound helper bound to the current sound setting
   const sfx = useCallback((kind: Parameters<typeof playSound>[0]) => {
     playSound(kind, settingsRef.current.sound);
+  }, []);
+
+  const handleEquip = useCallback((slot: CosmeticSlot, id: string | null) => {
+    setProgress((p) => {
+      const next = equipCosmetic(p, slot, id);
+      saveProgress(next);
+      return next;
+    });
+    playSound('tap', settingsRef.current.sound);
   }, []);
 
   const toggleFullscreen = useCallback(() => {
@@ -181,6 +195,7 @@ export default function BelusWorldGame() {
         grewUp: res.grewUp,
         growthLabel: getGrowth(res.progress).label,
         islandMastered: mastered,
+        unlockedItem: res.unlockedItem ? { name: res.unlockedItem.name, icon: res.unlockedItem.icon } : undefined,
       });
     },
     [progress, memory],
@@ -191,7 +206,7 @@ export default function BelusWorldGame() {
   }
 
   return (
-    <div ref={rootRef} className="relative h-screen w-full overflow-hidden bg-[#bfe2ff]">
+    <div ref={rootRef} className="fixed inset-0 z-50 overflow-hidden bg-[#bfe2ff]">
       <Suspense fallback={<LoadingWorld />}>
         <GameCanvas
           emotion={emotion}
@@ -201,6 +216,7 @@ export default function BelusWorldGame() {
           activeZone={nearZone}
           growthScale={growth.scale}
           growthStage={growth.stage}
+          equipped={progress.equipped}
           islandLevels={islandLevels}
           islandNextLevel={islandNextLevel}
           sound={settings.sound}
@@ -221,7 +237,9 @@ export default function BelusWorldGame() {
         isTouch={isTouch.current}
         onOpenSettings={() => setShowSettings(true)}
         onOpenMap={() => setShowMap(true)}
+        onOpenWardrobe={() => setShowWardrobe(true)}
         onToggleFullscreen={toggleFullscreen}
+        onExit={() => { stopSpeaking(); window.history.back(); }}
       />
 
       <AnimatePresence>
@@ -240,6 +258,11 @@ export default function BelusWorldGame() {
       {/* Growth map */}
       <AnimatePresence>{showMap && <GrowthMap progress={progress} onClose={() => setShowMap(false)} />}</AnimatePresence>
 
+      {/* Wardrobe */}
+      <AnimatePresence>
+        {showWardrobe && <Wardrobe progress={progress} onEquip={handleEquip} onClose={() => setShowWardrobe(false)} />}
+      </AnimatePresence>
+
       {/* Settings */}
       <AnimatePresence>
         {showSettings && (
@@ -256,7 +279,7 @@ function IntroScreen({ memory, growthLabel, onStart, onToggleFullscreen }: { mem
   const returning = memory.visitCount > 0;
   return (
     <div
-      className="relative flex h-screen w-full flex-col items-center justify-center overflow-hidden p-6 text-center"
+      className="fixed inset-0 z-50 flex flex-col items-center justify-center overflow-y-auto p-6 text-center"
       style={{ background: 'linear-gradient(180deg,#aee0ff 0%,#d8f0ff 55%,#fff6e0 100%)' }}
     >
       {[0, 1, 2].map((i) => (
@@ -517,6 +540,11 @@ function RewardToast({ reward, onClose }: { reward: RewardInfo; onClose: () => v
         {reward.islandMastered && !reward.grewUp && (
           <p className="mt-3 rounded-2xl bg-amber-100 px-4 py-2 text-sm font-bold text-amber-700">
             🌷 You fully bloomed this island!
+          </p>
+        )}
+        {reward.unlockedItem && (
+          <p className="mt-3 rounded-2xl bg-violet-100 px-4 py-2 text-sm font-bold text-violet-700">
+            🎁 New for Belu: {reward.unlockedItem.icon} {reward.unlockedItem.name}! Tap 🎩 to wear it.
           </p>
         )}
 

--- a/components/game/BelusWorld/three/Belu3D.tsx
+++ b/components/game/BelusWorld/three/Belu3D.tsx
@@ -9,6 +9,7 @@ import { useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import type { BeluEmotion } from '../BeluCharacter';
+import type { EquippedCosmetics } from '../belu/progress';
 
 export interface MotionRef {
   speed: number; // 0..1 how fast Belu is moving on the ground
@@ -23,6 +24,8 @@ interface Props {
   growthScale?: number;
   /** 0 baby, 1 little, 2 big, 3 grown — gates visible features */
   growthStage?: number;
+  /** cosmetics Belu is wearing */
+  equipped?: EquippedCosmetics;
 }
 
 const BODY = '#5fa8e8';
@@ -61,7 +64,7 @@ function Leg({ x, z, swing }: { x: number; z: number; swing: React.MutableRefObj
   );
 }
 
-export default function Belu3D({ motion, emotion, growthScale = 1, growthStage = 2 }: Props) {
+export default function Belu3D({ motion, emotion, growthScale = 1, growthStage = 2, equipped }: Props) {
   const root = useRef<THREE.Group>(null);
   const bodyGrp = useRef<THREE.Group>(null);
   const head = useRef<THREE.Group>(null);
@@ -272,9 +275,155 @@ export default function Belu3D({ motion, emotion, growthScale = 1, growthStage =
               </mesh>
             </>
           )}
+
+          {/* worn cosmetics on the head + face */}
+          {equipped?.head && <HeadGear id={equipped.head} />}
+          {equipped?.face && <FaceGear id={equipped.face} />}
         </group>
+
+        {/* worn cosmetics on the back */}
+        {equipped?.back && <BackGear id={equipped.back} />}
       </group>
     </group>
    </group>
   );
+}
+
+// --- worn cosmetics (procedural, nothing to download) -----------------------
+
+function HeadGear({ id }: { id: string }) {
+  if (id === 'cap') {
+    return (
+      <group position={[0, 0.82, 0.05]}>
+        <mesh castShadow scale={[1, 0.62, 1]}>
+          <sphereGeometry args={[0.52, 18, 12]} />
+          <meshStandardMaterial color="#e8556b" roughness={0.6} />
+        </mesh>
+        <mesh position={[0, -0.04, 0.42]} rotation={[-0.25, 0, 0]}>
+          <cylinderGeometry args={[0.34, 0.34, 0.06, 20, 1, false, 0, Math.PI]} />
+          <meshStandardMaterial color="#c8455a" roughness={0.6} side={THREE.DoubleSide} />
+        </mesh>
+        <mesh position={[0, 0.32, 0]}>
+          <sphereGeometry args={[0.07, 10, 8]} />
+          <meshStandardMaterial color="#ffd166" />
+        </mesh>
+      </group>
+    );
+  }
+  if (id === 'bow') {
+    return (
+      <group position={[0.34, 0.78, 0.1]} rotation={[0, 0, -0.3]}>
+        <mesh position={[-0.16, 0, 0]} rotation={[0, 0, 0.5]}>
+          <coneGeometry args={[0.16, 0.3, 12]} />
+          <meshStandardMaterial color="#ff8fc8" roughness={0.5} />
+        </mesh>
+        <mesh position={[0.16, 0, 0]} rotation={[0, 0, -0.5 + Math.PI]}>
+          <coneGeometry args={[0.16, 0.3, 12]} />
+          <meshStandardMaterial color="#ff8fc8" roughness={0.5} />
+        </mesh>
+        <mesh>
+          <sphereGeometry args={[0.09, 12, 10]} />
+          <meshStandardMaterial color="#ff6fb5" />
+        </mesh>
+      </group>
+    );
+  }
+  if (id === 'party') {
+    return (
+      <group position={[0, 0.95, 0.05]}>
+        <mesh castShadow position={[0, 0.3, 0]}>
+          <coneGeometry args={[0.34, 0.9, 18]} />
+          <meshStandardMaterial color="#6c8cff" roughness={0.4} emissive="#6c8cff" emissiveIntensity={0.15} />
+        </mesh>
+        <mesh position={[0, 0.78, 0]}>
+          <sphereGeometry args={[0.1, 12, 10]} />
+          <meshStandardMaterial color="#ffd166" emissive="#ffd166" emissiveIntensity={0.3} />
+        </mesh>
+      </group>
+    );
+  }
+  if (id === 'crown') {
+    return (
+      <group position={[0, 0.9, 0.05]}>
+        <mesh castShadow>
+          <cylinderGeometry args={[0.42, 0.42, 0.22, 7, 1, true]} />
+          <meshStandardMaterial color="#ffcf33" metalness={0.7} roughness={0.25} emissive="#caa000" emissiveIntensity={0.2} side={THREE.DoubleSide} />
+        </mesh>
+        {[0, 1, 2, 3, 4].map((i) => {
+          const a = (i / 5) * Math.PI * 2;
+          return (
+            <mesh key={i} position={[Math.cos(a) * 0.42, 0.18, Math.sin(a) * 0.42]}>
+              <coneGeometry args={[0.07, 0.2, 8]} />
+              <meshStandardMaterial color="#ffcf33" metalness={0.7} roughness={0.25} />
+            </mesh>
+          );
+        })}
+      </group>
+    );
+  }
+  if (id === 'wizard') {
+    return (
+      <group position={[0, 0.95, 0.05]}>
+        <mesh castShadow position={[0, 0.45, 0]} rotation={[0.05, 0, 0.04]}>
+          <coneGeometry args={[0.32, 1.2, 20]} />
+          <meshStandardMaterial color="#3b3a8c" roughness={0.6} />
+        </mesh>
+        <mesh position={[0, -0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+          <ringGeometry args={[0.3, 0.62, 24]} />
+          <meshStandardMaterial color="#2c2b6e" roughness={0.6} side={THREE.DoubleSide} />
+        </mesh>
+        <mesh position={[0.05, 0.55, 0.28]}>
+          <octahedronGeometry args={[0.08, 0]} />
+          <meshStandardMaterial color="#ffd166" emissive="#ffd166" emissiveIntensity={0.5} />
+        </mesh>
+      </group>
+    );
+  }
+  return null;
+}
+
+function FaceGear({ id }: { id: string }) {
+  if (id === 'glasses') {
+    return (
+      <group position={[0, 0.12, 0.78]}>
+        <mesh position={[-0.3, 0, 0]}>
+          <cylinderGeometry args={[0.2, 0.2, 0.04, 18]} />
+          <meshStandardMaterial color="#1c2433" roughness={0.2} metalness={0.3} />
+        </mesh>
+        <mesh position={[0.3, 0, 0]}>
+          <cylinderGeometry args={[0.2, 0.2, 0.04, 18]} />
+          <meshStandardMaterial color="#1c2433" roughness={0.2} metalness={0.3} />
+        </mesh>
+        <mesh position={[0, 0, 0]} rotation={[0, 0, Math.PI / 2]}>
+          <cylinderGeometry args={[0.025, 0.025, 0.22, 8]} />
+          <meshStandardMaterial color="#1c2433" />
+        </mesh>
+      </group>
+    );
+  }
+  return null;
+}
+
+function BackGear({ id }: { id: string }) {
+  if (id === 'cape') {
+    return (
+      <mesh position={[0, 0.15, -0.95]} rotation={[0.22, 0, 0]} castShadow>
+        <planeGeometry args={[1.5, 1.7, 6, 6]} />
+        <meshStandardMaterial color="#e8395b" roughness={0.7} side={THREE.DoubleSide} />
+      </mesh>
+    );
+  }
+  if (id === 'wings') {
+    return (
+      <group position={[0, 0.3, -0.7]}>
+        {[-1, 1].map((s) => (
+          <mesh key={s} position={[0.5 * s, 0, 0]} rotation={[0, s * 0.5, s * 0.3]} scale={[1, 1.4, 0.1]}>
+            <sphereGeometry args={[0.5, 16, 12]} />
+            <meshStandardMaterial color="#bfe7ff" transparent opacity={0.6} emissive="#9fd8ff" emissiveIntensity={0.3} roughness={0.2} side={THREE.DoubleSide} />
+          </mesh>
+        ))}
+      </group>
+    );
+  }
+  return null;
 }

--- a/components/game/BelusWorld/three/GameCanvas.tsx
+++ b/components/game/BelusWorld/three/GameCanvas.tsx
@@ -32,6 +32,7 @@ interface Props {
   /** Belu's current size + growth stage (visible "growing up") */
   growthScale: number;
   growthStage: number;
+  equipped?: import('../belu/progress').EquippedCosmetics;
   /** completed-level count per zone island (drives the bloom) */
   islandLevels: Partial<Record<ZoneId, number>>;
   /** which level to play next on each zone island */
@@ -79,6 +80,7 @@ export default function GameCanvas({
   activeZone,
   growthScale,
   growthStage,
+  equipped,
   islandLevels,
   islandNextLevel,
   sound,
@@ -142,6 +144,7 @@ export default function GameCanvas({
           reduceMotion={reduceMotion}
           growthScale={growthScale}
           growthStage={growthStage}
+          equipped={equipped}
         />
         {/* Feelings Meadow is caring-play (StoryLayer); the other islands use
             the quest/orb layer. */}

--- a/components/game/BelusWorld/three/Player.tsx
+++ b/components/game/BelusWorld/three/Player.tsx
@@ -16,6 +16,7 @@ import { input } from './input';
 import { beluPos, beluState } from './playerState';
 import { ISLANDS, ZONE_ISLANDS, INTERACT_RADIUS, PLAYER_SPAWN, OBSTACLES, type ZoneId } from './worldConfig';
 import type { BeluEmotion } from '../BeluCharacter';
+import type { EquippedCosmetics } from '../belu/progress';
 
 const SPEED = 7.5;
 const GRAVITY = 24;
@@ -36,10 +37,11 @@ interface Props {
   reduceMotion: boolean;
   growthScale: number;
   growthStage: number;
+  equipped?: EquippedCosmetics;
 }
 
 const Player = forwardRef<PlayerHandle, Props>(function Player(
-  { emotion, paused, onProximity, onEnter, reduceMotion, growthScale, growthStage },
+  { emotion, paused, onProximity, onEnter, reduceMotion, growthScale, growthStage, equipped },
   ref,
 ) {
   const group = useRef<THREE.Group>(null);
@@ -199,7 +201,7 @@ const Player = forwardRef<PlayerHandle, Props>(function Player(
 
   return (
     <group ref={group}>
-      <Belu3D motion={motion} emotion={emotion} growthScale={growthScale} growthStage={growthStage} />
+      <Belu3D motion={motion} emotion={emotion} growthScale={growthScale} growthStage={growthStage} equipped={equipped} />
     </group>
   );
 });

--- a/components/game/BelusWorld/three/quest/Animal3D.tsx
+++ b/components/game/BelusWorld/three/quest/Animal3D.tsx
@@ -1,0 +1,223 @@
+// ---------------------------------------------------------------------------
+// Little 3D animal friends for the meadow — built from primitives (nothing to
+// download) so the world looks real, not like emoji blobs. One component makes a
+// fox, bunny, bear, bird or cat, and its BODY acts out the feeling: a scared
+// one crouches and trembles, a sad one slumps, a happy one bounces. The child
+// reads the emotion from the body language (the whole point of the island).
+// ---------------------------------------------------------------------------
+
+import { useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+
+export type AnimalSpecies = 'fox' | 'bunny' | 'bear' | 'bird' | 'cat';
+export type AnimalMood = 'scared' | 'sad' | 'lonely' | 'worried' | 'happy';
+
+interface SpeciesCfg {
+  body: string;
+  belly: string;
+  ear: 'pointy' | 'long' | 'round' | 'none';
+  earInner: string;
+  tail: 'bushy' | 'round' | 'long' | 'short' | 'none';
+  tailColor: string;
+  snout: boolean;
+  beak: boolean;
+  wings: boolean;
+  scale: number;
+}
+
+const SPECIES: Record<AnimalSpecies, SpeciesCfg> = {
+  fox: { body: '#e8843c', belly: '#fff3e0', ear: 'pointy', earInner: '#ffd9b8', tail: 'bushy', tailColor: '#e8843c', snout: true, beak: false, wings: false, scale: 1 },
+  bunny: { body: '#dfe3ea', belly: '#ffffff', ear: 'long', earInner: '#ffd1e0', tail: 'round', tailColor: '#ffffff', snout: false, beak: false, wings: false, scale: 0.92 },
+  bear: { body: '#9c6b4a', belly: '#c9a182', ear: 'round', earInner: '#7a5238', tail: 'none', tailColor: '#9c6b4a', snout: true, beak: false, wings: false, scale: 1.12 },
+  bird: { body: '#6fb7ff', belly: '#dff0ff', ear: 'none', earInner: '', tail: 'short', tailColor: '#4f97df', snout: false, beak: true, wings: true, scale: 0.8 },
+  cat: { body: '#b9c0cc', belly: '#ffffff', ear: 'pointy', earInner: '#ffd1e0', tail: 'long', tailColor: '#b9c0cc', snout: true, beak: false, wings: false, scale: 0.95 },
+};
+
+interface Props {
+  species: AnimalSpecies;
+  mood: AnimalMood;
+  position: [number, number, number];
+  seed?: number;
+}
+
+export default function Animal3D({ species, mood, position, seed = 0 }: Props) {
+  const cfg = SPECIES[species];
+  const root = useRef<THREE.Group>(null);
+  const head = useRef<THREE.Group>(null);
+  const tail = useRef<THREE.Group>(null);
+  const t = useRef(seed);
+
+  useFrame((_, dt) => {
+    t.current += dt;
+    const time = t.current;
+    const g = root.current;
+    if (!g) return;
+    let y = 0;
+    let rotZ = 0;
+    let headTilt = 0;
+    switch (mood) {
+      case 'scared':
+        y = -0.18 + Math.sin(time * 30) * 0.015; // crouched + tremble
+        g.position.x = position[0] + Math.sin(time * 34) * 0.02;
+        headTilt = -0.25;
+        break;
+      case 'sad':
+        y = -0.1 + Math.sin(time * 1.4) * 0.02;
+        headTilt = 0.4; // head drooped down
+        rotZ = Math.sin(time * 0.7) * 0.03;
+        break;
+      case 'lonely':
+        y = Math.sin(time * 1.1) * 0.04;
+        headTilt = 0.25;
+        rotZ = Math.sin(time * 0.6) * 0.05;
+        break;
+      case 'worried':
+        y = Math.sin(time * 2.2) * 0.03;
+        g.rotation.y = Math.sin(time * 1.3) * 0.25; // looking around
+        headTilt = 0.1;
+        break;
+      default: // happy
+        y = Math.abs(Math.sin(time * 5)) * 0.22;
+        rotZ = Math.sin(time * 10) * 0.03;
+        headTilt = -0.1;
+    }
+    g.position.y = position[1] + y;
+    if (mood !== 'worried') g.rotation.y = 0;
+    g.rotation.z = rotZ;
+    if (head.current) head.current.rotation.x = THREE.MathUtils.lerp(head.current.rotation.x, headTilt, 0.1);
+    if (tail.current) tail.current.rotation.z = Math.sin(time * (mood === 'happy' ? 10 : 2)) * 0.4;
+  });
+
+  const eyeWide = mood === 'scared' || mood === 'worried';
+  const eyeScaleY = mood === 'sad' || mood === 'lonely' ? 0.55 : eyeWide ? 1.25 : 1;
+
+  return (
+    <group ref={root} position={position} scale={cfg.scale}>
+      {/* body */}
+      <mesh castShadow position={[0, 0.5, 0]} scale={[1, 0.95, 1.15]}>
+        <sphereGeometry args={[0.55, 22, 16]} />
+        <meshStandardMaterial color={cfg.body} roughness={0.7} />
+      </mesh>
+      {/* belly */}
+      <mesh position={[0, 0.38, 0.4]} scale={[0.7, 0.8, 0.5]}>
+        <sphereGeometry args={[0.45, 18, 14]} />
+        <meshStandardMaterial color={cfg.belly} roughness={0.75} />
+      </mesh>
+      {/* legs */}
+      {[[-0.28, 0.28], [0.28, 0.28], [-0.28, -0.28], [0.28, -0.28]].map(([x, z], i) => (
+        <mesh key={i} position={[x, 0.12, z]}>
+          <cylinderGeometry args={[0.12, 0.13, 0.28, 10]} />
+          <meshStandardMaterial color={cfg.body} roughness={0.7} />
+        </mesh>
+      ))}
+      {/* tail */}
+      {cfg.tail !== 'none' && (
+        <group ref={tail} position={[0, 0.45, -0.6]}>
+          {cfg.tail === 'bushy' && (
+            <mesh position={[0, 0.05, -0.2]} rotation={[0.6, 0, 0]}>
+              <sphereGeometry args={[0.26, 14, 12]} />
+              <meshStandardMaterial color={cfg.tailColor} roughness={0.8} />
+            </mesh>
+          )}
+          {cfg.tail === 'round' && (
+            <mesh position={[0, 0, -0.1]}>
+              <sphereGeometry args={[0.16, 12, 10]} />
+              <meshStandardMaterial color={cfg.tailColor} roughness={0.85} />
+            </mesh>
+          )}
+          {cfg.tail === 'long' && (
+            <mesh position={[0, 0.1, -0.25]} rotation={[0.8, 0, 0]}>
+              <cylinderGeometry args={[0.06, 0.09, 0.7, 8]} />
+              <meshStandardMaterial color={cfg.tailColor} roughness={0.8} />
+            </mesh>
+          )}
+          {cfg.tail === 'short' && (
+            <mesh position={[0, 0, -0.12]} rotation={[0.5, 0, 0]}>
+              <coneGeometry args={[0.18, 0.3, 8]} />
+              <meshStandardMaterial color={cfg.tailColor} roughness={0.8} />
+            </mesh>
+          )}
+        </group>
+      )}
+
+      {/* head */}
+      <group ref={head} position={[0, 0.85, 0.32]}>
+        <mesh castShadow>
+          <sphereGeometry args={[0.42, 20, 16]} />
+          <meshStandardMaterial color={cfg.body} roughness={0.7} />
+        </mesh>
+
+        {/* ears */}
+        {cfg.ear === 'pointy' && [-1, 1].map((s) => (
+          <mesh key={s} position={[0.22 * s, 0.4, 0]} rotation={[0, 0, -s * 0.2]}>
+            <coneGeometry args={[0.14, 0.34, 10]} />
+            <meshStandardMaterial color={cfg.body} roughness={0.7} />
+          </mesh>
+        ))}
+        {cfg.ear === 'long' && [-1, 1].map((s) => (
+          <mesh key={s} position={[0.16 * s, 0.5, 0]} rotation={[mood === 'scared' ? -0.6 : 0, 0, -s * 0.15]} scale={[0.5, 1.4, 0.5]}>
+            <sphereGeometry args={[0.18, 12, 12]} />
+            <meshStandardMaterial color={cfg.body} roughness={0.7} />
+          </mesh>
+        ))}
+        {cfg.ear === 'round' && [-1, 1].map((s) => (
+          <mesh key={s} position={[0.3 * s, 0.34, 0]}>
+            <sphereGeometry args={[0.16, 12, 10]} />
+            <meshStandardMaterial color={cfg.body} roughness={0.7} />
+          </mesh>
+        ))}
+
+        {/* snout / beak */}
+        {cfg.snout && (
+          <mesh position={[0, -0.05, 0.4]} rotation={[Math.PI / 2, 0, 0]}>
+            <coneGeometry args={[0.13, 0.3, 12]} />
+            <meshStandardMaterial color={cfg.belly} roughness={0.7} />
+          </mesh>
+        )}
+        {cfg.snout && (
+          <mesh position={[0, -0.05, 0.55]}>
+            <sphereGeometry args={[0.06, 10, 8]} />
+            <meshStandardMaterial color="#3a2a22" roughness={0.5} />
+          </mesh>
+        )}
+        {cfg.beak && (
+          <mesh position={[0, -0.02, 0.45]} rotation={[Math.PI / 2, 0, 0]}>
+            <coneGeometry args={[0.1, 0.26, 8]} />
+            <meshStandardMaterial color="#ffb74d" roughness={0.5} />
+          </mesh>
+        )}
+
+        {/* eyes */}
+        {[-1, 1].map((s) => (
+          <group key={s} position={[0.16 * s, 0.08, 0.36]} scale={[1, eyeScaleY, 1]}>
+            <mesh>
+              <sphereGeometry args={[0.1, 14, 12]} />
+              <meshStandardMaterial color="#ffffff" roughness={0.3} />
+            </mesh>
+            <mesh position={[0, mood === 'sad' ? -0.02 : 0, 0.07]}>
+              <sphereGeometry args={[0.055, 12, 10]} />
+              <meshStandardMaterial color="#26334d" />
+            </mesh>
+          </group>
+        ))}
+
+        {/* worried/sad brow */}
+        {(mood === 'sad' || mood === 'worried' || mood === 'scared') && (
+          <mesh position={[0, 0.22, 0.34]} rotation={[0, 0, 0]} scale={[0.5, 0.5, 0.5]}>
+            <torusGeometry args={[0.12, 0.02, 6, 12, Math.PI]} />
+            <meshStandardMaterial color="#3a2a22" />
+          </mesh>
+        )}
+      </group>
+
+      {/* wings (bird) */}
+      {cfg.wings && [-1, 1].map((s) => (
+        <mesh key={s} position={[0.45 * s, 0.5, 0]} rotation={[0, 0, s * 0.4]} scale={[0.18, 0.5, 0.9]}>
+          <sphereGeometry args={[0.4, 12, 10]} />
+          <meshStandardMaterial color={cfg.tailColor} roughness={0.7} />
+        </mesh>
+      ))}
+    </group>
+  );
+}

--- a/components/game/BelusWorld/three/quest/StoryLayer.tsx
+++ b/components/game/BelusWorld/three/quest/StoryLayer.tsx
@@ -1,11 +1,11 @@
 // ---------------------------------------------------------------------------
-// Feelings Meadow as CARING PLAY (no questions, no orbs).
-//
-// Friends sit under weather clouds that show their feeling. The child walks
-// Belu up to a friend and just stays close — Belu comforts them, their cloud
-// clears (🌧️→🌥️→☀️), flowers burst open, and they cheer. Help everyone and the
-// whole meadow blooms. Pure cause-and-effect kindness; the feeling is read by
-// seeing the cloud + body language and hearing Belu name it.
+// Feelings Meadow — caring play (the owner's design).
+//   • 3D animal friends act out a feeling with their bodies.
+//   • Walk Belu up to one and LINGER a moment → a clue bubble appears telling
+//     you how they feel.
+//   • 3 ways-to-help then appear around them → walk into (or tap) the kind one.
+//   • Right → the animal cheers up, flowers bloom. Help everyone → meadow blooms.
+// No abstract quiz: read the body language, understand, choose how to be kind.
 // ---------------------------------------------------------------------------
 
 import { useRef, useState } from 'react';
@@ -15,22 +15,42 @@ import * as THREE from 'three';
 import { ISLANDS } from '../worldConfig';
 import { beluPos } from '../playerState';
 import type { BeluEmotion } from '../../BeluCharacter';
-import QuestNPC from './QuestNPC';
+import Animal3D, { type AnimalMood } from './Animal3D';
+import AnswerOrb, { type OrbStatus } from './AnswerOrb';
 import { Flower } from '../Scenery';
 import { makeLabelTexture } from './emojiTexture';
 import { MEADOW_STORY } from './storyContent';
 import type { QuestStatus } from './QuestLayer';
 
 const ZONE = 'meadow' as const;
-const CARE_RADIUS = 2.4; // how close Belu must be to comfort a friend
-const CARE_STEP = 0.7; // seconds between each cloud-clearing step
+const APPROACH = 3.2; // get this close to a friend to start observing
+const LINGER = 1.6; // seconds of staying close before the clue appears
+const HELP_DIST = 2.0; // how far the help bubbles sit in front of a friend
+const HELP_PICK = 1.7; // walk this close to a help bubble to choose it
+
+const FEELING_FACE: Record<AnimalMood, string> = {
+  scared: '😨', sad: '😢', lonely: '😞', worried: '😟', happy: '😊',
+};
 
 interface FriendRT {
-  careStage: number; // 0..clouds.length-1 ; last = sunny/healed
   healed: boolean;
-  named: boolean;
-  lastCareAt: number;
   healedAt: number;
+}
+interface State {
+  clock: number;
+  active: boolean;
+  level: number;
+  friends: FriendRT[];
+  helped: number;
+  disarmed: boolean;
+  // current friend being observed/helped
+  activeFriend: number;
+  lingerStart: number;
+  observed: boolean;
+  wrongIdx: number;
+  wrongUntil: number;
+  lockUntil: number;
+  finishAt: number;
 }
 
 interface Props {
@@ -43,71 +63,113 @@ interface Props {
   onStatus: (s: QuestStatus | null) => void;
 }
 
-interface State {
-  clock: number;
-  active: boolean;
-  level: number;
-  friends: FriendRT[];
-  helped: number;
-  disarmed: boolean;
-  pendingSayAt: number;
-  pendingSay: string | null;
-  finishAt: number; // >0 → complete the level at this clock time (lets the last bloom show)
-}
-
-function freshFriends(level: number): FriendRT[] {
-  const lvl = MEADOW_STORY[Math.max(0, Math.min(MEADOW_STORY.length - 1, level - 1))];
-  return lvl.friends.map(() => ({ careStage: 0, healed: false, named: false, lastCareAt: -99, healedAt: -99 }));
+function clampLevel(level: number) {
+  return Math.max(0, Math.min(MEADOW_STORY.length - 1, level - 1));
 }
 
 export default function StoryLayer(props: Props) {
   const [, force] = useState(0);
   const bump = () => force((v) => (v + 1) % 1_000_000);
   const S = useRef<State>({
-    clock: 0, active: false, level: props.level, friends: freshFriends(props.level),
-    helped: 0, disarmed: false, pendingSayAt: 0, pendingSay: null, finishAt: 0,
+    clock: 0, active: false, level: props.level, friends: MEADOW_STORY[clampLevel(props.level)].friends.map(() => ({ healed: false, healedAt: -99 })),
+    helped: 0, disarmed: false, activeFriend: -1, lingerStart: 0, observed: false,
+    wrongIdx: -1, wrongUntil: 0, lockUntil: 0, finishAt: 0,
   });
   const frame = useRef<(dt: number) => void>(() => {});
-
   const isl = ISLANDS[ZONE];
-  const lvlDef = MEADOW_STORY[Math.max(0, Math.min(MEADOW_STORY.length - 1, S.current.level - 1))];
 
-  function emitStatus(phase: 'question' | 'correct', instruction: string) {
+  const friendWorld = (i: number): [number, number] => {
+    const fr = MEADOW_STORY[clampLevel(S.current.level)].friends[i];
+    return [isl.cx + fr.pos[0], isl.cz + fr.pos[1]];
+  };
+
+  // 3 help bubbles in an arc on the home-facing side of a friend
+  function helpLayout(i: number): [number, number, number][] {
+    const [fx, fz] = friendWorld(i);
+    const len = Math.hypot(fx, fz) || 1;
+    const dx = -fx / len; // toward home (0,0)
+    const dz = -fz / len;
+    const px = -dz;
+    const pz = dx;
+    return [-1, 0, 1].map((o) => [
+      fx + dx * HELP_DIST + px * o * 1.8,
+      isl.top + 1.0,
+      fz + dz * HELP_DIST + pz * o * 1.8,
+    ]);
+  }
+
+  function emitStatus(phase: 'question' | 'correct', instruction: string, hint?: string) {
+    const lvl = MEADOW_STORY[clampLevel(S.current.level)];
     props.onStatus({
       zone: ZONE, title: isl.label, emoji: isl.emoji, accent: isl.accent,
       level: S.current.level, instruction, step: S.current.helped,
-      total: lvlDef.friends.length, phase,
-      hint: phase === 'question' ? 'Walk up to a cloudy friend and stay close to help 💛' : undefined,
+      total: lvl.friends.length, phase, hint,
     });
   }
 
   function startStory() {
+    const lvl = MEADOW_STORY[clampLevel(props.level)];
     S.current.active = true;
     S.current.level = props.level;
-    S.current.friends = freshFriends(props.level);
+    S.current.friends = lvl.friends.map(() => ({ healed: false, healedAt: -99 }));
     S.current.helped = 0;
-    const lvl = MEADOW_STORY[Math.max(0, Math.min(MEADOW_STORY.length - 1, props.level - 1))];
+    S.current.activeFriend = -1;
+    S.current.observed = false;
     props.setEmotion('curious');
     props.speak(lvl.intro);
-    emitStatus('question', lvl.intro);
+    emitStatus('question', lvl.intro, 'Walk up to a friend to see how they feel 💛');
     bump();
   }
 
   function stopStory() {
     S.current.active = false;
+    S.current.activeFriend = -1;
+    S.current.observed = false;
     props.setEmotion('happy');
     props.onStatus(null);
     bump();
   }
 
   function finish() {
-    const lvl = MEADOW_STORY[Math.max(0, Math.min(MEADOW_STORY.length - 1, S.current.level - 1))];
+    const lvl = MEADOW_STORY[clampLevel(S.current.level)];
     props.onComplete(ZONE, S.current.level, 3, lvl.moment);
     props.speak(lvl.outro);
     S.current.active = false;
     S.current.disarmed = true;
+    S.current.activeFriend = -1;
     props.onStatus(null);
     bump();
+  }
+
+  function pickHelp(i: number) {
+    const st = S.current;
+    if (st.clock < st.lockUntil) return;
+    const fr = MEADOW_STORY[clampLevel(st.level)].friends[st.activeFriend];
+    const opt = fr.helps[i];
+    if (opt.correct) {
+      st.friends[st.activeFriend].healed = true;
+      st.friends[st.activeFriend].healedAt = st.clock;
+      st.helped += 1;
+      st.lockUntil = st.clock + 0.8;
+      props.playSound('star');
+      props.setEmotion('excited');
+      emitStatus('correct', `Yay! Your ${fr.species} feels safe and happy now! ☀️`);
+      const total = MEADOW_STORY[clampLevel(st.level)].friends.length;
+      if (st.helped >= total) st.finishAt = st.clock + 1.5;
+      else {
+        st.activeFriend = -1;
+        st.observed = false;
+      }
+      bump();
+    } else {
+      st.wrongIdx = i;
+      st.wrongUntil = st.clock + 0.5;
+      st.lockUntil = st.clock + 0.5;
+      props.playSound('tap');
+      props.setEmotion('curious');
+      props.speak('Hmm, that might not help them. What would a kind friend do?');
+      bump();
+    }
   }
 
   frame.current = (dt: number) => {
@@ -115,26 +177,22 @@ export default function StoryLayer(props: Props) {
     if (props.paused) return;
     st.clock += dt;
 
-    if (st.pendingSay && st.clock >= st.pendingSayAt) {
-      props.speak(st.pendingSay);
-      st.pendingSay = null;
-    }
-
     if (st.finishAt > 0 && st.clock >= st.finishAt) {
       st.finishAt = 0;
       finish();
       return;
     }
+    if (st.wrongIdx >= 0 && st.clock > st.wrongUntil) {
+      st.wrongIdx = -1;
+      bump();
+    }
 
     const dCenter = Math.hypot(beluPos.x - isl.cx, beluPos.z - isl.cz);
     const onIsland = dCenter < isl.radius * 0.82;
-
-    // re-arm after Belu wanders off a finished meadow
     if (st.disarmed && dCenter > isl.radius + 1.5) {
       st.disarmed = false;
       bump();
     }
-
     if (!st.active) {
       if (onIsland && !st.disarmed) startStory();
       return;
@@ -144,75 +202,115 @@ export default function StoryLayer(props: Props) {
       return;
     }
 
-    // comfort the nearest cloudy friend Belu is standing with
-    const defs = MEADOW_STORY[Math.max(0, Math.min(MEADOW_STORY.length - 1, st.level - 1))].friends;
-    for (let i = 0; i < defs.length; i++) {
-      const rt = st.friends[i];
-      if (rt.healed) continue;
-      const wx = isl.cx + defs[i].pos[0];
-      const wz = isl.cz + defs[i].pos[1];
-      const d = Math.hypot(beluPos.x - wx, beluPos.z - wz);
-      if (d > CARE_RADIUS) continue;
+    const friends = MEADOW_STORY[clampLevel(st.level)].friends;
 
-      if (!rt.named) {
-        rt.named = true;
-        props.speak(`This friend feels ${defs[i].feeling}. Stay close — you're helping! 💛`);
-        props.setEmotion('curious');
+    // who is Belu nearest to (unhealed)?
+    let near = -1;
+    let nearD = APPROACH;
+    for (let i = 0; i < friends.length; i++) {
+      if (st.friends[i].healed) continue;
+      const [fx, fz] = friendWorld(i);
+      const d = Math.hypot(beluPos.x - fx, beluPos.z - fz);
+      if (d < nearD) {
+        nearD = d;
+        near = i;
       }
-      if (st.clock - rt.lastCareAt >= CARE_STEP) {
-        rt.lastCareAt = st.clock;
-        rt.careStage += 1;
-        props.playSound('tap');
-        props.setEmotion('happy');
-        if (rt.careStage >= defs[i].clouds.length - 1) {
-          rt.healed = true;
-          rt.healedAt = st.clock;
-          st.helped += 1;
-          props.playSound('star');
-          props.setEmotion('excited');
-          emitStatus('correct', `Yay! Your ${defs[i].feeling} friend feels sunny now! ☀️`);
-          if (st.helped >= defs.length) st.finishAt = st.clock + 1.4; // let the last bloom show
-        } else {
-          emitStatus('question', `You're cheering up your ${defs[i].feeling} friend… keep going!`);
-        }
+    }
+
+    if (near === -1) {
+      if (st.activeFriend !== -1) {
+        st.activeFriend = -1;
+        st.observed = false;
+        emitStatus('question', 'Walk up to a friend who needs help.', 'Stay close to see how they feel 💛');
         bump();
       }
-      break; // only comfort one friend at a time
+      return;
+    }
+
+    if (near !== st.activeFriend) {
+      st.activeFriend = near;
+      st.lingerStart = st.clock;
+      st.observed = false;
+      props.setEmotion('curious');
+      bump();
+    }
+
+    if (!st.observed && st.clock - st.lingerStart >= LINGER) {
+      st.observed = true;
+      const fr = friends[near];
+      props.speak(`The ${fr.species} ${fr.clue}`);
+      emitStatus('question', `The ${fr.species} ${fr.clue}`, 'Walk into a kind way to help 💛');
+      st.lockUntil = st.clock + 0.4;
+      bump();
+    }
+
+    // once observed, let Belu walk into a help bubble
+    if (st.observed) {
+      const layout = helpLayout(near);
+      let best = -1;
+      let bestD = HELP_PICK;
+      for (let i = 0; i < layout.length; i++) {
+        const d = Math.hypot(beluPos.x - layout[i][0], beluPos.z - layout[i][2]);
+        if (d < bestD) {
+          bestD = d;
+          best = i;
+        }
+      }
+      if (best >= 0) pickHelp(best);
     }
   };
 
   // ---- render ----
-  const defs = lvlDef.friends;
+  const friends = MEADOW_STORY[clampLevel(S.current.level)].friends;
   return (
     <group>
       <Ticker fnRef={frame} />
-      {defs.map((fr, i) => {
-        const rt = S.current.friends[i] ?? { careStage: 0, healed: false, healedAt: -99 };
-        const wx = isl.cx + fr.pos[0];
-        const wz = isl.cz + fr.pos[1];
-        const cloud = fr.clouds[Math.min(rt.careStage, fr.clouds.length - 1)];
+      {friends.map((fr, i) => {
+        const rt = S.current.friends[i] ?? { healed: false, healedAt: -99 };
+        const [fx, fz] = friendWorld(i);
+        const isActive = S.current.active && S.current.activeFriend === i && !rt.healed;
         const justHealed = rt.healed && S.current.clock - rt.healedAt < 2.5;
         return (
           <group key={`${S.current.level}-${i}`}>
-            <QuestNPC
-              position={[wx, isl.top, wz]}
-              face={fr.face}
-              mood={rt.healed ? 'happy' : fr.mood}
-              color={isl.accent}
-              beckon={!rt.healed && S.current.active}
+            <Animal3D
+              species={fr.species}
+              mood={rt.healed ? 'happy' : fr.feeling}
+              position={[fx, isl.top, fz]}
               seed={i * 1.7}
             />
-            {/* weather cloud showing the feeling, above the friend */}
-            <CloudSprite emoji={cloud} position={[wx, isl.top + 2.1, wz]} />
-            {/* kindness bursts when a friend turns sunny */}
+            {/* bubble above the friend: 👀 while observing, the feeling once seen */}
+            {isActive && (
+              <Bubble
+                emoji={S.current.observed ? FEELING_FACE[fr.feeling] : '👀'}
+                position={[fx, isl.top + 1.9, fz]}
+              />
+            )}
+            {/* the 3 ways-to-help, once observed */}
+            {isActive && S.current.observed &&
+              helpLayout(i).map((p, oi) => {
+                const opt = fr.helps[oi];
+                const status: OrbStatus = S.current.wrongIdx === oi ? 'wrong' : 'idle';
+                return (
+                  <AnswerOrb
+                    key={oi}
+                    position={p}
+                    emoji={opt.emoji}
+                    caption={opt.label}
+                    color={isl.accent}
+                    status={status}
+                    bobSeed={oi * 0.7}
+                    onPick={() => pickHelp(oi)}
+                  />
+                );
+              })}
             {justHealed && (
-              <Sparkles count={20} scale={3} size={6} speed={0.6} color="#ffd166" position={[wx, isl.top + 1.2, wz]} />
+              <Sparkles count={22} scale={3} size={6} speed={0.6} color="#ffd166" position={[fx, isl.top + 1.2, fz]} />
             )}
             {rt.healed && (
               <>
-                <Flower position={[wx + 1.1, isl.top, wz + 0.6]} color="#ff8fc8" />
-                <Flower position={[wx - 1.0, isl.top, wz + 0.8]} color="#ffd166" />
-                <Flower position={[wx + 0.5, isl.top, wz - 1.1]} color="#a78bfa" />
+                <Flower position={[fx + 1.1, isl.top, fz + 0.6]} color="#ff8fc8" />
+                <Flower position={[fx - 1.0, isl.top, fz + 0.8]} color="#ffd166" />
+                <Flower position={[fx + 0.4, isl.top, fz - 1.1]} color="#a78bfa" />
               </>
             )}
           </group>
@@ -222,15 +320,14 @@ export default function StoryLayer(props: Props) {
   );
 }
 
-function CloudSprite({ emoji, position }: { emoji: string; position: [number, number, number] }) {
-  const tex = useRef<THREE.CanvasTexture>(makeLabelTexture(emoji));
-  // update texture when the emoji changes
+function Bubble({ emoji, position }: { emoji: string; position: [number, number, number] }) {
+  const tex = useRef<THREE.CanvasTexture>(makeLabelTexture(emoji, undefined, true));
   if ((tex.current as unknown as { __e?: string }).__e !== emoji) {
-    tex.current = makeLabelTexture(emoji);
+    tex.current = makeLabelTexture(emoji, undefined, true);
     (tex.current as unknown as { __e?: string }).__e = emoji;
   }
   return (
-    <sprite position={position} scale={[1.5, 1.5, 1]} renderOrder={12}>
+    <sprite position={position} scale={[1.4, 1.4, 1]} renderOrder={12}>
       <spriteMaterial map={tex.current} transparent depthWrite={false} depthTest={false} />
     </sprite>
   );

--- a/components/game/BelusWorld/three/quest/storyContent.ts
+++ b/components/game/BelusWorld/three/quest/storyContent.ts
@@ -1,27 +1,25 @@
 // ---------------------------------------------------------------------------
-// Feelings Meadow — reshaped as CARING PLAY, not a quiz.
-//
-// Friends sit in the meadow under a little weather cloud that shows how they
-// feel (🌧️ sad, ⛈️ scared, ☁️ lonely, 🌥️ worried). There are no questions and
-// no right/wrong answers. The child simply walks Belu up to a friend and stays
-// with them — Belu comforts them, their cloud clears step by step into sunshine,
-// flowers burst open, and when every friend is sunny the whole meadow blooms.
-//
-// The learning (reading emotions) happens by SEEING the feeling and the body
-// language, hearing Belu name it, and watching kindness change their world.
+// Feelings Meadow content — caring play, the owner's design:
+//   walk up to a 3D animal → linger a moment → a CLUE about how it feels pops
+//   up → 3 ways to help appear → choose the kind one → the animal cheers up.
+// The feeling is read from the animal's body language + the clue; the choice is
+// about HOW TO BE KIND (a real social skill), never an abstract "what feeling?".
 // ---------------------------------------------------------------------------
 
-import type { Mood } from './QuestNPC';
+import type { AnimalSpecies, AnimalMood } from './Animal3D';
+
+export interface HelpOption {
+  emoji: string;
+  label: string;
+  correct?: boolean;
+}
 
 export interface StoryFriend {
-  face: string;
-  /** kid-facing feeling word — Belu names it on approach */
-  feeling: string;
-  mood: Mood;
-  /** cloud stages from worst → sunny; last is always ☀️. careNeeded = stages-1 */
-  clouds: string[];
-  /** local position on the meadow (offset from the island centre, XZ) */
-  pos: [number, number];
+  species: AnimalSpecies;
+  feeling: AnimalMood; // also drives the body-language animation
+  clue: string;
+  helps: HelpOption[];
+  pos: [number, number]; // local offset from the meadow centre (XZ)
 }
 
 export interface StoryLevel {
@@ -32,71 +30,84 @@ export interface StoryLevel {
   friends: StoryFriend[];
 }
 
-const RAIN = ['🌧️', '🌥️', '☀️'];
-const STORM = ['⛈️', '🌥️', '☀️'];
-const LONELY = ['☁️', '🌤️', '☀️'];
-const WORRY = ['🌥️', '🌤️', '☀️'];
+// the clue + the 3 ways-to-help for each feeling (1 kind choice, 2 unkind)
+const FEELINGS: Record<AnimalMood, { clue: string; helps: HelpOption[] }> = {
+  scared: {
+    clue: 'is hiding and trembling — they feel scared.',
+    helps: [
+      { emoji: '🤫', label: 'Sit quietly close', correct: true },
+      { emoji: '👻', label: 'Jump out & yell' },
+      { emoji: '🚶', label: 'Walk away' },
+    ],
+  },
+  sad: {
+    clue: 'is slumped and quiet — they feel sad.',
+    helps: [
+      { emoji: '🤗', label: 'Give a warm hug', correct: true },
+      { emoji: '🙅', label: 'Say "stop crying"' },
+      { emoji: '😆', label: 'Laugh at them' },
+    ],
+  },
+  lonely: {
+    clue: 'is sitting all by themselves — they feel lonely.',
+    helps: [
+      { emoji: '🎈', label: 'Invite them to play', correct: true },
+      { emoji: '🙈', label: 'Ignore them' },
+      { emoji: '🚶', label: 'Leave them alone' },
+    ],
+  },
+  worried: {
+    clue: 'keeps fidgeting and looking around — they feel worried.',
+    helps: [
+      { emoji: '🌬️', label: 'Breathe slow together', correct: true },
+      { emoji: '🏃', label: 'Rush them' },
+      { emoji: '🙄', label: 'Say it’s silly' },
+    ],
+  },
+  happy: { clue: 'feels happy!', helps: [{ emoji: '🎉', label: 'Celebrate!', correct: true }] },
+};
 
-function f(face: string, feeling: string, mood: Mood, clouds: string[], x: number, z: number): StoryFriend {
-  return { face, feeling, mood, clouds, pos: [x, z] };
+function f(species: AnimalSpecies, feeling: AnimalMood, x: number, z: number): StoryFriend {
+  return { species, feeling, clue: FEELINGS[feeling].clue, helps: FEELINGS[feeling].helps, pos: [x, z] };
 }
 
 export const MEADOW_STORY: StoryLevel[] = [
   {
-    goal: 'Cheer up 2 friends',
-    intro: "Some meadow friends feel cloudy today. Walk up close and Belu will help them feel better!",
-    outro: 'You made the whole meadow sunny! You are such a kind friend. ☀️',
-    moment: 'cheered up friends in the meadow',
-    friends: [
-      f('🐰', 'sad', 'sad', RAIN, -2, -1),
-      f('🦊', 'scared', 'scared', STORM, 3, 1),
-    ],
+    goal: 'Help 2 friends',
+    intro: "Some meadow friends are feeling big feelings. Walk up close, see how they feel, and choose a kind way to help!",
+    outro: 'You helped every friend feel better. You are so kind! ☀️',
+    moment: 'helped friends in the meadow',
+    friends: [f('fox', 'scared', -2, 0), f('bunny', 'sad', 3, 1)],
   },
   {
-    goal: 'Help 3 friends feel sunny',
-    intro: "More friends feel cloudy. Go be with each one until their sunshine comes back!",
-    outro: 'Every friend is smiling now. You helped the sun come out! 🌈',
-    moment: 'cheered up friends in the meadow',
-    friends: [
-      f('🐻', 'sad', 'sad', RAIN, -3, 2),
-      f('🐥', 'scared', 'scared', STORM, 3, -2),
-      f('🐰', 'lonely', 'sad', LONELY, 0, 3),
-    ],
+    goal: 'Help 3 friends',
+    intro: "More friends need a kind buddy. Look at how each one looks and feels, then help.",
+    outro: 'Three happy friends — the whole meadow is smiling! 🌈',
+    moment: 'helped friends in the meadow',
+    friends: [f('bear', 'sad', -3, 2), f('bird', 'scared', 3, -2), f('bunny', 'lonely', 0, 3)],
   },
   {
-    goal: 'Warm up 3 cloudy friends',
-    intro: "Look at how each friend's body looks. Stay close and help their cloud clear away.",
-    outro: 'You noticed how everyone felt and helped. The meadow is glowing! ☀️',
-    moment: 'cheered up friends in the meadow',
-    friends: [
-      f('🦊', 'worried', 'disappointed', WORRY, -3, -2),
-      f('🐻', 'sad', 'sad', RAIN, 3, 2),
-      f('🐱', 'scared', 'scared', STORM, -2, 3),
-    ],
+    goal: 'Read 3 feelings & help',
+    intro: "Watch their bodies closely — they each feel something different. Choose how to help each one.",
+    outro: 'You read every feeling and helped. Amazing kindness! ☀️',
+    moment: 'helped friends in the meadow',
+    friends: [f('cat', 'worried', -3, -2), f('bear', 'sad', 3, 2), f('fox', 'scared', -2, 3)],
   },
   {
-    goal: 'Bring sunshine to 4 friends',
-    intro: "Lots of friends need a kind buddy today. Visit every one of them!",
-    outro: 'Four happy friends! You turned the whole sky sunny. 🌻',
-    moment: 'cheered up friends in the meadow',
-    friends: [
-      f('🐰', 'sad', 'sad', RAIN, -4, 0),
-      f('🐦', 'lonely', 'sad', LONELY, 4, 0),
-      f('🐻', 'worried', 'disappointed', WORRY, 0, -3),
-      f('🦊', 'scared', 'scared', STORM, 0, 3),
-    ],
+    goal: 'Help 4 friends',
+    intro: "Lots of friends need help today. You know how to be kind — go to each one!",
+    outro: 'Four friends, four smiles. You’re a wonderful friend! 🌻',
+    moment: 'helped friends in the meadow',
+    friends: [f('bunny', 'sad', -4, 0), f('bird', 'lonely', 4, 0), f('bear', 'worried', 0, -3), f('cat', 'scared', 0, 3)],
   },
   {
     goal: 'Be everyone’s kind friend',
-    intro: "The whole meadow is feeling big feelings. You know just what to do — go spread kindness!",
-    outro: 'You are the kindest friend in all the sky islands. The meadow is in full bloom! 🌷',
+    intro: "The whole meadow has big feelings. Help every single friend feel safe and happy!",
+    outro: 'You are the kindest friend in the sky islands. The meadow is in full bloom! 🌷',
     moment: 'spread kindness across the meadow',
     friends: [
-      f('🐻', 'sad', 'sad', RAIN, -4, -2),
-      f('🐱', 'scared', 'scared', STORM, 4, -2),
-      f('🐰', 'lonely', 'sad', LONELY, -3, 3),
-      f('🦊', 'worried', 'disappointed', WORRY, 3, 3),
-      f('🐥', 'sad', 'sad', RAIN, 0, 0),
+      f('bear', 'sad', -4, -2), f('cat', 'scared', 4, -2), f('bunny', 'lonely', -3, 3),
+      f('fox', 'worried', 3, 3), f('bird', 'sad', 0, 0),
     ],
   },
 ];

--- a/components/game/BelusWorld/ui/HUD.tsx
+++ b/components/game/BelusWorld/ui/HUD.tsx
@@ -16,10 +16,12 @@ interface Props {
   isTouch: boolean;
   onOpenSettings: () => void;
   onOpenMap: () => void;
+  onOpenWardrobe: () => void;
   onToggleFullscreen: () => void;
+  onExit: () => void;
 }
 
-export default function HUD({ beluLine, nearZone, stickers, totalStars, isTouch, onOpenSettings, onOpenMap, onToggleFullscreen }: Props) {
+export default function HUD({ beluLine, nearZone, stickers, totalStars, isTouch, onOpenSettings, onOpenMap, onOpenWardrobe, onToggleFullscreen, onExit }: Props) {
   const zoneMeta = nearZone && nearZone !== 'home' ? ISLANDS[nearZone] : null;
 
   return (
@@ -61,6 +63,14 @@ export default function HUD({ beluLine, nearZone, stickers, totalStars, isTouch,
           )}
         </div>
         <button
+          onClick={onOpenWardrobe}
+          className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg shadow-lg backdrop-blur transition hover:bg-white"
+          aria-label="Dress up Belu"
+          title="Dress up Belu"
+        >
+          🎩
+        </button>
+        <button
           onClick={onOpenMap}
           className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg shadow-lg backdrop-blur transition hover:bg-white"
           aria-label="Growth map"
@@ -74,6 +84,14 @@ export default function HUD({ beluLine, nearZone, stickers, totalStars, isTouch,
           title="Full screen"
         >
           ⛶
+        </button>
+        <button
+          onClick={onExit}
+          className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg shadow-lg backdrop-blur transition hover:bg-white"
+          aria-label="Exit game"
+          title="Exit"
+        >
+          ✕
         </button>
         <button
           onClick={onOpenSettings}

--- a/components/game/BelusWorld/ui/Wardrobe.tsx
+++ b/components/game/BelusWorld/ui/Wardrobe.tsx
@@ -1,0 +1,108 @@
+// ---------------------------------------------------------------------------
+// Belu's Wardrobe — the reward for finishing levels. Each completed level
+// unlocks a new accessory; here the child dresses Belu up (a hat, shades, a
+// cape…). Equipping is instant and saved, so Belu keeps the look across visits.
+// ---------------------------------------------------------------------------
+
+import { motion } from 'framer-motion';
+import {
+  COSMETICS,
+  type CosmeticSlot,
+  type GameProgress,
+} from '../belu/progress';
+
+const SLOTS: { slot: CosmeticSlot; label: string }[] = [
+  { slot: 'head', label: 'Hats' },
+  { slot: 'face', label: 'Glasses' },
+  { slot: 'back', label: 'Capes & Wings' },
+];
+
+export default function Wardrobe({
+  progress,
+  onEquip,
+  onClose,
+}: {
+  progress: GameProgress;
+  onEquip: (slot: CosmeticSlot, id: string | null) => void;
+  onClose: () => void;
+}) {
+  const unlockedCount = progress.unlocked.length;
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      className="fixed inset-0 z-[60] flex items-center justify-center p-4"
+      style={{ background: 'rgba(20,28,46,0.55)', backdropFilter: 'blur(10px)' }}
+    >
+      <motion.div
+        initial={{ scale: 0.92, y: 20 }}
+        animate={{ scale: 1, y: 0 }}
+        exit={{ scale: 0.92 }}
+        transition={{ type: 'spring', stiffness: 260, damping: 24 }}
+        className="max-h-[88vh] w-full max-w-md overflow-y-auto rounded-[28px] bg-white p-6 shadow-2xl"
+      >
+        <div className="mb-1 flex items-center justify-between">
+          <h2 className="text-2xl font-black text-slate-800">Belu's Wardrobe 🎩</h2>
+          <button onClick={onClose} className="flex h-9 w-9 items-center justify-center rounded-full bg-slate-100 text-slate-500">
+            ✕
+          </button>
+        </div>
+        <p className="mb-4 text-sm font-semibold text-violet-500">
+          {unlockedCount} of {COSMETICS.length} unlocked · finish levels to earn more!
+        </p>
+
+        {SLOTS.map(({ slot, label }) => {
+          const items = COSMETICS.filter((c) => c.slot === slot);
+          const equippedId = progress.equipped[slot];
+          return (
+            <div key={slot} className="mb-4">
+              <h3 className="mb-2 text-xs font-bold uppercase tracking-wide text-slate-400">{label}</h3>
+              <div className="flex flex-wrap gap-2">
+                {/* "take it off" option */}
+                <button
+                  onClick={() => onEquip(slot, null)}
+                  className={`flex h-16 w-16 flex-col items-center justify-center rounded-2xl border-2 text-2xl ${
+                    !equippedId ? 'border-violet-400 bg-violet-50' : 'border-slate-100 bg-slate-50'
+                  }`}
+                >
+                  🚫
+                  <span className="text-[9px] font-bold text-slate-400">None</span>
+                </button>
+                {items.map((c) => {
+                  const unlocked = progress.unlocked.includes(c.id);
+                  const equipped = equippedId === c.id;
+                  return (
+                    <button
+                      key={c.id}
+                      disabled={!unlocked}
+                      onClick={() => onEquip(slot, c.id)}
+                      title={unlocked ? c.name : 'Finish a level to unlock'}
+                      className={`relative flex h-16 w-16 flex-col items-center justify-center rounded-2xl border-2 text-2xl transition ${
+                        equipped
+                          ? 'border-violet-500 bg-violet-100'
+                          : unlocked
+                            ? 'border-slate-200 bg-white hover:bg-slate-50'
+                            : 'border-slate-100 bg-slate-100 opacity-60'
+                      }`}
+                    >
+                      <span style={{ filter: unlocked ? 'none' : 'grayscale(1)' }}>{c.icon}</span>
+                      <span className="text-[9px] font-bold text-slate-400">{unlocked ? c.name.split(' ')[0] : '🔒'}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+
+        <button
+          onClick={onClose}
+          className="mt-2 w-full rounded-full bg-violet-500 py-3 text-lg font-bold text-white shadow-lg transition active:scale-95"
+        >
+          Looking good! →
+        </button>
+      </motion.div>
+    </motion.div>
+  );
+}


### PR DESCRIPTION
Major reshape of Feelings Meadow from owner playtest feedback.

### Feelings are now evident — real 3D animals
- New `Animal3D`: fox/bunny/bear/bird/cat from primitives, each **acting out the feeling with its body** (scared = crouch + tremble, sad = slump, lonely/worried, happy = bounce). No more emoji blobs.

### The owner's interaction design
- Walk up to an animal → **linger a moment** → a 👀 then a **clue bubble + line** about how it feels → **3 ways to help** appear → walk into / tap the **kind** one → the animal cheers up and flowers bloom. No-fail (gentle retry). Reading body language + choosing kindness — a real social skill, not an abstract quiz.

### A reason to finish — cosmetics + wardrobe
- Completing a level **unlocks a cosmetic** (cap, bow, shades, cape, party/crown/wizard hats, fairy wings). `Belu3D` renders worn items; a **Wardrobe (🎩)** lets the child dress Belu; the first earned item auto-equips; the unlock shows in the celebration. Saved across visits.

### Fullscreen + visible controls
- The game is now a **full-viewport overlay**, so the HUD controls aren't hidden behind the site nav. Added in-game **Full Screen (⛶)** and **Exit (✕)**, plus a Full Screen button on the menu.

### Verify
`tsc` + `vite build` clean. Headless playtest: Meadow L1 completes via observe→help (no quiz) → unlocks + equips the Explorer Cap → progress persisted; HUD controls, clue bubble, and 3 help options confirmed on-screen with zero JS errors.

Note: only Feelings Meadow uses this model so far; the other 3 islands still use the orb model and will be reshaped next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)