### PR TITLE
Belu's World: bubble spacing, solid animals/objects, home button

### DIFF
--- a/components/game/BelusWorld/index.tsx
+++ b/components/game/BelusWorld/index.tsx
@@ -15,7 +15,7 @@ import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } fro
 import { AnimatePresence, motion } from 'framer-motion';
 import type { BeluEmotion } from './BeluCharacter';
 import { ISLANDS, type ZoneId } from './three/worldConfig';
-import { attachKeyboard } from './three/input';
+import { attachKeyboard, queueGoHome } from './three/input';
 import HUD from './ui/HUD';
 import TouchControls from './ui/TouchControls';
 import GrowthMap from './ui/GrowthMap';
@@ -239,6 +239,7 @@ export default function BelusWorldGame() {
         onOpenMap={() => setShowMap(true)}
         onOpenWardrobe={() => setShowWardrobe(true)}
         onToggleFullscreen={toggleFullscreen}
+        onGoHome={() => { queueGoHome(); sfx('tap'); }}
         onExit={() => { stopSpeaking(); window.history.back(); }}
       />
 

--- a/components/game/BelusWorld/three/Player.tsx
+++ b/components/game/BelusWorld/three/Player.tsx
@@ -13,7 +13,7 @@ import * as THREE from 'three';
 import Belu3D, { type MotionRef } from './Belu3D';
 import { sampleGround } from './worldMath';
 import { input } from './input';
-import { beluPos, beluState } from './playerState';
+import { beluPos, beluState, dynamicSolids } from './playerState';
 import { ISLANDS, ZONE_ISLANDS, INTERACT_RADIUS, PLAYER_SPAWN, OBSTACLES, type ZoneId } from './worldConfig';
 import type { BeluEmotion } from '../BeluCharacter';
 import type { EquippedCosmetics } from '../belu/progress';
@@ -74,6 +74,14 @@ const Player = forwardRef<PlayerHandle, Props>(function Player(
       if (nearZone.current && onEnter) onEnter(nearZone.current);
     }
 
+    // ---- warp home (quick-travel button) ----
+    if (input.goHomeQueued) {
+      input.goHomeQueued = false;
+      pos.current.set(PLAYER_SPAWN.x, sampleGround(PLAYER_SPAWN.x, PLAYER_SPAWN.z).y + 0.5, PLAYER_SPAWN.z);
+      vy.current = 0;
+      vel.current.set(0, 0, 0);
+    }
+
     if (paused) {
       motion.current.speed = 0;
       // keep camera trained on Belu while a panel is open
@@ -93,15 +101,21 @@ const Player = forwardRef<PlayerHandle, Props>(function Player(
     pos.current.x += vel.current.x * dt;
     pos.current.z += vel.current.z * dt;
 
-    // ---- solid obstacles (walk around, not through) ----
-    for (const o of OBSTACLES) {
-      const dx = pos.current.x - o.x;
-      const dz = pos.current.z - o.z;
+    // ---- solid things (walk around, not through): static obstacles +
+    //      animals/friends that each layer registers as dynamic solids ----
+    const pushOut = (ox: number, oz: number, r: number) => {
+      const dx = pos.current.x - ox;
+      const dz = pos.current.z - oz;
       const d = Math.hypot(dx, dz);
-      if (d < o.r && d > 1e-4) {
-        pos.current.x = o.x + (dx / d) * o.r;
-        pos.current.z = o.z + (dz / d) * o.r;
+      if (d < r && d > 1e-4) {
+        pos.current.x = ox + (dx / d) * r;
+        pos.current.z = oz + (dz / d) * r;
       }
+    };
+    for (const o of OBSTACLES) pushOut(o.x, o.z, o.r);
+    for (const key in dynamicSolids) {
+      const list = dynamicSolids[key];
+      for (let i = 0; i < list.length; i++) pushOut(list[i].x, list[i].z, list[i].r);
     }
 
     // ---- jump + gravity ----

--- a/components/game/BelusWorld/three/input.ts
+++ b/components/game/BelusWorld/three/input.ts
@@ -13,6 +13,8 @@ export interface InputState {
   jumpQueued: boolean;
   /** edge-triggered interact request (E / tap action) */
   interactQueued: boolean;
+  /** edge-triggered "warp back to home island" request */
+  goHomeQueued: boolean;
 }
 
 export const input: InputState = {
@@ -20,7 +22,12 @@ export const input: InputState = {
   moveZ: 0,
   jumpQueued: false,
   interactQueued: false,
+  goHomeQueued: false,
 };
+
+export function queueGoHome() {
+  input.goHomeQueued = true;
+}
 
 const keys = new Set<string>();
 

--- a/components/game/BelusWorld/three/playerState.ts
+++ b/components/game/BelusWorld/three/playerState.ts
@@ -12,3 +12,15 @@ export const beluPos = new THREE.Vector3(0, 0.4, 6);
 
 /** Is Belu currently standing on the ground (not mid-jump)? */
 export const beluState = { grounded: true };
+
+export interface Solid {
+  x: number;
+  z: number;
+  r: number;
+}
+
+// Moving / per-island solids Belu can't walk through (animals, friends). Each
+// layer (StoryLayer, QuestLayer) writes its own keyed slice every frame; the
+// Player controller pushes Belu out of all of them. Static solids (mountain,
+// hut, trees) live in worldConfig.OBSTACLES.
+export const dynamicSolids: Record<string, Solid[]> = {};

--- a/components/game/BelusWorld/three/quest/AnswerOrb.tsx
+++ b/components/game/BelusWorld/three/quest/AnswerOrb.tsx
@@ -53,7 +53,7 @@ export default function AnswerOrb({ position, emoji, caption, color, status, bob
       // is Belu close enough to choose me? → swell + brighten so it's obvious
       const near =
         Math.hypot(beluPos.x - position[0], beluPos.z - position[2]) < NEAR_DIST;
-      const targetScale = near ? 1.28 : 1;
+      const targetScale = near ? 1.12 : 1;
       const s = grp.current.scale.x + (targetScale - grp.current.scale.x) * Math.min(1, dt * 8);
       // idle bob (a little livelier when Belu is near)
       const bob = Math.sin(t.current * 2) * (near ? 0.2 : 0.12);
@@ -87,7 +87,7 @@ export default function AnswerOrb({ position, emoji, caption, color, status, bob
         onPointerOver={() => (document.body.style.cursor = 'pointer')}
         onPointerOut={() => (document.body.style.cursor = 'auto')}
       >
-        <sphereGeometry args={[0.85, 24, 18]} />
+        <sphereGeometry args={[0.6, 24, 18]} />
         <meshStandardMaterial
           color={color}
           emissive={color}
@@ -95,17 +95,17 @@ export default function AnswerOrb({ position, emoji, caption, color, status, bob
           roughness={0.25}
           metalness={0.1}
           transparent
-          opacity={0.4}
+          opacity={0.38}
           depthWrite={false}
         />
       </mesh>
       {/* picture + word — always on top of the bubble & facing the camera */}
-      <sprite position={[0, 0, 0]} scale={[1.9, 1.9, 1]} renderOrder={10}>
+      <sprite position={[0, 0, 0]} scale={[1.5, 1.5, 1]} renderOrder={10}>
         <spriteMaterial map={tex} transparent depthWrite={false} depthTest={false} />
       </sprite>
       {/* soft glow ring under it on the ground */}
-      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -1.05, 0]}>
-        <ringGeometry args={[0.7, 1.0, 28]} />
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.75, 0]}>
+        <ringGeometry args={[0.45, 0.66, 28]} />
         <meshBasicMaterial color={color} transparent opacity={0.35} side={THREE.DoubleSide} />
       </mesh>
     </group>

--- a/components/game/BelusWorld/three/quest/QuestLayer.tsx
+++ b/components/game/BelusWorld/three/quest/QuestLayer.tsx
@@ -13,7 +13,7 @@
 import { useRef, useState } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { ISLANDS } from '../worldConfig';
-import { beluPos } from '../playerState';
+import { beluPos, dynamicSolids } from '../playerState';
 import type { ActivityZone } from '../../belu/progress';
 import type { BeluEmotion } from '../../BeluCharacter';
 import { getQuest, starsFromSlips, type Quest, type QuestRound } from './quests';
@@ -286,6 +286,11 @@ export default function QuestLayer(props: Props) {
   // ---- per-frame logic ----
   frame.current = (dt: number) => {
     const st = S.current;
+    // keep each island's friend registered as a solid thing (walk around them)
+    dynamicSolids.quest = zones.map((z) => {
+      const isl = ISLANDS[z];
+      return { x: isl.cx, z: isl.cz, r: 1.05 };
+    });
     if (import.meta.env.DEV) {
       (window as unknown as { __quest?: unknown }).__quest = {
         zone: st.zone, roundIdx: st.roundIdx, picked: st.picked.size,

--- a/components/game/BelusWorld/three/quest/StoryLayer.tsx
+++ b/components/game/BelusWorld/three/quest/StoryLayer.tsx
@@ -13,7 +13,7 @@ import { useFrame } from '@react-three/fiber';
 import { Sparkles } from '@react-three/drei';
 import * as THREE from 'three';
 import { ISLANDS } from '../worldConfig';
-import { beluPos } from '../playerState';
+import { beluPos, dynamicSolids } from '../playerState';
 import type { BeluEmotion } from '../../BeluCharacter';
 import Animal3D, { type AnimalMood } from './Animal3D';
 import AnswerOrb, { type OrbStatus } from './AnswerOrb';
@@ -23,10 +23,11 @@ import { MEADOW_STORY } from './storyContent';
 import type { QuestStatus } from './QuestLayer';
 
 const ZONE = 'meadow' as const;
-const APPROACH = 3.2; // get this close to a friend to start observing
+const APPROACH = 4.6; // stay this close to a friend while observing & choosing
 const LINGER = 1.6; // seconds of staying close before the clue appears
-const HELP_DIST = 2.0; // how far the help bubbles sit in front of a friend
-const HELP_PICK = 1.7; // walk this close to a help bubble to choose it
+const HELP_DIST = 2.3; // how far the help bubbles sit in front of a friend
+const HELP_SPREAD = 2.8; // sideways gap between the 3 help bubbles (no overlap)
+const HELP_PICK = 1.5; // walk this close to a help bubble to choose it
 
 const FEELING_FACE: Record<AnimalMood, string> = {
   scared: '😨', sad: '😢', lonely: '😞', worried: '😟', happy: '😊',
@@ -92,9 +93,9 @@ export default function StoryLayer(props: Props) {
     const px = -dz;
     const pz = dx;
     return [-1, 0, 1].map((o) => [
-      fx + dx * HELP_DIST + px * o * 1.8,
+      fx + dx * HELP_DIST + px * o * HELP_SPREAD,
       isl.top + 1.0,
-      fz + dz * HELP_DIST + pz * o * 1.8,
+      fz + dz * HELP_DIST + pz * o * HELP_SPREAD,
     ]);
   }
 
@@ -174,6 +175,12 @@ export default function StoryLayer(props: Props) {
 
   frame.current = (dt: number) => {
     const st = S.current;
+    // keep the meadow animals registered as solid things (walk around them)
+    const lvlFriends = MEADOW_STORY[clampLevel(st.level)].friends;
+    dynamicSolids.meadow = lvlFriends.map((_, i) => {
+      const [fx, fz] = friendWorld(i);
+      return { x: fx, z: fz, r: 1.05 };
+    });
     if (props.paused) return;
     st.clock += dt;
 

--- a/components/game/BelusWorld/three/worldConfig.ts
+++ b/components/game/BelusWorld/three/worldConfig.ts
@@ -129,5 +129,16 @@ export interface Obstacle {
 export const OBSTACLES: Obstacle[] = (() => {
   const m = ISLANDS.mountain;
   const len = Math.hypot(m.cx, m.cz) || 1;
-  return [{ x: m.cx + (m.cx / len) * 6.5, z: m.cz + (m.cz / len) * 6.5, r: 3.0 }];
+  const home = ISLANDS.home;
+  const meadow = ISLANDS.meadow;
+  return [
+    // Morning Mountain peak
+    { x: m.cx + (m.cx / len) * 6.5, z: m.cz + (m.cz / len) * 6.5, r: 3.0 },
+    // home cottage + its welcome trees (positions mirror HomeDecor in World.tsx)
+    { x: home.cx + 0, z: home.cz - 2, r: 1.7 },
+    { x: home.cx + 3.5, z: home.cz + 1, r: 0.7 },
+    { x: home.cx - 3.8, z: home.cz + 0.5, r: 0.7 },
+    // the meadow's big tree (mirrors ZoneDecor meadow tree)
+    { x: meadow.cx + meadow.radius * 0.5, z: meadow.cz - meadow.radius * 0.3, r: 0.7 },
+  ];
 })();

--- a/components/game/BelusWorld/ui/HUD.tsx
+++ b/components/game/BelusWorld/ui/HUD.tsx
@@ -18,10 +18,11 @@ interface Props {
   onOpenMap: () => void;
   onOpenWardrobe: () => void;
   onToggleFullscreen: () => void;
+  onGoHome: () => void;
   onExit: () => void;
 }
 
-export default function HUD({ beluLine, nearZone, stickers, totalStars, isTouch, onOpenSettings, onOpenMap, onOpenWardrobe, onToggleFullscreen, onExit }: Props) {
+export default function HUD({ beluLine, nearZone, stickers, totalStars, isTouch, onOpenSettings, onOpenMap, onOpenWardrobe, onToggleFullscreen, onGoHome, onExit }: Props) {
   const zoneMeta = nearZone && nearZone !== 'home' ? ISLANDS[nearZone] : null;
 
   return (
@@ -62,6 +63,14 @@ export default function HUD({ beluLine, nearZone, stickers, totalStars, isTouch,
             </span>
           )}
         </div>
+        <button
+          onClick={onGoHome}
+          className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg shadow-lg backdrop-blur transition hover:bg-white"
+          aria-label="Go to home island"
+          title="Home base"
+        >
+          🏡
+        </button>
         <button
           onClick={onOpenWardrobe}
           className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg shadow-lg backdrop-blur transition hover:bg-white"


### PR DESCRIPTION
Owner feedback: bubbles overlap; make animals solid everywhere; quick home button.

- Smaller, wider-spaced help bubbles (no overlap/clipping); same smaller orbs on other islands.
- Belu can't walk through animals/friends (dynamic solids) or the cottage/trees (static obstacles); mountain already solid.
- 🏡 Home-base quick-travel button in the HUD.

tsc + vite build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)