### PR TITLE
Belu's World: all 4 islands are now real play (no more quiz)

### DIFF
--- a/components/game/BelusWorld/three/GameCanvas.tsx
+++ b/components/game/BelusWorld/three/GameCanvas.tsx
@@ -15,8 +15,11 @@ import { EffectComposer, Bloom } from '@react-three/postprocessing';
 import * as THREE from 'three';
 import Player, { type PlayerHandle } from './Player';
 import World from './World';
-import QuestLayer, { type QuestStatus } from './quest/QuestLayer';
+import { type QuestStatus } from './quest/QuestLayer';
 import StoryLayer from './quest/StoryLayer';
+import ForestLayer from './quest/ForestLayer';
+import MountainLayer from './quest/MountainLayer';
+import CoveLayer from './quest/CoveLayer';
 import { PLAYER_SPAWN, type ZoneId } from './worldConfig';
 import type { BeluEmotion } from '../BeluCharacter';
 import type { ActivityZone } from '../belu/progress';
@@ -146,8 +149,10 @@ export default function GameCanvas({
           growthStage={growthStage}
           equipped={equipped}
         />
-        {/* Feelings Meadow is caring-play (StoryLayer); the other islands use
-            the quest/orb layer. */}
+        {/* Each island now has its own bespoke play layer: Feelings Meadow is
+            caring-play (StoryLayer), Friendship Forest is magic words
+            (ForestLayer), Morning Mountain is do-the-routine (MountainLayer),
+            and Calm Cove is calm-the-storm breathing (CoveLayer). */}
         <StoryLayer
           level={islandNextLevel.meadow}
           paused={paused}
@@ -157,12 +162,27 @@ export default function GameCanvas({
           onComplete={onQuestComplete}
           onStatus={onQuestStatus}
         />
-        <QuestLayer
-          islandNextLevel={islandNextLevel}
-          zones={['mountain', 'cove', 'forest']}
+        <ForestLayer
+          level={islandNextLevel.forest}
           paused={paused}
-          reduceMotion={reduceMotion}
-          sound={sound}
+          speak={speak}
+          setEmotion={setEmotion}
+          playSound={playSound}
+          onComplete={onQuestComplete}
+          onStatus={onQuestStatus}
+        />
+        <MountainLayer
+          level={islandNextLevel.mountain}
+          paused={paused}
+          speak={speak}
+          setEmotion={setEmotion}
+          playSound={playSound}
+          onComplete={onQuestComplete}
+          onStatus={onQuestStatus}
+        />
+        <CoveLayer
+          level={islandNextLevel.cove}
+          paused={paused}
           speak={speak}
           setEmotion={setEmotion}
           playSound={playSound}

--- a/components/game/BelusWorld/three/quest/CoveLayer.tsx
+++ b/components/game/BelusWorld/three/quest/CoveLayer.tsx
@@ -1,0 +1,487 @@
+// ---------------------------------------------------------------------------
+// Calm Cove — "calm the storm" (self-regulation).
+//   • The cove water starts agitated: a dark, choppy plane with cold rain.
+//   • Belu arrives → a BreatheOrb appears. As the child FOLLOWS the breaths, the
+//     sea visibly CALMS each cycle — the waves settle, the colour brightens from
+//     stormy grey-blue toward bright cyan.
+//   • When the sea is fully calm, fish leap and a rainbow arcs over the cove, and
+//     Belu is calm.
+//   • Higher levels add a gentle pre-step before breathing (a body-scan spot, a
+//     calm strategy, or a 3-part calm plan) walked to as glowing AnswerOrb totems.
+// No quiz feel, no fail: you literally calm the sea by breathing. Wrong taps just
+// wiggle (handled by AnswerOrb) and earn a kind word — never a buzzer.
+// ---------------------------------------------------------------------------
+
+import { useRef, useState } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { Sparkles } from '@react-three/drei';
+import * as THREE from 'three';
+import { ISLANDS } from '../worldConfig';
+import { beluPos, dynamicSolids } from '../playerState';
+import type { BeluEmotion } from '../../BeluCharacter';
+import AnswerOrb, { type OrbStatus } from './AnswerOrb';
+import BreatheOrb from './BreatheOrb';
+import { makeLabelTexture } from './emojiTexture';
+import { COVE_LEVELS, type CoveLevel, type CoveTotem } from './coveContent';
+import type { QuestStatus } from './QuestLayer';
+
+const ZONE = 'cove' as const;
+const TOTEM_DIST = 3.0; // how far the totems sit out in front, toward home
+const TOTEM_SPREAD = 2.9; // sideways gap between totems (no overlap)
+const TOTEM_PICK = 1.6; // walk this close to a totem to choose it
+
+// stormy → calm colours the water lerps between as breaths complete
+const STORM_COLOR = new THREE.Color('#3a4a5e'); // dark, choppy grey-blue
+const CALM_COLOR = new THREE.Color('#5fd0e0'); // the cove's bright cyan accent
+
+interface State {
+  clock: number;
+  active: boolean;
+  level: number;
+  disarmed: boolean;
+  // phase of play within an active session
+  phase: 'pre' | 'breathing' | 'done';
+  // how calm the sea is, 0 (full storm) → 1 (fully calm). Animates toward target.
+  calm: number;
+  calmTarget: number;
+  // pre-step bookkeeping
+  picked: number[]; // indices of totems walked into (plan can need several)
+  wrongIdx: number;
+  wrongUntil: number;
+  lockUntil: number;
+  finishAt: number;
+}
+
+interface Props {
+  level: number;
+  paused: boolean;
+  speak: (line: string) => void;
+  setEmotion: (e: BeluEmotion) => void;
+  playSound: (kind: 'tap' | 'correct' | 'star' | 'levelup' | 'growup') => void;
+  onComplete: (zone: 'cove', level: number, stars: number, moment: string) => void;
+  onStatus: (s: QuestStatus | null) => void;
+}
+
+function clampLevel(level: number) {
+  return Math.max(0, Math.min(COVE_LEVELS.length - 1, level - 1));
+}
+
+/** how many totems the pre-step needs walked into before breathing begins */
+function needCount(lvl: CoveLevel): number {
+  switch (lvl.pre.kind) {
+    case 'plan': return lvl.pre.need;
+    case 'bodySpot':
+    case 'pickOne': return 1;
+    default: return 0;
+  }
+}
+
+function preTotems(lvl: CoveLevel): CoveTotem[] {
+  return lvl.pre.kind === 'none' ? [] : lvl.pre.totems;
+}
+
+export default function CoveLayer(props: Props) {
+  const [, force] = useState(0);
+  const bump = () => force((v) => (v + 1) % 1_000_000);
+  const S = useRef<State>({
+    clock: 0, active: false, level: props.level, disarmed: false,
+    phase: 'pre', calm: 0, calmTarget: 0, picked: [],
+    wrongIdx: -1, wrongUntil: 0, lockUntil: 0, finishAt: 0,
+  });
+  const frame = useRef<(dt: number) => void>(() => {});
+  const water = useRef<THREE.Mesh>(null);
+  const isl = ISLANDS[ZONE];
+
+  // the breathing bubble sits out in front of the friend, toward home (0,0)
+  const orbPos = (): [number, number, number] => {
+    const len = Math.hypot(isl.cx, isl.cz) || 1;
+    return [isl.cx + (-isl.cx / len) * 2.6, isl.top + 2.4, isl.cz + (-isl.cz / len) * 2.6];
+  };
+
+  // lay the pre-step totems out in an arc on the home-facing side of the cove
+  function totemLayout(n: number): [number, number, number][] {
+    const len = Math.hypot(isl.cx, isl.cz) || 1;
+    const dx = -isl.cx / len; // toward home
+    const dz = -isl.cz / len;
+    const px = -dz;
+    const pz = dx;
+    const out: [number, number, number][] = [];
+    for (let i = 0; i < n; i++) {
+      const frac = n === 1 ? 0 : i / (n - 1) - 0.5;
+      const off = frac * (n - 1) * TOTEM_SPREAD;
+      out.push([
+        isl.cx + dx * TOTEM_DIST + px * off,
+        isl.top + 1.0,
+        isl.cz + dz * TOTEM_DIST + pz * off,
+      ]);
+    }
+    return out;
+  }
+
+  function emitStatus(phase: 'question' | 'correct', instruction: string, hint?: string) {
+    const lvl = COVE_LEVELS[clampLevel(S.current.level)];
+    const need = needCount(lvl);
+    // step/total reflect the pre-step progress so the task card shows movement
+    props.onStatus({
+      zone: ZONE, title: isl.label, emoji: isl.emoji, accent: isl.accent,
+      level: S.current.level, instruction,
+      step: S.current.phase === 'pre' ? S.current.picked.length : need,
+      total: Math.max(1, need),
+      phase, hint,
+    });
+  }
+
+  function startSession() {
+    const lvl = COVE_LEVELS[clampLevel(props.level)];
+    const st = S.current;
+    st.active = true;
+    st.level = props.level;
+    st.picked = [];
+    st.wrongIdx = -1;
+    st.finishAt = 0;
+    st.calm = 0;
+    st.calmTarget = 0;
+    props.setEmotion('overwhelmed'); // the sea (and Belu) start stormy
+    props.speak(lvl.intro);
+    if (needCount(lvl) > 0) {
+      st.phase = 'pre';
+      st.lockUntil = st.clock + 0.4;
+      emitStatus('question', lvl.intro, preHint(lvl));
+    } else {
+      // no pre-step → go straight to breathing
+      st.phase = 'breathing';
+      props.setEmotion('calm');
+      props.speak(lvl.breatheCue);
+      emitStatus('question', lvl.breatheCue, 'Follow the bubble and breathe 🫧');
+    }
+    bump();
+  }
+
+  function preHint(lvl: CoveLevel): string {
+    switch (lvl.pre.kind) {
+      case 'bodySpot': return 'Walk to a body spot to send your calm there 💙';
+      case 'pickOne': return 'Walk into one thing that helps you feel calm 💙';
+      case 'plan': return `Walk into ${lvl.pre.need} calm things to build your plan 💙`;
+      default: return 'Follow the bubble and breathe 🫧';
+    }
+  }
+
+  function stopSession() {
+    const st = S.current;
+    st.active = false;
+    st.phase = 'pre';
+    st.picked = [];
+    st.calmTarget = 0;
+    props.setEmotion('happy');
+    props.onStatus(null);
+    bump();
+  }
+
+  function finish() {
+    const lvl = COVE_LEVELS[clampLevel(S.current.level)];
+    // always errorless: a finished level is always worth 3 stars
+    props.onComplete(ZONE, S.current.level, 3, lvl.moment);
+    props.speak(lvl.outro);
+    S.current.active = false;
+    S.current.disarmed = true;
+    S.current.phase = 'pre';
+    props.onStatus(null);
+    bump();
+  }
+
+  // child walked into / tapped a pre-step totem
+  function pickTotem(i: number) {
+    const st = S.current;
+    if (st.phase !== 'pre' || st.clock < st.lockUntil) return;
+    const lvl = COVE_LEVELS[clampLevel(st.level)];
+    const need = needCount(lvl);
+    if (st.picked.includes(i)) return; // already chosen — no double counting
+    // every totem here is a kind/valid choice (errorless), so picking always helps
+    st.picked.push(i);
+    st.lockUntil = st.clock + 0.3;
+    props.playSound('correct');
+    if (st.picked.length >= need) {
+      // pre-step complete → begin the calming breaths
+      st.phase = 'breathing';
+      st.lockUntil = st.clock + 0.5;
+      props.setEmotion('calm');
+      props.speak(lvl.breatheCue);
+      emitStatus('question', lvl.breatheCue, 'Follow the bubble and breathe 🫧');
+    } else {
+      props.setEmotion('happy');
+      emitStatus('question', lvl.intro, `Nice! Walk into ${need - st.picked.length} more 💙`);
+    }
+    bump();
+  }
+
+  // BreatheOrb tells us each phase begins; on every "Breathe out" the sea settles
+  // one notch (so the child SEES their breathing calm the storm).
+  function onBreathPhase(label: string) {
+    const st = S.current;
+    props.speak(label);
+    if (label.startsWith('Breathe out')) {
+      const lvl = COVE_LEVELS[clampLevel(st.level)];
+      // step the calm target up by one breath's worth toward fully calm
+      const stepEach = 1 / Math.max(1, lvl.cycles);
+      st.calmTarget = Math.min(1, st.calmTarget + stepEach);
+      props.playSound('tap'); // soft water "settle" tick
+      bump();
+    }
+  }
+
+  function onBreatheDone() {
+    const st = S.current;
+    st.calmTarget = 1; // sea fully calm
+    st.phase = 'done';
+    props.setEmotion('calm');
+    props.playSound('star');
+    const lvl = COVE_LEVELS[clampLevel(st.level)];
+    emitStatus('correct', lvl.outro, 'The sea is calm 🌈');
+    st.finishAt = st.clock + 2.2; // let fish leap + rainbow show before finishing
+    bump();
+  }
+
+  frame.current = (dt: number) => {
+    const st = S.current;
+    // register the cove friend/totems as solids so Belu walks around them
+    const lvl = COVE_LEVELS[clampLevel(st.level)];
+    const solids: { x: number; z: number; r: number }[] = [
+      { x: isl.cx, z: isl.cz, r: 1.05 }, // the calm-friend at centre
+    ];
+    if (st.active && st.phase === 'pre') {
+      totemLayout(preTotems(lvl).length).forEach((p) => solids.push({ x: p[0], z: p[2], r: 0.7 }));
+    }
+    dynamicSolids.cove = solids;
+
+    if (props.paused) return;
+    st.clock += dt;
+
+    // ease the visible sea-calm toward its target every frame
+    st.calm += (st.calmTarget - st.calm) * Math.min(1, dt * 2.2);
+
+    // animate the water mesh: choppy & dark when stormy, flat & bright when calm
+    if (water.current) {
+      const m = water.current.material as THREE.MeshStandardMaterial;
+      m.color.copy(STORM_COLOR).lerp(CALM_COLOR, st.calm);
+      m.emissive.copy(CALM_COLOR);
+      m.emissiveIntensity = 0.05 + st.calm * 0.35;
+      // chop: bob/tilt the plane a lot when stormy, almost still when calm
+      const chop = (1 - st.calm) * 0.5;
+      water.current.position.y = isl.top - 0.35 + Math.sin(st.clock * 3.2) * chop * 0.25;
+      water.current.rotation.x = -Math.PI / 2 + Math.sin(st.clock * 2.1) * chop * 0.06;
+      water.current.rotation.z = Math.cos(st.clock * 1.7) * chop * 0.06;
+    }
+
+    if (st.finishAt > 0 && st.clock >= st.finishAt) {
+      st.finishAt = 0;
+      finish();
+      return;
+    }
+    if (st.wrongIdx >= 0 && st.clock > st.wrongUntil) {
+      st.wrongIdx = -1;
+      bump();
+    }
+
+    const dCenter = Math.hypot(beluPos.x - isl.cx, beluPos.z - isl.cz);
+    const onIsland = dCenter < isl.radius * 0.82;
+    if (st.disarmed && dCenter > isl.radius + 1.5) {
+      st.disarmed = false;
+      bump();
+    }
+    if (!st.active) {
+      if (onIsland && !st.disarmed) startSession();
+      return;
+    }
+    if (dCenter > isl.radius + 1.5) {
+      stopSession();
+      return;
+    }
+
+    // during the pre-step, detect Belu walking into a totem
+    if (st.phase === 'pre' && st.clock >= st.lockUntil) {
+      const layout = totemLayout(preTotems(lvl).length);
+      let best = -1;
+      let bestD = TOTEM_PICK;
+      for (let i = 0; i < layout.length; i++) {
+        if (st.picked.includes(i)) continue;
+        const d = Math.hypot(beluPos.x - layout[i][0], beluPos.z - layout[i][2]);
+        if (d < bestD) {
+          bestD = d;
+          best = i;
+        }
+      }
+      if (best >= 0) pickTotem(best);
+    }
+    // breathing & done phases drive themselves via BreatheOrb callbacks
+  };
+
+  // ---- render ----
+  const lvl = COVE_LEVELS[clampLevel(S.current.level)];
+  const totems = preTotems(lvl);
+  const layout = S.current.active && S.current.phase === 'pre' ? totemLayout(totems.length) : [];
+  const calm = S.current.calm;
+  const seaCalm = calm > 0.92; // fully-calm celebration threshold
+
+  return (
+    <group>
+      <Ticker fnRef={frame} />
+
+      {/* the cove water plane — choppy/dark when stormy, bright/flat when calm */}
+      <mesh ref={water} position={[isl.cx, isl.top - 0.35, isl.cz]} rotation={[-Math.PI / 2, 0, 0]}>
+        <circleGeometry args={[isl.radius * 0.92, 48]} />
+        <meshStandardMaterial
+          color={STORM_COLOR}
+          emissive={CALM_COLOR}
+          emissiveIntensity={0.05}
+          roughness={0.25}
+          metalness={0.35}
+          transparent
+          opacity={0.92}
+        />
+      </mesh>
+
+      {/* cold rain while the sea is still stormy; fades out as it calms */}
+      {S.current.active && calm < 0.7 && (
+        <Sparkles
+          count={40}
+          scale={[isl.radius * 1.6, 6, isl.radius * 1.6]}
+          size={4}
+          speed={2.4}
+          opacity={Math.max(0, 0.7 - calm) }
+          color="#bcd4e6"
+          position={[isl.cx, isl.top + 3, isl.cz]}
+        />
+      )}
+
+      {/* the calm friend at the cove centre (a gentle floating orb-buddy) */}
+      <CalmFriend
+        position={[isl.cx, isl.top + 0.9, isl.cz]}
+        color={isl.accent}
+        calm={calm}
+        clock={S.current.clock}
+      />
+
+      {/* pre-step totems (body spots / calm strategies) to walk into */}
+      {S.current.active && S.current.phase === 'pre' &&
+        totems.map((t, i) => {
+          const status: OrbStatus = S.current.picked.includes(i)
+            ? 'chosen'
+            : S.current.wrongIdx === i
+              ? 'wrong'
+              : 'idle';
+          return (
+            <AnswerOrb
+              key={`${S.current.level}-tot-${i}`}
+              position={layout[i]}
+              emoji={t.emoji}
+              caption={t.label}
+              color={isl.accent}
+              status={status}
+              bobSeed={i * 0.7}
+              onPick={() => pickTotem(i)}
+            />
+          );
+        })}
+
+      {/* the breathing bubble — appears once we're breathing the storm away */}
+      {S.current.active && S.current.phase === 'breathing' && (
+        <BreatheOrb
+          key={`${S.current.level}-breathe`}
+          position={orbPos()}
+          cycles={lvl.cycles}
+          color={isl.accent}
+          onPhase={onBreathPhase}
+          onDone={onBreatheDone}
+        />
+      )}
+
+      {/* celebration when the sea is fully calm: leaping fish + a rainbow */}
+      {seaCalm && (
+        <>
+          <Sparkles count={26} scale={5} size={7} speed={0.5} color="#bff6ff" position={[isl.cx, isl.top + 1.4, isl.cz]} />
+          <LeapingFish position={[isl.cx, isl.top, isl.cz]} radius={isl.radius * 0.55} clock={S.current.clock} />
+          <Rainbow position={[isl.cx, isl.top + 0.2, isl.cz]} radius={isl.radius * 0.8} />
+        </>
+      )}
+    </group>
+  );
+}
+
+// A soft, friendly calm-buddy that floats over the cove. It looks worried while
+// the sea is stormy and beams a happy face once it's calm — pure primitives.
+function CalmFriend({ position, color, calm, clock }: { position: [number, number, number]; color: string; calm: number; clock: number }) {
+  const grp = useRef<THREE.Group>(null);
+  // swap the face sprite between worried (stormy) and calm (settled)
+  const faceTex = useRef<{ stormy: THREE.CanvasTexture; calm: THREE.CanvasTexture }>({
+    stormy: makeLabelTexture('😣'),
+    calm: makeLabelTexture('😌'),
+  });
+  useFrame(() => {
+    if (!grp.current) return;
+    // bob faster/jitterier while stormy, gentle float once calm
+    const chop = 1 - calm;
+    grp.current.position.y = position[1] + Math.sin(clock * (1.6 + chop * 3)) * (0.08 + chop * 0.12);
+  });
+  return (
+    <group ref={grp} position={position}>
+      <mesh>
+        <sphereGeometry args={[0.7, 24, 18]} />
+        <meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.4 + calm * 0.5} roughness={0.3} metalness={0.1} />
+      </mesh>
+      <sprite position={[0, 0, 0.72]} scale={[1, 1, 1]} renderOrder={11}>
+        <spriteMaterial map={calm > 0.6 ? faceTex.current.calm : faceTex.current.stormy} transparent depthWrite={false} depthTest={false} />
+      </sprite>
+    </group>
+  );
+}
+
+// A few fish that leap in gentle arcs out of the now-calm water.
+function LeapingFish({ position, radius, clock }: { position: [number, number, number]; radius: number; clock: number }) {
+  const fish = useRef<THREE.Group>(null);
+  useFrame(() => {
+    if (!fish.current) return;
+    fish.current.children.forEach((child, i) => {
+      const phase = (clock * 0.6 + i * 0.5) % 1; // 0..1 leap progress
+      const ang = (i / 3) * Math.PI * 2 + i;
+      const r = radius * 0.6;
+      child.position.x = Math.cos(ang) * r;
+      child.position.z = Math.sin(ang) * r;
+      // a parabolic leap above the water
+      child.position.y = Math.sin(phase * Math.PI) * 1.6;
+      child.rotation.z = (phase - 0.5) * 2.2; // tip up then down
+    });
+  });
+  return (
+    <group ref={fish} position={[position[0], position[1], position[2]]}>
+      {[0, 1, 2].map((i) => (
+        <mesh key={i} scale={[0.4, 0.22, 0.16]}>
+          <sphereGeometry args={[0.5, 12, 10]} />
+          <meshStandardMaterial color="#7fdfff" emissive="#7fdfff" emissiveIntensity={0.4} roughness={0.3} />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+// A simple rainbow: concentric coloured half-torus arcs over the calm cove.
+function Rainbow({ position, radius }: { position: [number, number, number]; radius: number }) {
+  const colors = ['#ff6b6b', '#ffa94d', '#ffd43b', '#69db7c', '#4dabf7', '#b197fc'];
+  return (
+    <group position={position} rotation={[0, 0, 0]}>
+      {colors.map((c, i) => {
+        const r = radius + i * 0.5;
+        return (
+          <mesh key={c} position={[0, 0, 0]} rotation={[Math.PI / 2, 0, 0]}>
+            <torusGeometry args={[r, 0.22, 10, 40, Math.PI]} />
+            <meshStandardMaterial color={c} emissive={c} emissiveIntensity={0.6} roughness={0.4} transparent opacity={0.9} />
+          </mesh>
+        );
+      })}
+    </group>
+  );
+}
+
+function Ticker({ fnRef }: { fnRef: React.MutableRefObject<(dt: number) => void> }) {
+  useFrame((_, dt) => fnRef.current(Math.min(dt, 0.05)));
+  return null;
+}

--- a/components/game/BelusWorld/three/quest/ForestLayer.tsx
+++ b/components/game/BelusWorld/three/quest/ForestLayer.tsx
@@ -1,0 +1,438 @@
+// ---------------------------------------------------------------------------
+// Friendship Forest — MAGIC WORDS (the expressive-language island).
+//   • 3D animal friends (Animal3D) each show a thought bubble of what they WANT
+//     or SEE (a picture, on a soft thought card).
+//   • Walk Belu up to a friend and LINGER a moment → word bubbles (AnswerOrb,
+//     word as caption + matching picture) appear in an arc around them.
+//   • Walk Belu into the words IN THE RIGHT ORDER to "say" the phrase. Each
+//     correct word lights up; the wanted thing then magically appears (a
+//     Sparkles burst + the item pops) and the friend cheers.
+//   • Wrong word = a gentle wiggle + a kind nudge ("try the first word"),
+//     never a buzzer, never a fail. Single-word levels just have a 1-word order.
+// This teaches expressive language as CASTING WORD-SPELLS — using your words to
+// make real things happen — not as an abstract quiz.
+//
+// Mirrors StoryLayer's lifecycle exactly: arm on the island, abort if Belu
+// leaves, finish → disarm → re-arm only after Belu wanders off again.
+// ---------------------------------------------------------------------------
+
+import { useRef, useState } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { Sparkles } from '@react-three/drei';
+import * as THREE from 'three';
+import { ISLANDS } from '../worldConfig';
+import { beluPos, dynamicSolids } from '../playerState';
+import type { BeluEmotion } from '../../BeluCharacter';
+import Animal3D from './Animal3D';
+import AnswerOrb, { type OrbStatus } from './AnswerOrb';
+import { makeLabelTexture } from './emojiTexture';
+import { FOREST_STORY, type SpellWord } from './forestContent';
+import type { QuestStatus } from './QuestLayer';
+
+const ZONE = 'forest' as const;
+const APPROACH = 4.8; // stay this close to a friend while it listens & you cast
+const LINGER = 1.4; // seconds close before the word bubbles appear
+const WORD_DIST = 3.0; // how far the word bubbles sit in front of the friend
+const WORD_SPREAD = 2.6; // sideways gap between word bubbles (no overlap)
+const WORD_PICK = 1.5; // walk this close to a word bubble to "say" it
+
+// Deterministic shuffle (no Math.random at render/module time — like the rest of
+// the world). Same friend always lays its words out the same way.
+function ordered(spell: SpellWord[], decoys: SpellWord[], seed: number): SpellWord[] {
+  const all = [...spell, ...decoys];
+  // a tiny seeded sort: score each word by a hash of (seed, index) so the order
+  // is stable per friend but mixes the correct words among the decoys.
+  return all
+    .map((wd, i) => ({ wd, k: Math.sin((seed + 1) * 12.9898 + i * 78.233) }))
+    .sort((a, b) => a.k - b.k)
+    .map((o) => o.wd);
+}
+
+interface FriendRT {
+  done: boolean;
+  doneAt: number;
+}
+interface State {
+  clock: number;
+  active: boolean;
+  level: number;
+  friends: FriendRT[];
+  finished: number; // how many friends have completed their spell
+  disarmed: boolean;
+  // the friend currently being talked to
+  activeFriend: number;
+  lingerStart: number;
+  listening: boolean; // true once the word bubbles are showing
+  progress: number; // how many words of the current spell have been cast
+  wrongIdx: number; // word bubble showing a wiggle, or -1
+  wrongUntil: number;
+  lockUntil: number;
+  finishAt: number;
+}
+
+interface Props {
+  level: number;
+  paused: boolean;
+  speak: (line: string) => void;
+  setEmotion: (e: BeluEmotion) => void;
+  playSound: (kind: 'tap' | 'correct' | 'star' | 'levelup' | 'growup') => void;
+  onComplete: (zone: 'forest', level: number, stars: number, moment: string) => void;
+  onStatus: (s: QuestStatus | null) => void;
+}
+
+function clampLevel(level: number) {
+  return Math.max(0, Math.min(FOREST_STORY.length - 1, level - 1));
+}
+
+export default function ForestLayer(props: Props) {
+  const [, force] = useState(0);
+  const bump = () => force((v) => (v + 1) % 1_000_000);
+  const S = useRef<State>({
+    clock: 0, active: false, level: props.level,
+    friends: FOREST_STORY[clampLevel(props.level)].friends.map(() => ({ done: false, doneAt: -99 })),
+    finished: 0, disarmed: false, activeFriend: -1, lingerStart: 0, listening: false,
+    progress: 0, wrongIdx: -1, wrongUntil: 0, lockUntil: 0, finishAt: 0,
+  });
+  const frame = useRef<(dt: number) => void>(() => {});
+  const isl = ISLANDS[ZONE];
+
+  const friendWorld = (i: number): [number, number] => {
+    const fr = FOREST_STORY[clampLevel(S.current.level)].friends[i];
+    return [isl.cx + fr.pos[0], isl.cz + fr.pos[1]];
+  };
+
+  // the laid-out word bubbles for a friend (correct words + decoys, mixed)
+  function wordsFor(i: number): SpellWord[] {
+    const fr = FOREST_STORY[clampLevel(S.current.level)].friends[i];
+    return ordered(fr.spell, fr.decoys, i + 1);
+  }
+
+  // arc of word bubbles on the home-facing side of a friend (same math as
+  // StoryLayer's help layout so it reads from any approach angle)
+  function wordLayout(i: number): [number, number, number][] {
+    const [fx, fz] = friendWorld(i);
+    const words = wordsFor(i);
+    const n = words.length;
+    const len = Math.hypot(fx, fz) || 1;
+    const dx = -fx / len; // toward home (0,0)
+    const dz = -fz / len;
+    const px = -dz;
+    const pz = dx;
+    const out: [number, number, number][] = [];
+    for (let k = 0; k < n; k++) {
+      const frac = n === 1 ? 0 : k / (n - 1) - 0.5;
+      const off = frac * (n - 1) * WORD_SPREAD;
+      out.push([
+        fx + dx * WORD_DIST + px * off,
+        isl.top + 1.0,
+        fz + dz * WORD_DIST + pz * off,
+      ]);
+    }
+    return out;
+  }
+
+  function emitStatus(phase: 'question' | 'correct', instruction: string, hint?: string) {
+    const lvl = FOREST_STORY[clampLevel(S.current.level)];
+    props.onStatus({
+      zone: ZONE, title: isl.label, emoji: isl.emoji, accent: isl.accent,
+      level: S.current.level, instruction, step: S.current.finished,
+      total: lvl.friends.length, phase, hint,
+    });
+  }
+
+  function startStory() {
+    const lvl = FOREST_STORY[clampLevel(props.level)];
+    S.current.active = true;
+    S.current.level = props.level;
+    S.current.friends = lvl.friends.map(() => ({ done: false, doneAt: -99 }));
+    S.current.finished = 0;
+    S.current.activeFriend = -1;
+    S.current.listening = false;
+    S.current.progress = 0;
+    props.setEmotion('curious');
+    props.speak(lvl.intro);
+    emitStatus('question', lvl.intro, 'Walk up to a friend to hear their wish 💜');
+    bump();
+  }
+
+  function stopStory() {
+    S.current.active = false;
+    S.current.activeFriend = -1;
+    S.current.listening = false;
+    S.current.progress = 0;
+    props.setEmotion('happy');
+    props.onStatus(null);
+    bump();
+  }
+
+  function finish() {
+    const lvl = FOREST_STORY[clampLevel(S.current.level)];
+    // errorless & no-fail: every completed level is worth a full 3 stars
+    props.onComplete(ZONE, S.current.level, 3, lvl.moment);
+    props.speak(lvl.outro);
+    S.current.active = false;
+    S.current.disarmed = true;
+    S.current.activeFriend = -1;
+    S.current.listening = false;
+    props.onStatus(null);
+    bump();
+  }
+
+  // the phrase, spaced out, for the on-screen hint ("apple" or "want ball")
+  function phraseOf(i: number): string {
+    return FOREST_STORY[clampLevel(S.current.level)].friends[i].spell.map((s) => s.word).join(' ');
+  }
+
+  // Belu walked into the word bubble at layout index `k`.
+  function castWord(i: number, k: number) {
+    const st = S.current;
+    if (st.clock < st.lockUntil) return;
+    const fr = FOREST_STORY[clampLevel(st.level)].friends[i];
+    const words = wordsFor(i);
+    const said = words[k].word;
+    const expected = fr.spell[st.progress].word;
+
+    if (said === expected) {
+      st.progress += 1;
+      props.playSound('correct');
+      if (st.progress >= fr.spell.length) {
+        // the whole spell landed → the wanted thing magically appears
+        st.friends[i].done = true;
+        st.friends[i].doneAt = st.clock;
+        st.finished += 1;
+        st.listening = false;
+        st.lockUntil = st.clock + 0.8;
+        props.playSound('star');
+        props.setEmotion('excited');
+        emitStatus('correct', fr.cheer);
+        const total = FOREST_STORY[clampLevel(st.level)].friends.length;
+        if (st.finished >= total) st.finishAt = st.clock + 1.6;
+        else {
+          // move on: let Belu wander to the next friend
+          st.activeFriend = -1;
+        }
+      } else {
+        // partway through a multi-word spell — keep going to the next word
+        st.lockUntil = st.clock + 0.3;
+        props.setEmotion('happy');
+        const next = fr.spell[st.progress].word;
+        emitStatus('question', `Say "${phraseOf(i)}"`, `Now walk into "${next}" 💜`);
+      }
+      bump();
+    } else {
+      // gentle wiggle — never a fail. Nudge toward the right next word.
+      st.wrongIdx = k;
+      st.wrongUntil = st.clock + 0.5;
+      st.lockUntil = st.clock + 0.5;
+      props.playSound('tap');
+      props.setEmotion('curious');
+      props.speak(st.progress === 0 ? `Try the first word — "${expected}".` : `Almost! Next is "${expected}".`);
+      bump();
+    }
+  }
+
+  frame.current = (dt: number) => {
+    const st = S.current;
+    // keep the forest animals registered as solid (Belu walks around them)
+    const lvlFriends = FOREST_STORY[clampLevel(st.level)].friends;
+    dynamicSolids.forest = lvlFriends.map((_, i) => {
+      const [fx, fz] = friendWorld(i);
+      return { x: fx, z: fz, r: 1.05 };
+    });
+    if (props.paused) return;
+    st.clock += dt;
+
+    if (st.finishAt > 0 && st.clock >= st.finishAt) {
+      st.finishAt = 0;
+      finish();
+      return;
+    }
+    if (st.wrongIdx >= 0 && st.clock > st.wrongUntil) {
+      st.wrongIdx = -1;
+      bump();
+    }
+
+    const dCenter = Math.hypot(beluPos.x - isl.cx, beluPos.z - isl.cz);
+    const onIsland = dCenter < isl.radius * 0.82;
+    if (st.disarmed && dCenter > isl.radius + 1.5) {
+      st.disarmed = false;
+      bump();
+    }
+    if (!st.active) {
+      if (onIsland && !st.disarmed) startStory();
+      return;
+    }
+    if (dCenter > isl.radius + 1.5) {
+      stopStory();
+      return;
+    }
+
+    const friends = FOREST_STORY[clampLevel(st.level)].friends;
+
+    // which unfinished friend is Belu nearest to?
+    let near = -1;
+    let nearD = APPROACH;
+    for (let i = 0; i < friends.length; i++) {
+      if (st.friends[i].done) continue;
+      const [fx, fz] = friendWorld(i);
+      const d = Math.hypot(beluPos.x - fx, beluPos.z - fz);
+      if (d < nearD) {
+        nearD = d;
+        near = i;
+      }
+    }
+
+    if (near === -1) {
+      if (st.activeFriend !== -1) {
+        st.activeFriend = -1;
+        st.listening = false;
+        st.progress = 0;
+        emitStatus('question', 'Walk up to a friend to hear their wish.', 'Stay close to help them cast words 💜');
+        bump();
+      }
+      return;
+    }
+
+    if (near !== st.activeFriend) {
+      st.activeFriend = near;
+      st.lingerStart = st.clock;
+      st.listening = false;
+      st.progress = 0;
+      props.setEmotion('curious');
+      bump();
+    }
+
+    if (!st.listening && st.clock - st.lingerStart >= LINGER) {
+      st.listening = true;
+      st.progress = 0;
+      const first = friends[near].spell[0].word;
+      props.speak(`Help me say "${phraseOf(near)}"!`);
+      emitStatus(
+        'question',
+        `Say "${phraseOf(near)}"`,
+        friends[near].spell.length > 1 ? `Walk into the words in order — start with "${first}" 💜` : `Walk into "${first}" 💜`,
+      );
+      st.lockUntil = st.clock + 0.4;
+      bump();
+    }
+
+    // once listening, let Belu walk into a word bubble (in order)
+    if (st.listening) {
+      const layout = wordLayout(near);
+      let best = -1;
+      let bestD = WORD_PICK;
+      for (let k = 0; k < layout.length; k++) {
+        const d = Math.hypot(beluPos.x - layout[k][0], beluPos.z - layout[k][2]);
+        if (d < bestD) {
+          bestD = d;
+          best = k;
+        }
+      }
+      if (best >= 0) castWord(near, best);
+    }
+  };
+
+  // ---- render ----
+  const friends = FOREST_STORY[clampLevel(S.current.level)].friends;
+  return (
+    <group>
+      <Ticker fnRef={frame} />
+      {friends.map((fr, i) => {
+        const rt = S.current.friends[i] ?? { done: false, doneAt: -99 };
+        const [fx, fz] = friendWorld(i);
+        const isActive = S.current.active && S.current.activeFriend === i && !rt.done;
+        const justDone = rt.done && S.current.clock - rt.doneAt < 2.5;
+        const layout = isActive && S.current.listening ? wordLayout(i) : [];
+        const words = isActive && S.current.listening ? wordsFor(i) : [];
+        return (
+          <group key={`${S.current.level}-${i}`}>
+            <Animal3D
+              species={fr.species}
+              mood={rt.done ? 'happy' : 'happy'}
+              position={[fx, isl.top, fz]}
+              seed={i * 1.7}
+            />
+            {/* thought bubble above the friend: what they want / see */}
+            {isActive && !S.current.listening && (
+              <Bubble emoji={fr.thought} position={[fx, isl.top + 1.9, fz]} />
+            )}
+            {/* the word bubbles (AnswerOrb) — walk into them in order to "say" them */}
+            {isActive && S.current.listening &&
+              layout.map((p, k) => {
+                const wd = words[k];
+                // is this bubble the word the spell wants next? (stays live & glowing)
+                const isNextExpected =
+                  S.current.progress < fr.spell.length && wd.word === fr.spell[S.current.progress].word;
+                // has a word like this already been cast earlier in the phrase?
+                const alreadyCast =
+                  fr.spell.findIndex((s, si) => si < S.current.progress && s.word === wd.word) >= 0;
+                let status: OrbStatus = 'idle';
+                if (S.current.wrongIdx === k) status = 'wrong';
+                else if (alreadyCast && !isNextExpected) status = 'chosen';
+                return (
+                  <AnswerOrb
+                    key={k}
+                    position={p}
+                    emoji={wd.emoji}
+                    caption={wd.word}
+                    color={isl.accent}
+                    status={status}
+                    bobSeed={k * 0.7}
+                    onPick={() => castWord(i, k)}
+                  />
+                );
+              })}
+            {/* the spell lands: sparkles burst + the wanted thing pops up */}
+            {justDone && (
+              <>
+                <Sparkles count={26} scale={3.2} size={7} speed={0.7} color={isl.accent} position={[fx, isl.top + 1.2, fz]} />
+                <Reward emoji={fr.reward} position={[fx, isl.top + 2.1, fz]} born={rt.doneAt} clock={S.current.clock} />
+              </>
+            )}
+            {/* the wanted thing stays as a little keepsake by the happy friend */}
+            {rt.done && !justDone && (
+              <Bubble emoji={fr.reward} position={[fx + 1.2, isl.top + 0.6, fz + 0.4]} scale={0.9} />
+            )}
+          </group>
+        );
+      })}
+    </group>
+  );
+}
+
+// A picture sprite on a thought card (what a friend wants / a kept reward).
+function Bubble({ emoji, position, scale = 1.4 }: { emoji: string; position: [number, number, number]; scale?: number }) {
+  const tex = useRef<THREE.CanvasTexture>(makeLabelTexture(emoji, undefined, true));
+  if ((tex.current as unknown as { __e?: string }).__e !== emoji) {
+    tex.current = makeLabelTexture(emoji, undefined, true);
+    (tex.current as unknown as { __e?: string }).__e = emoji;
+  }
+  return (
+    <sprite position={position} scale={[scale, scale, 1]} renderOrder={12}>
+      <spriteMaterial map={tex.current} transparent depthWrite={false} depthTest={false} />
+    </sprite>
+  );
+}
+
+// The reward item that magically appears — pops up and grows for a beat.
+function Reward({ emoji, position, born, clock }: { emoji: string; position: [number, number, number]; born: number; clock: number }) {
+  const tex = useRef<THREE.CanvasTexture>(makeLabelTexture(emoji));
+  if ((tex.current as unknown as { __e?: string }).__e !== emoji) {
+    tex.current = makeLabelTexture(emoji);
+    (tex.current as unknown as { __e?: string }).__e = emoji;
+  }
+  // simple grow-and-rise driven by how long ago it was born (no Date.now)
+  const age = Math.max(0, clock - born);
+  const s = 0.4 + Math.min(1, age * 4) * 1.4; // 0.4 → ~1.8
+  const y = position[1] + Math.min(1, age * 3) * 0.5;
+  return (
+    <sprite position={[position[0], y, position[2]]} scale={[s, s, 1]} renderOrder={13}>
+      <spriteMaterial map={tex.current} transparent depthWrite={false} depthTest={false} />
+    </sprite>
+  );
+}
+
+function Ticker({ fnRef }: { fnRef: React.MutableRefObject<(dt: number) => void> }) {
+  useFrame((_, dt) => fnRef.current(Math.min(dt, 0.05)));
+  return null;
+}

--- a/components/game/BelusWorld/three/quest/MountainLayer.tsx
+++ b/components/game/BelusWorld/three/quest/MountainLayer.tsx
@@ -1,0 +1,360 @@
+// ---------------------------------------------------------------------------
+// Morning Mountain — life skills you DO by walking the routine.
+//   • Little station objects (bed, sink, wardrobe, breakfast, backpack, door…)
+//     stand around the island, each with an emoji sign above it.
+//   • Belu WALKS to the next-correct station to "do" that step: it bounces +
+//     glows, a ✅ sparkle pops, and Belu narrates the step.
+//   • Walking to a wrong / out-of-order station = a gentle wiggle + a kind
+//     "what do we do first?" — never a buzzer, never a fail.
+//   • L1-L3 must be done in order; L4 = walk to the SAFE marker of each pair;
+//     L5 = visit every job in ANY order. Finishing the routine completes the
+//     level and always awards 3 stars (errorless, no losing).
+// Mirrors StoryLayer's frame-ref + arm/disarm/finish structure exactly.
+// ---------------------------------------------------------------------------
+
+import { useRef, useState } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { Sparkles } from '@react-three/drei';
+import * as THREE from 'three';
+import { ISLANDS } from '../worldConfig';
+import { beluPos, dynamicSolids } from '../playerState';
+import type { BeluEmotion } from '../../BeluCharacter';
+import { makeLabelTexture } from './emojiTexture';
+import { MOUNTAIN_ROUTINE, type Station } from './mountainContent';
+import type { QuestStatus } from './QuestLayer';
+
+const ZONE = 'mountain' as const;
+const REACH = 1.7; // walk this close to a station to "do" it
+const NUDGE_AT = 1.7; // walking this close to a wrong station triggers the nudge
+const STATION_SOLID_R = 0.85; // keep-out radius so Belu walks around the objects
+
+interface StationRT {
+  done: boolean;
+  doneAt: number;
+}
+interface State {
+  clock: number;
+  active: boolean;
+  level: number;
+  stations: StationRT[];
+  doneCount: number;
+  disarmed: boolean;
+  // gentle-nudge wiggle on a wrong/out-of-order station
+  wrongIdx: number;
+  wrongUntil: number;
+  lockUntil: number;
+  finishAt: number;
+}
+
+interface Props {
+  level: number;
+  paused: boolean;
+  speak: (line: string) => void;
+  setEmotion: (e: BeluEmotion) => void;
+  playSound: (kind: 'tap' | 'correct' | 'star' | 'levelup' | 'growup') => void;
+  onComplete: (zone: 'mountain', level: number, stars: number, moment: string) => void;
+  onStatus: (s: QuestStatus | null) => void;
+}
+
+function clampLevel(level: number) {
+  return Math.max(0, Math.min(MOUNTAIN_ROUTINE.length - 1, level - 1));
+}
+
+/** stations that actually need visiting to finish (the un-safe twins don't). */
+function targetCount(stations: Station[]) {
+  return stations.filter((s) => s.kind !== 'unsafe').length;
+}
+
+export default function MountainLayer(props: Props) {
+  const [, force] = useState(0);
+  const bump = () => force((v) => (v + 1) % 1_000_000);
+  const S = useRef<State>({
+    clock: 0, active: false, level: props.level,
+    stations: MOUNTAIN_ROUTINE[clampLevel(props.level)].stations.map(() => ({ done: false, doneAt: -99 })),
+    doneCount: 0, disarmed: false, wrongIdx: -1, wrongUntil: 0, lockUntil: 0, finishAt: 0,
+  });
+  const frame = useRef<(dt: number) => void>(() => {});
+  const isl = ISLANDS[ZONE];
+
+  const stationWorld = (s: Station): [number, number] => [isl.cx + s.pos[0], isl.cz + s.pos[1]];
+
+  function emitStatus(phase: 'question' | 'correct', instruction: string, hint?: string) {
+    const lvl = MOUNTAIN_ROUTINE[clampLevel(S.current.level)];
+    props.onStatus({
+      zone: ZONE, title: isl.label, emoji: isl.emoji, accent: isl.accent,
+      level: S.current.level, instruction, step: S.current.doneCount,
+      total: targetCount(lvl.stations), phase, hint,
+    });
+  }
+
+  // the hint depends on the level's mechanic so the task card guides the child
+  function actionHint(): string {
+    const lvl = MOUNTAIN_ROUTINE[clampLevel(S.current.level)];
+    // L5 'any' order: just visit every job
+    if (lvl.stations.every((s) => s.kind === 'any')) return 'Walk to each job — any order you like! ✅';
+    // L4 safety: pick the safe one of each pair
+    if (lvl.stations.some((s) => s.kind === 'safe')) return 'Walk to the SAFE choice of each pair ✅';
+    // L1-L3 ordered: point at the next step
+    const first = lvl.stations.find((s, i) => s.kind === 'ordered' && !S.current.stations[i].done);
+    return first ? `Walk to: ${first.label} ✅` : 'Walk to the next job ✅';
+  }
+
+  function startRoutine() {
+    const lvl = MOUNTAIN_ROUTINE[clampLevel(props.level)];
+    S.current.active = true;
+    S.current.level = props.level;
+    S.current.stations = lvl.stations.map(() => ({ done: false, doneAt: -99 }));
+    S.current.doneCount = 0;
+    S.current.wrongIdx = -1;
+    S.current.finishAt = 0;
+    S.current.lockUntil = S.current.clock + 0.35;
+    props.setEmotion('curious');
+    props.speak(lvl.intro);
+    emitStatus('question', lvl.intro, actionHint());
+    bump();
+  }
+
+  function stopRoutine() {
+    S.current.active = false;
+    S.current.wrongIdx = -1;
+    props.setEmotion('happy');
+    props.onStatus(null);
+    bump();
+  }
+
+  function finish() {
+    const lvl = MOUNTAIN_ROUTINE[clampLevel(S.current.level)];
+    props.onComplete(ZONE, S.current.level, 3, lvl.moment);
+    props.speak(lvl.outro);
+    S.current.active = false;
+    S.current.disarmed = true;
+    S.current.wrongIdx = -1;
+    props.onStatus(null);
+    bump();
+  }
+
+  // gentle "not yet" — a little wiggle + a kind line, never a fail
+  function nudge(i: number, kind: 'order' | 'unsafe') {
+    const st = S.current;
+    st.wrongIdx = i;
+    st.wrongUntil = st.clock + 0.5;
+    st.lockUntil = st.clock + 0.45;
+    props.playSound('tap');
+    props.setEmotion('curious');
+    props.speak(
+      kind === 'unsafe'
+        ? 'Hmm, that one is not safe. Which choice keeps us safe?'
+        : 'Almost! What do we do first? Walk to the next job in order.',
+    );
+    bump();
+  }
+
+  // Belu reached station i — "do" it (or nudge if it's wrong/out-of-order)
+  function reach(i: number) {
+    const st = S.current;
+    if (st.clock < st.lockUntil) return;
+    const lvl = MOUNTAIN_ROUTINE[clampLevel(st.level)];
+    const station = lvl.stations[i];
+    if (st.stations[i].done) return;
+
+    // L4 un-safe twin → gentle nudge, no progress
+    if (station.kind === 'unsafe') {
+      nudge(i, 'unsafe');
+      return;
+    }
+
+    // ordered levels: must be the next not-yet-done ordered station
+    if (station.kind === 'ordered') {
+      const nextOrderedIdx = lvl.stations.findIndex((s, j) => s.kind === 'ordered' && !st.stations[j].done);
+      if (i !== nextOrderedIdx) {
+        nudge(i, 'order');
+        return;
+      }
+    }
+    // 'safe' and 'any' can be done whenever Belu reaches them
+
+    // do it!
+    st.stations[i].done = true;
+    st.stations[i].doneAt = st.clock;
+    st.doneCount += 1;
+    st.lockUntil = st.clock + 0.4;
+    props.playSound('correct');
+    props.setEmotion('excited');
+
+    const total = targetCount(lvl.stations);
+    if (st.doneCount >= total) {
+      props.playSound('star');
+      emitStatus('correct', station.done ?? 'You did it!', 'Routine complete! 🌟');
+      st.finishAt = st.clock + 1.4;
+    } else {
+      emitStatus('correct', station.done ?? 'Nice — you did it!', actionHint());
+    }
+    bump();
+  }
+
+  frame.current = (dt: number) => {
+    const st = S.current;
+    // keep every station registered as a solid so Belu walks around the objects
+    const lvl = MOUNTAIN_ROUTINE[clampLevel(st.level)];
+    dynamicSolids.mountain = lvl.stations.map((s) => {
+      const [x, z] = stationWorld(s);
+      return { x, z, r: STATION_SOLID_R };
+    });
+    if (props.paused) return;
+    st.clock += dt;
+
+    if (st.finishAt > 0 && st.clock >= st.finishAt) {
+      st.finishAt = 0;
+      finish();
+      return;
+    }
+    if (st.wrongIdx >= 0 && st.clock > st.wrongUntil) {
+      st.wrongIdx = -1;
+      bump();
+    }
+
+    const dCenter = Math.hypot(beluPos.x - isl.cx, beluPos.z - isl.cz);
+    const onIsland = dCenter < isl.radius * 0.82;
+    if (st.disarmed && dCenter > isl.radius + 1.5) {
+      st.disarmed = false;
+      bump();
+    }
+    if (!st.active) {
+      if (onIsland && !st.disarmed) startRoutine();
+      return;
+    }
+    if (dCenter > isl.radius + 1.5) {
+      stopRoutine();
+      return;
+    }
+    if (st.clock < st.lockUntil) return;
+
+    // which station is Belu close enough to "do"? (nearest within reach)
+    let best = -1;
+    let bestD = Math.max(REACH, NUDGE_AT);
+    for (let i = 0; i < lvl.stations.length; i++) {
+      if (st.stations[i].done) continue;
+      const [x, z] = stationWorld(lvl.stations[i]);
+      const d = Math.hypot(beluPos.x - x, beluPos.z - z);
+      if (d < bestD) {
+        bestD = d;
+        best = i;
+      }
+    }
+    if (best >= 0) reach(best);
+  };
+
+  // ---- render ----
+  const lvl = MOUNTAIN_ROUTINE[clampLevel(S.current.level)];
+  return (
+    <group>
+      <Ticker fnRef={frame} />
+      {lvl.stations.map((station, i) => {
+        const rt = S.current.stations[i] ?? { done: false, doneAt: -99 };
+        const [x, z] = stationWorld(station);
+        const wiggling = S.current.wrongIdx === i && S.current.clock < S.current.wrongUntil;
+        const justDone = rt.done && S.current.clock - rt.doneAt < 2.2;
+        return (
+          <Station3D
+            key={`${S.current.level}-${i}`}
+            position={[x, isl.top, z]}
+            emoji={station.emoji}
+            label={station.label}
+            accent={isl.accent}
+            done={rt.done}
+            wiggle={wiggling}
+            clock={S.current.clock}
+            seed={i * 1.3}
+          >
+            {justDone && (
+              <Sparkles count={20} scale={2.4} size={6} speed={0.6} color="#7CFC9A" position={[0, 1.4, 0]} />
+            )}
+          </Station3D>
+        );
+      })}
+    </group>
+  );
+}
+
+// A little routine station: a low rounded base + a tinted glow pad, an emoji
+// sign floating above, and a ✅ badge once it's been done. Built from primitives
+// only (no downloads). The sign is a sprite with depthTest off so it never hides
+// inside the geometry.
+function Station3D({
+  position, emoji, label, accent, done, wiggle, clock, seed, children,
+}: {
+  position: [number, number, number];
+  emoji: string;
+  label: string;
+  accent: string;
+  done: boolean;
+  wiggle: boolean;
+  clock: number;
+  seed: number;
+  children?: React.ReactNode;
+}) {
+  const grp = useRef<THREE.Group>(null);
+  const t = useRef(seed);
+  const tex = useRef<THREE.CanvasTexture>(makeLabelTexture(emoji, label, true));
+  const checkTex = useRef<THREE.CanvasTexture>(makeLabelTexture('✅'));
+  // refresh the sign texture if the emoji/label ever changes for this slot
+  const key = `${emoji} ${label}`;
+  if ((tex.current as unknown as { __k?: string }).__k !== key) {
+    tex.current = makeLabelTexture(emoji, label, true);
+    (tex.current as unknown as { __k?: string }).__k = key;
+  }
+
+  useFrame((_, dt) => {
+    t.current += dt;
+    const g = grp.current;
+    if (!g) return;
+    // a soft idle bob; a quick wiggle when nudged; a celebratory bounce when done
+    let y = position[1];
+    let rz = 0;
+    if (wiggle) {
+      rz = Math.sin(clock * 40) * 0.18;
+    } else if (done) {
+      y = position[1] + Math.abs(Math.sin(t.current * 4)) * 0.12;
+    } else {
+      y = position[1] + Math.sin(t.current * 1.6) * 0.05;
+    }
+    g.position.y += (y - g.position.y) * Math.min(1, dt * 12);
+    g.rotation.z += (rz - g.rotation.z) * Math.min(1, dt * 18);
+  });
+
+  return (
+    <group ref={grp} position={position}>
+      {/* glow pad on the ground */}
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.02, 0]}>
+        <ringGeometry args={[0.5, 0.82, 28]} />
+        <meshBasicMaterial color={done ? '#7CFC9A' : accent} transparent opacity={done ? 0.55 : 0.3} side={THREE.DoubleSide} />
+      </mesh>
+      {/* a little pedestal you walk up to */}
+      <mesh castShadow position={[0, 0.35, 0]}>
+        <cylinderGeometry args={[0.5, 0.6, 0.7, 16]} />
+        <meshStandardMaterial color={accent} roughness={0.55} metalness={0.1} emissive={accent} emissiveIntensity={done ? 0.5 : 0.18} />
+      </mesh>
+      {/* signpost stalk */}
+      <mesh position={[0, 0.95, 0]}>
+        <cylinderGeometry args={[0.06, 0.06, 0.6, 8]} />
+        <meshStandardMaterial color="#caa46a" roughness={0.8} />
+      </mesh>
+      {/* the emoji + word sign (sprite always faces camera, drawn on top) */}
+      <sprite position={[0, 1.7, 0]} scale={[1.6, 1.6, 1]} renderOrder={11}>
+        <spriteMaterial map={tex.current} transparent depthWrite={false} depthTest={false} />
+      </sprite>
+      {/* ✅ badge once done */}
+      {done && (
+        <sprite position={[0.6, 2.35, 0]} scale={[0.7, 0.7, 1]} renderOrder={13}>
+          <spriteMaterial map={checkTex.current} transparent depthWrite={false} depthTest={false} />
+        </sprite>
+      )}
+      {children}
+    </group>
+  );
+}
+
+function Ticker({ fnRef }: { fnRef: React.MutableRefObject<(dt: number) => void> }) {
+  useFrame((_, dt) => fnRef.current(Math.min(dt, 0.05)));
+  return null;
+}

--- a/components/game/BelusWorld/three/quest/coveContent.ts
+++ b/components/game/BelusWorld/three/quest/coveContent.ts
@@ -1,0 +1,110 @@
+// ---------------------------------------------------------------------------
+// Calm Cove content — "calm the storm" play.
+//   The cove water starts stormy and choppy. As the child follows BreatheOrb's
+//   breaths, the sea visibly settles each cycle — waves shrink, the colour
+//   brightens from stormy grey-blue to bright cyan, and at the end fish leap and
+//   a rainbow appears. No quiz feel: you literally calm the sea by breathing.
+//
+// The pedagogy mirrors quests.ts COVE exactly (same breath counts + the same
+// pre-breath actions per level), only reshaped for the embodied "calm the storm"
+// mechanic so integration stays trivial:
+//   L1: 2 breaths.            L2: 3 breaths.
+//   L3: body-scan — walk to a glowing body-spot totem, then breathe.
+//   L4: pick ONE calm strategy totem, then 1 breath.
+//   L5: build a calm plan — walk to 3 strategy totems in a row, then 1 breath.
+// ---------------------------------------------------------------------------
+
+/** A totem the child walks Belu into (or taps) — a body spot or a calm strategy. */
+export interface CoveTotem {
+  emoji: string;
+  label: string;
+}
+
+/** What the child must do BEFORE the breathing begins on a given level. */
+export type CovePreStep =
+  | { kind: 'none' }
+  /** walk to ONE body spot to "send calm" there */
+  | { kind: 'bodySpot'; totems: CoveTotem[] }
+  /** walk to ONE calm strategy */
+  | { kind: 'pickOne'; totems: CoveTotem[] }
+  /** walk to `need` strategies in a row to build a plan */
+  | { kind: 'plan'; need: number; totems: CoveTotem[] };
+
+export interface CoveLevel {
+  goal: string;
+  intro: string;
+  outro: string;
+  moment: string;
+  /** how many calm breath cycles settle the sea on this level */
+  cycles: number;
+  /** the action before breathing (drives the totems that appear) */
+  pre: CovePreStep;
+  /** the line Belu says once the pre-step is done and breathing is about to start */
+  breatheCue: string;
+}
+
+// Reused calm strategies (matches quests.ts CALM_STRATEGIES pedagogy).
+const STRATEGIES: CoveTotem[] = [
+  { emoji: '🌬️', label: 'Deep breaths' },
+  { emoji: '🤫', label: 'Quiet spot' },
+  { emoji: '✊', label: 'Squeeze hands' },
+  { emoji: '✋', label: 'Ask for a break' },
+  { emoji: '🖐️', label: 'Count to five' },
+  { emoji: '🤗', label: 'Get a big hug' },
+];
+
+// Body spots for the level-3 body scan (matches quests.ts L3 options).
+const BODY_SPOTS: CoveTotem[] = [
+  { emoji: '🫄', label: 'Tummy' },
+  { emoji: '🫁', label: 'Chest' },
+  { emoji: '💪', label: 'Shoulders' },
+  { emoji: '🤲', label: 'Hands' },
+];
+
+export const COVE_LEVELS: CoveLevel[] = [
+  {
+    goal: 'Calm the sea with 2 breaths',
+    intro: "The cove is stormy today. Let's calm the sea together — follow the bubble and breathe with me.",
+    outro: 'Look — the sea is calm and bright! Thank you for breathing with me. 🌈',
+    moment: 'calmed the stormy sea at the cove',
+    cycles: 2,
+    pre: { kind: 'none' },
+    breatheCue: 'Breathe in as the bubble grows, out as it shrinks. Watch the sea settle.',
+  },
+  {
+    goal: 'Calm the sea with 3 breaths',
+    intro: "The storm is a little bigger now. We can do it — a longer calm together.",
+    outro: 'The whole cove is sparkling cyan now. You calmed the sea! 🌈',
+    moment: 'calmed the stormy sea at the cove',
+    cycles: 3,
+    pre: { kind: 'none' },
+    breatheCue: 'Breathe slowly with the bubble. Each breath calms the waves.',
+  },
+  {
+    goal: 'Send calm to your body, then breathe',
+    intro: "Before we breathe, let's notice our body. Walk to a spot to send your calm to.",
+    outro: 'Calm in your body, calm in the sea. Beautiful! 🌈',
+    moment: 'did a calm body check at the cove',
+    cycles: 2,
+    pre: { kind: 'bodySpot', totems: BODY_SPOTS },
+    breatheCue: 'Now breathe with me, sending calm to that spot — and watch the sea settle.',
+  },
+  {
+    goal: 'Pick a calm strategy, then breathe',
+    intro: "It feels loud and busy here. Walk to one thing that helps you feel calm.",
+    outro: 'Great choice — that really helps. The sea is calm and bright. 🌈',
+    moment: 'chose a calm strategy at the cove',
+    cycles: 1,
+    pre: { kind: 'pickOne', totems: STRATEGIES.slice(0, 4) },
+    breatheCue: 'Now one calm breath together — let the sea grow calm.',
+  },
+  {
+    goal: 'Build your calm plan, then breathe',
+    intro: "Let's build YOUR calm plan. Walk to three things that help you most.",
+    outro: 'A wonderful calm plan — and a calm, sparkling sea! 🌈',
+    moment: 'built my own calm plan at the cove',
+    cycles: 1,
+    pre: { kind: 'plan', need: 3, totems: STRATEGIES },
+    breatheCue: 'A wonderful plan! One calm breath to finish — and the sea is calm.',
+  },
+];

--- a/components/game/BelusWorld/three/quest/forestContent.ts
+++ b/components/game/BelusWorld/three/quest/forestContent.ts
@@ -1,0 +1,223 @@
+// ---------------------------------------------------------------------------
+// Friendship Forest content — MAGIC WORDS (expressive language as spell-casting).
+//   walk up to a 3D animal friend → linger a moment → a thought bubble shows
+//   what they WANT or SEE (a picture) → 3 word bubbles appear around them →
+//   walk Belu into the word bubbles IN ORDER to "say" the phrase → the wanted
+//   thing magically appears (sparkles + the item pops) and the friend cheers.
+// The child isn't taking a quiz: they are CASTING the phrase out loud, word by
+// word, and watching their words make something real happen. That is exactly
+// what expressive language is for — using words to act on the world.
+// Pedagogy mirrors quests.ts FOREST: L1 single mands, L2 action verbs,
+// L3 two-word combos, L4 "I see X", L5 short sentences + a friendly turn-take.
+// ---------------------------------------------------------------------------
+
+import type { AnimalSpecies } from './Animal3D';
+
+export interface SpellWord {
+  /** the word painted on the bubble (also what the child "says") */
+  word: string;
+  /** a picture that helps a pre-reader recognise the word */
+  emoji: string;
+}
+
+export interface ForestFriend {
+  species: AnimalSpecies;
+  /** what the friend is thinking about — shown in their thought card */
+  thought: string;
+  /** the magic phrase, in order. Walk into these words to cast it. */
+  spell: SpellWord[];
+  /** a couple of EXTRA decoy words mixed in so there's a real choice to make.
+   *  (left empty for the very first single-word rounds to keep them errorless-easy) */
+  decoys: SpellWord[];
+  /** the thing that magically appears once the phrase is complete */
+  reward: string;
+  /** Belu's happy line when the spell lands */
+  cheer: string;
+  /** local XZ offset from the forest centre */
+  pos: [number, number];
+}
+
+export interface ForestLevel {
+  goal: string;
+  intro: string;
+  outro: string;
+  moment: string;
+  friends: ForestFriend[];
+}
+
+// ---- little builders so the data stays readable -----------------------------
+
+function w(word: string, emoji: string): SpellWord {
+  return { word, emoji };
+}
+
+// ===========================================================================
+// FRIENDSHIP FOREST — Expressive Language (5 levels, 2..5 friends each)
+// ===========================================================================
+
+export const FOREST_STORY: ForestLevel[] = [
+  // L1 — single mands: "apple" / "ball" / "book". One word = the whole spell.
+  {
+    goal: 'Say the magic word',
+    intro:
+      "My forest friends are wishing for things! Walk up close, see what they want, then walk into the magic WORD to make it appear.",
+    outro: 'You said every magic word so well! Your words make things happen. 🌳',
+    moment: 'cast my first magic words in the forest',
+    friends: [
+      {
+        species: 'fox', thought: '🍎',
+        spell: [w('apple', '🍎')], decoys: [w('ball', '⚽')],
+        reward: '🍎', cheer: 'Apple! You said it — here it comes! 🍎',
+        pos: [-3, 0],
+      },
+      {
+        species: 'bunny', thought: '⚽',
+        spell: [w('ball', '⚽')], decoys: [w('book', '📖')],
+        reward: '⚽', cheer: 'Ball! Your word made it pop! ⚽',
+        pos: [3, 1],
+      },
+      {
+        species: 'bear', thought: '📖',
+        spell: [w('book', '📖')], decoys: [w('apple', '🍎')],
+        reward: '📖', cheer: 'Book! Magic words really work! 📖',
+        pos: [0, -3],
+      },
+    ],
+  },
+
+  // L2 — action verbs: name what the friend is DOING. Still one word per spell.
+  {
+    goal: 'Say the action word',
+    intro:
+      'Watch what my friends are doing! Walk up close, then walk into the ACTION word to cheer them on.',
+    outro: 'You named every action! Action words are powerful. 🏃',
+    moment: 'used action words in the forest',
+    friends: [
+      {
+        species: 'fox', thought: '💨',
+        spell: [w('running', '🏃')], decoys: [w('sleeping', '😴'), w('eating', '🍽️')],
+        reward: '🏃', cheer: 'Running! Look at Fox go! 🏃',
+        pos: [-4, -1],
+      },
+      {
+        species: 'bird', thought: '☁️',
+        spell: [w('flying', '🕊️')], decoys: [w('jumping', '🦘'), w('eating', '🍽️')],
+        reward: '🕊️', cheer: 'Flying! Up Bird goes! 🕊️',
+        pos: [4, -1],
+      },
+      {
+        species: 'bear', thought: '🍯',
+        spell: [w('eating', '🍽️')], decoys: [w('running', '🏃'), w('flying', '🕊️')],
+        reward: '🍯', cheer: 'Eating! Yummy honey! 🍯',
+        pos: [-2, 3],
+      },
+      {
+        species: 'bunny', thought: '⬆️',
+        spell: [w('jumping', '🦘')], decoys: [w('sleeping', '😴'), w('flying', '🕊️')],
+        reward: '🦘', cheer: 'Jumping! Hop hop hop! 🦘',
+        pos: [3, 3],
+      },
+    ],
+  },
+
+  // L3 — two-word combos: "want ball", "want apple", "big hug". Order matters!
+  {
+    goal: 'Cast a two-word spell',
+    intro:
+      "Now let's put TWO words together! Walk into the words in order to cast the whole spell.",
+    outro: 'You put words together so well! Two words, big magic. ✨',
+    moment: 'made two-word spells in the forest',
+    friends: [
+      {
+        species: 'bunny', thought: '⚽',
+        spell: [w('want', '🙋'), w('ball', '⚽')], decoys: [w('book', '📖')],
+        reward: '⚽', cheer: '"want ball" — perfect! Here it is! ⚽',
+        pos: [-3, 1],
+      },
+      {
+        species: 'fox', thought: '🍎',
+        spell: [w('want', '🙋'), w('apple', '🍎')], decoys: [w('drink', '🥤')],
+        reward: '🍎', cheer: '"want apple" — yes! 🍎',
+        pos: [3, 1],
+      },
+      {
+        species: 'bear', thought: '🤗',
+        spell: [w('big', '🫅'), w('hug', '🤗')], decoys: [w('ball', '⚽')],
+        reward: '🤗', cheer: '"big hug" — aww, the best kind! 🤗',
+        pos: [0, -3],
+      },
+    ],
+  },
+
+  // L4 — "I see X": noticing + sharing. Three words, the first two are constant.
+  {
+    goal: 'Say "I see a…"',
+    intro:
+      "When we notice something we can tell a friend! Walk into 'I' then 'see' then what you SEE.",
+    outro: 'You told me everything you saw! Sharing what we notice is wonderful. 👀',
+    moment: 'told friends what I saw in the forest',
+    friends: [
+      {
+        species: 'fox', thought: '🐶',
+        spell: [w('I', '🙋'), w('see', '👀'), w('dog', '🐶')],
+        decoys: [w('cat', '🐱')],
+        reward: '🐶', cheer: '"I see a dog!" Great noticing! 🐶',
+        pos: [-4, 0],
+      },
+      {
+        species: 'bird', thought: '🌳',
+        spell: [w('I', '🙋'), w('see', '👀'), w('tree', '🌳')],
+        decoys: [w('rock', '🪨')],
+        reward: '🌳', cheer: '"I see a tree!" 🌳',
+        pos: [4, 0],
+      },
+      {
+        species: 'bunny', thought: '⭐',
+        spell: [w('I', '🙋'), w('see', '👀'), w('star', '⭐')],
+        decoys: [w('moon', '🌙')],
+        reward: '⭐', cheer: '"I see a star!" Way up high! ⭐',
+        pos: [0, 3],
+      },
+      {
+        species: 'bear', thought: '🦋',
+        spell: [w('I', '🙋'), w('see', '👀'), w('butterfly', '🦋')],
+        decoys: [w('bee', '🐝')],
+        reward: '🦋', cheer: '"I see a butterfly!" So pretty! 🦋',
+        pos: [0, -3],
+      },
+    ],
+  },
+
+  // L5 — whole sentences + a friendly turn-take with Belu (the social finale).
+  {
+    goal: 'Whole sentences & taking turns',
+    intro:
+      "Let's make WHOLE sentences, then chat like good friends — taking turns talking!",
+    outro: 'We took turns talking so nicely. That is what friends do. 💜',
+    moment: 'made sentences and took turns in the forest',
+    friends: [
+      {
+        species: 'fox', thought: '🍎',
+        spell: [w('I', '🙋'), w('like', '💗'), w('apples', '🍎')],
+        decoys: [w('run', '🏃')],
+        reward: '🍎', cheer: '"I like apples." Wonderful sentence! 🍎',
+        pos: [-4, 1],
+      },
+      {
+        species: 'bunny', thought: '🫵',
+        spell: [w('I', '🙋'), w('see', '👀'), w('you', '🫵')],
+        decoys: [w('big', '🫅')],
+        reward: '💜', cheer: '"I see you." I see you too, friend! 💜',
+        pos: [4, 1],
+      },
+      // a friendly turn-take: say it back and forth like a real little chat
+      {
+        species: 'bear', thought: '💬',
+        spell: [w('my turn', '💬'), w('your turn', '🗨️'), w('my turn', '💬'), w('your turn', '🗨️')],
+        decoys: [],
+        reward: '💜', cheer: 'We took turns so nicely! That is what friends do. 💜',
+        pos: [0, -3],
+      },
+    ],
+  },
+];

--- a/components/game/BelusWorld/three/quest/mountainContent.ts
+++ b/components/game/BelusWorld/three/quest/mountainContent.ts
@@ -1,0 +1,144 @@
+// ---------------------------------------------------------------------------
+// Morning Mountain content — life skills you DO by walking, not a quiz.
+//   Stations sit around the island, each a little object (bed 🛏️, sink 🪥,
+//   wardrobe 👕, breakfast 🥣, backpack 🎒, door 🚪 …). Belu walks to them IN
+//   ORDER to "do" each step of the morning routine. Walking to the next-correct
+//   station does it (bounce + ✅ sparkle + Belu narrates); a wrong/out-of-order
+//   station gives a gentle "what do we do first?" nudge — never a fail.
+//
+// The pedagogy mirrors quests.ts MOUNTAIN exactly, just re-expressed as a
+// walk-the-routine layout:
+//   L1 single self-care matches  • L2 short chains  • L3 full morning sequence
+//   L4 safety (walk to the SAFE marker of two)  • L5 independent self-check (any order)
+// ---------------------------------------------------------------------------
+
+/** How a station behaves once Belu reaches it. */
+export type StationKind =
+  | 'ordered' // must be visited in sequence order (L1-L3, the routine)
+  | 'safe' // L4: the safe choice of a pair (visiting it completes that pair)
+  | 'unsafe' // L4: the un-safe twin — a gentle nudge, never a fail
+  | 'any'; // L5: visit in any order, all count
+
+export interface Station {
+  emoji: string;
+  /** the word under the picture, and the routine step it represents */
+  label: string;
+  kind: StationKind;
+  /** local XZ offset from the island centre */
+  pos: [number, number];
+  /** the kind line Belu says when this station is "done" */
+  done?: string;
+  /** L4 only: which safe/unsafe pair this station belongs to */
+  pair?: number;
+}
+
+export interface MountainLevel {
+  goal: string;
+  intro: string;
+  outro: string;
+  moment: string;
+  /** the routine, in the order the ordered/safe stations must be visited */
+  stations: Station[];
+}
+
+function st(
+  emoji: string,
+  label: string,
+  kind: StationKind,
+  x: number,
+  z: number,
+  extra: Partial<Station> = {},
+): Station {
+  return { emoji, label, kind, pos: [x, z], ...extra };
+}
+
+// A ring of station spots around the island centre, so the routine is a little
+// walking loop. Index = the visit order for ordered levels.
+const RING: [number, number][] = [
+  [0, -5], // top
+  [4.5, -2.5], // upper-right
+  [4.5, 2.5], // lower-right
+  [0, 5], // bottom
+  [-4.5, 2.5], // lower-left
+  [-4.5, -2.5], // upper-left
+];
+
+// L4 safety pairs sit side by side (safe on the left, twin on the right) at a
+// few spots around the ring, so Belu chooses by walking to the safe one.
+const SAFE_SPOTS: [number, number][] = [[-2.6, -4], [2.6, -4], [-2.6, 4], [2.6, 4]];
+const TWIN_DX = 2.4;
+
+export const MOUNTAIN_ROUTINE: MountainLevel[] = [
+  {
+    goal: 'Do each self-care job',
+    intro: "Let's get ready for the day! Walk to each job in order to do it.",
+    outro: 'You did it all by yourself — you are so ready!',
+    moment: 'practiced life skills on the mountain',
+    // L1: a short ordered chain of single self-care matches (wake→wash→brush→shoes)
+    stations: [
+      st('🛏️', 'Wake up', 'ordered', RING[0][0], RING[0][1], { done: 'Good morning! Up we get.' }),
+      st('🧼', 'Wash hands', 'ordered', RING[1][0], RING[1][1], { done: 'Squeaky clean hands!' }),
+      st('🪥', 'Brush teeth', 'ordered', RING[2][0], RING[2][1], { done: 'Sparkly clean teeth!' }),
+      st('👟', 'Put on shoes', 'ordered', RING[3][0], RING[3][1], { done: 'Shoes on — ready to go!' }),
+    ],
+  },
+  {
+    goal: 'Do the steps in order',
+    intro: 'Some jobs have steps in order. Walk the steps from first to last!',
+    outro: 'You did it all by yourself — you are so ready!',
+    moment: 'practiced life skills on the mountain',
+    // L2: a short chain — get up, get dressed, then breakfast
+    stations: [
+      st('😴', 'Wake up', 'ordered', RING[0][0], RING[0][1], { done: 'Up and at it!' }),
+      st('🪥', 'Brush teeth', 'ordered', RING[1][0], RING[1][1], { done: "That's how we brush!" }),
+      st('👕', 'Get dressed', 'ordered', RING[3][0], RING[3][1], { done: 'All dressed!' }),
+      st('🥣', 'Eat breakfast', 'ordered', RING[4][0], RING[4][1], { done: 'Yum — good fuel!' }),
+    ],
+  },
+  {
+    goal: 'The whole morning',
+    intro: "Let's do the WHOLE morning, step by step. Walk them in order!",
+    outro: 'A perfect morning, start to finish!',
+    moment: 'practiced life skills on the mountain',
+    // L3: the full morning sequence wake→brush→dress→eat→pack→goodbye
+    stations: [
+      st('😴', 'Wake up', 'ordered', RING[0][0], RING[0][1], { done: 'Good morning!' }),
+      st('🪥', 'Brush teeth', 'ordered', RING[1][0], RING[1][1], { done: 'Teeth all clean!' }),
+      st('👕', 'Get dressed', 'ordered', RING[2][0], RING[2][1], { done: 'Looking sharp!' }),
+      st('🥣', 'Eat breakfast', 'ordered', RING[3][0], RING[3][1], { done: 'Yummy breakfast!' }),
+      st('🎒', 'Pack bag', 'ordered', RING[4][0], RING[4][1], { done: 'Bag is packed!' }),
+      st('🚪', 'Say goodbye', 'ordered', RING[5][0], RING[5][1], { done: 'Bye-bye — have a great day!' }),
+    ],
+  },
+  {
+    goal: 'Stay safe',
+    intro: 'Being safe is a big-kid skill. Walk to the choice that keeps us safe.',
+    outro: 'You made every safe choice — well done!',
+    moment: 'practiced staying safe on the mountain',
+    // L4: each pair = a safe marker + its un-safe twin. Walk to the SAFE one.
+    stations: [
+      st('👀', 'Look both ways', 'safe', SAFE_SPOTS[0][0], SAFE_SPOTS[0][1], { pair: 0, done: 'Yes — that is the safe choice!' }),
+      st('🏃', 'Run across fast', 'unsafe', SAFE_SPOTS[0][0] + TWIN_DX, SAFE_SPOTS[0][1], { pair: 0 }),
+      st('🙅', 'Stay away (hot stove)', 'safe', SAFE_SPOTS[1][0], SAFE_SPOTS[1][1], { pair: 1, done: 'Staying away keeps us safe.' }),
+      st('✋', 'Touch the stove', 'unsafe', SAFE_SPOTS[1][0] + TWIN_DX, SAFE_SPOTS[1][1], { pair: 1 }),
+      st('🙋', 'Find a trusted grown-up', 'safe', SAFE_SPOTS[2][0], SAFE_SPOTS[2][1], { pair: 2, done: 'Always find a trusted grown-up.' }),
+      st('🚶', 'Go with a stranger', 'unsafe', SAFE_SPOTS[2][0] + TWIN_DX, SAFE_SPOTS[2][1], { pair: 2 }),
+      st('🔒', 'Buckle your seatbelt', 'safe', SAFE_SPOTS[3][0], SAFE_SPOTS[3][1], { pair: 3, done: 'Click! Safe and ready.' }),
+      st('🎮', 'Stand up in the car', 'unsafe', SAFE_SPOTS[3][0] + TWIN_DX, SAFE_SPOTS[3][1], { pair: 3 }),
+    ],
+  },
+  {
+    goal: 'All by myself',
+    intro: 'Can you get ready all by yourself? Walk to each job — any order you like!',
+    outro: 'All done — you got ready by yourself! 🌟',
+    moment: 'got ready all by myself',
+    // L5: independent self-check — visit all five, any order
+    stations: [
+      st('🛏️', 'Make the bed', 'any', RING[0][0], RING[0][1], { done: 'Bed all made!' }),
+      st('🪥', 'Brush teeth', 'any', RING[1][0], RING[1][1], { done: 'Teeth all clean!' }),
+      st('👕', 'Get dressed', 'any', RING[2][0], RING[2][1], { done: 'All dressed!' }),
+      st('🥣', 'Eat breakfast', 'any', RING[4][0], RING[4][1], { done: 'Yummy breakfast!' }),
+      st('🎒', 'Pack my bag', 'any', RING[5][0], RING[5][1], { done: 'Bag is packed!' }),
+    ],
+  },
+];


### PR DESCRIPTION
Completes the reshape — every island is now embodied play, not multiple choice. (Built with a 4-agent workflow, verified locally.)

- 🌸 **Feelings Meadow** (already shipped) — observe a 3D animal's body language, see the clue, choose a kind way to help.
- 🌳 **Friendship Forest** = **magic words** — walk up to an animal, then walk into word bubbles in order to "say" the phrase; the wanted thing pops into being.
- ⛰️ **Morning Mountain** = **do the routine** — walk Belu to job stations (bed → sink → wardrobe → table → bag → door) in order; each animates and checks off.
- 🌊 **Calm Cove** = **calm the storm** — the stormy sea settles to bright cyan as you breathe with Belu; fish leap and a rainbow appears when it's calm.

All no-fail, award stars + unlock cosmetics, register characters/stations as solids (no walking through), and drive the on-screen task card. The orb-based `QuestLayer` is no longer rendered.

### Verify
`tsc` 0 · `vite build` 0 · headless: all three islands activate with the correct themed prompts and **zero runtime errors**; Morning Mountain stations render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)