### PR TITLE
Belu's World: Rainbow Playground reward island (forms after 1st level)

### DIFF
--- a/components/game/BelusWorld/index.tsx
+++ b/components/game/BelusWorld/index.tsx
@@ -14,7 +14,7 @@
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import type { BeluEmotion } from './BeluCharacter';
-import { ISLANDS, type ZoneId } from './three/worldConfig';
+import { ISLANDS, worldRuntime, type ZoneId } from './three/worldConfig';
 import { attachKeyboard, queueGoHome } from './three/input';
 import HUD from './ui/HUD';
 import TouchControls from './ui/TouchControls';
@@ -38,6 +38,7 @@ import {
   equipCosmetic,
   getGrowth,
   completedLevels,
+  totalCompletedLevels,
   nextLevel,
   totalStars,
   type GameProgress,
@@ -113,6 +114,9 @@ export default function BelusWorldGame() {
     () => Object.fromEntries(ZONES.map((z) => [z, nextLevel(progress, z)])) as Record<ActivityZone, number>,
     [progress],
   );
+  // the reward island forms once the child finishes their very first level
+  const rainbowUnlocked = useMemo(() => totalCompletedLevels(progress) >= 1, [progress]);
+  worldRuntime.rainbowUnlocked = rainbowUnlocked;
 
   // Belu speaks: speech bubble + (optional) read-aloud narration.
   const speak = useCallback((line: string) => {
@@ -218,6 +222,7 @@ export default function BelusWorldGame() {
           growthStage={growth.stage}
           equipped={progress.equipped}
           islandLevels={islandLevels}
+          rainbowUnlocked={rainbowUnlocked}
           islandNextLevel={islandNextLevel}
           sound={settings.sound}
           onProximity={handleProximity}

--- a/components/game/BelusWorld/three/GameCanvas.tsx
+++ b/components/game/BelusWorld/three/GameCanvas.tsx
@@ -38,6 +38,8 @@ interface Props {
   equipped?: import('../belu/progress').EquippedCosmetics;
   /** completed-level count per zone island (drives the bloom) */
   islandLevels: Partial<Record<ZoneId, number>>;
+  /** has the reward island formed? */
+  rainbowUnlocked: boolean;
   /** which level to play next on each zone island */
   islandNextLevel: Record<ActivityZone, number>;
   sound: boolean;
@@ -85,6 +87,7 @@ export default function GameCanvas({
   growthStage,
   equipped,
   islandLevels,
+  rainbowUnlocked,
   islandNextLevel,
   sound,
   onProximity,
@@ -138,7 +141,7 @@ export default function GameCanvas({
       <Lighting calmMode={calmMode} />
 
       <Suspense fallback={null}>
-        <World activeZone={activeZone} reduceMotion={reduceMotion} islandLevels={islandLevels} />
+        <World activeZone={activeZone} reduceMotion={reduceMotion} islandLevels={islandLevels} rainbowUnlocked={rainbowUnlocked} />
         <Player
           ref={player}
           emotion={emotion}

--- a/components/game/BelusWorld/three/World.tsx
+++ b/components/game/BelusWorld/three/World.tsx
@@ -44,10 +44,11 @@ function Island({ isl }: { isl: IslandDef }) {
   );
 }
 
-function RainbowBridges() {
+function RainbowBridges({ rainbowUnlocked }: { rainbowUnlocked: boolean }) {
   const planks = useMemo(() => {
     const all: { pos: [number, number, number]; rot: number; color: string; w: number }[] = [];
     BRIDGE_SEGMENTS.forEach((s, bi) => {
+      if (s.to === 'rainbow' && !rainbowUnlocked) return; // bridge not formed yet
       const colors = BRIDGES[bi].colors;
       const SEGS = 14;
       const dx = s.bx - s.ax;
@@ -62,7 +63,7 @@ function RainbowBridges() {
       }
     });
     return all;
-  }, []);
+  }, [rainbowUnlocked]);
 
   return (
     <group>
@@ -239,19 +240,22 @@ interface Props {
   activeZone: ZoneId | null;
   reduceMotion: boolean;
   islandLevels: Partial<Record<ZoneId, number>>;
+  /** has the reward island formed yet? (first level completed) */
+  rainbowUnlocked: boolean;
 }
 
-export default function World({ activeZone, reduceMotion, islandLevels }: Props) {
+export default function World({ activeZone, reduceMotion, islandLevels, rainbowUnlocked }: Props) {
   return (
     <group>
       <Clouds reduceMotion={reduceMotion} />
       <WorldLife reduceMotion={reduceMotion} />
-      <RainbowBridges />
-      {ISLAND_LIST.map((isl) => (
-        <Island key={isl.id} isl={isl} />
-      ))}
+      <RainbowBridges rainbowUnlocked={rainbowUnlocked} />
+      {ISLAND_LIST.map((isl) =>
+        isl.id === 'rainbow' && !rainbowUnlocked ? null : <Island key={isl.id} isl={isl} />,
+      )}
       <HomeDecor />
-      {ISLAND_LIST.filter((i) => i.id !== 'home').map((isl) => {
+      {rainbowUnlocked && <RainbowDecor />}
+      {ISLAND_LIST.filter((i) => i.id !== 'home' && i.id !== 'rainbow').map((isl) => {
         const bloom = islandLevels[isl.id] ?? 0;
         return (
           <group key={isl.id}>
@@ -260,6 +264,42 @@ export default function World({ activeZone, reduceMotion, islandLevels }: Props)
           </group>
         );
       })}
+    </group>
+  );
+}
+
+// The reward island's playful decor — a free-play spot the child earns. A
+// bouncy castle dome, a slide, balloons and a big rainbow arch overhead.
+function RainbowDecor() {
+  const isl = ISLANDS.rainbow;
+  const y = isl.top;
+  const arc = ['#ff6b6b', '#ffd166', '#7ec850', '#5fd0e0', '#8a7bff'];
+  return (
+    <group position={[isl.cx, 0, isl.cz]}>
+      {/* big rainbow arch */}
+      {arc.map((c, i) => (
+        <mesh key={i} position={[0, y + 1.5, -1]} rotation={[0, 0, 0]}>
+          <torusGeometry args={[5.2 - i * 0.45, 0.22, 10, 40, Math.PI]} />
+          <meshStandardMaterial color={c} emissive={c} emissiveIntensity={0.3} roughness={0.5} />
+        </mesh>
+      ))}
+      {/* bouncy dome */}
+      <mesh position={[-2.5, y + 0.6, 1]} scale={[1.4, 0.9, 1.4]}>
+        <sphereGeometry args={[1.4, 20, 14, 0, Math.PI * 2, 0, Math.PI / 2]} />
+        <meshStandardMaterial color="#ff9ed8" roughness={0.5} />
+      </mesh>
+      {/* slide */}
+      <mesh position={[2.8, y + 0.8, 1]} rotation={[0.5, 0, 0]}>
+        <boxGeometry args={[0.9, 0.12, 2.6]} />
+        <meshStandardMaterial color="#5fd0e0" roughness={0.4} />
+      </mesh>
+      {/* floating balloons */}
+      {[['#ff6b6b', -3, 2.6], ['#ffd166', 3, 3.2], ['#8a7bff', 0.5, 3.6]].map((b, i) => (
+        <mesh key={i} position={[b[1] as number, y + (b[2] as number), -2]}>
+          <sphereGeometry args={[0.5, 14, 12]} />
+          <meshStandardMaterial color={b[0] as string} roughness={0.4} />
+        </mesh>
+      ))}
     </group>
   );
 }

--- a/components/game/BelusWorld/three/worldConfig.ts
+++ b/components/game/BelusWorld/three/worldConfig.ts
@@ -5,7 +5,7 @@
 // the ground-collision math, and the gameplay all read from one source.
 // ---------------------------------------------------------------------------
 
-export type ZoneId = 'home' | 'meadow' | 'mountain' | 'cove' | 'forest';
+export type ZoneId = 'home' | 'meadow' | 'mountain' | 'cove' | 'forest' | 'rainbow';
 
 export interface IslandDef {
   id: ZoneId;
@@ -98,19 +98,44 @@ export const ISLANDS: Record<ZoneId, IslandDef> = {
     label: 'Friendship Forest',
     emoji: '🌳',
   },
+  // A reward island that only FORMS once the child masters their first island.
+  // It's a free-play playground (no lesson) Belu can walk to and explore — a
+  // visible "the world grew because of you" payoff. Sits out beyond home.
+  rainbow: {
+    id: 'rainbow',
+    cx: 0,
+    cz: -42,
+    radius: 10,
+    top: 3,
+    grass: '#b6e3ff',
+    rock: '#9a86c4',
+    accent: '#ff9ed8',
+    label: 'Rainbow Playground',
+    emoji: '🌈',
+  },
 };
 
 export const ISLAND_LIST = Object.values(ISLANDS);
 
+const RAINBOW_STRIPES = ['#ff6b6b', '#ffd166', '#7ec850', '#5fd0e0', '#8a7bff'];
+
 export const BRIDGES: BridgeDef[] = [
-  { from: 'home', to: 'meadow', halfWidth: 2.2, colors: ['#ff6b6b', '#ffd166', '#7ec850', '#5fd0e0', '#8a7bff'] },
-  { from: 'home', to: 'mountain', halfWidth: 2.2, colors: ['#ff6b6b', '#ffd166', '#7ec850', '#5fd0e0', '#8a7bff'] },
-  { from: 'home', to: 'cove', halfWidth: 2.2, colors: ['#ff6b6b', '#ffd166', '#7ec850', '#5fd0e0', '#8a7bff'] },
-  { from: 'home', to: 'forest', halfWidth: 2.2, colors: ['#ff6b6b', '#ffd166', '#7ec850', '#5fd0e0', '#8a7bff'] },
+  { from: 'home', to: 'meadow', halfWidth: 2.2, colors: RAINBOW_STRIPES },
+  { from: 'home', to: 'mountain', halfWidth: 2.2, colors: RAINBOW_STRIPES },
+  { from: 'home', to: 'cove', halfWidth: 2.2, colors: RAINBOW_STRIPES },
+  { from: 'home', to: 'forest', halfWidth: 2.2, colors: RAINBOW_STRIPES },
+  // bridge to the reward island — only walkable once it's unlocked
+  { from: 'home', to: 'rainbow', halfWidth: 2.4, colors: RAINBOW_STRIPES },
 ];
 
-// The zone islands that host a learning activity (everything except home).
+// The zone islands that host a learning activity (everything except home + the
+// reward island). The rainbow playground has no lesson — it's just to explore.
 export const ZONE_ISLANDS: ZoneId[] = ['meadow', 'mountain', 'cove', 'forest'];
+
+// Runtime flag: the reward island (and its bridge) only physically exist once
+// the child has finished their first level. Rendering AND ground-collision both
+// read this so a locked island is neither visible nor walkable.
+export const worldRuntime = { rainbowUnlocked: false };
 
 // Where the interaction crystal sits on each zone island (offset from centre)
 // and how close Belu must be to trigger the "Play!" prompt.

--- a/components/game/BelusWorld/three/worldMath.ts
+++ b/components/game/BelusWorld/three/worldMath.ts
@@ -6,7 +6,7 @@
 // ASD audience — completely predictable. No tunnelling, no jitter.
 // ---------------------------------------------------------------------------
 
-import { ISLAND_LIST, BRIDGES, ISLANDS, type ZoneId } from './worldConfig';
+import { ISLAND_LIST, BRIDGES, ISLANDS, worldRuntime, type ZoneId } from './worldConfig';
 
 export interface GroundSample {
   /** ground height at this point */
@@ -25,6 +25,7 @@ interface Segment {
   bz: number;
   by: number;
   halfWidth: number;
+  to: ZoneId;
 }
 
 // Precompute bridge segments (island-edge to island-edge) once.
@@ -41,7 +42,7 @@ export const BRIDGE_SEGMENTS: Segment[] = BRIDGES.map((b) => {
   const az = A.cz + uz * (A.radius - 1.5);
   const bx = B.cx - ux * (B.radius - 1.5);
   const bz = B.cz - uz * (B.radius - 1.5);
-  return { ax, az, ay: A.top, bx, bz, by: B.top, halfWidth: b.halfWidth };
+  return { ax, az, ay: A.top, bx, bz, by: B.top, halfWidth: b.halfWidth, to: b.to };
 });
 
 const EDGE_FALLOFF = 1.4; // soft margin past the rim before you actually fall
@@ -59,6 +60,7 @@ export function sampleGround(x: number, z: number): GroundSample {
 
   // Islands
   for (const isl of ISLAND_LIST) {
+    if (isl.id === 'rainbow' && !worldRuntime.rainbowUnlocked) continue; // not formed yet
     const d = Math.hypot(x - isl.cx, z - isl.cz);
     if (d <= isl.radius + EDGE_FALLOFF) {
       const y = islandHeightAt(Math.min(d, isl.radius), isl.radius, isl.top);
@@ -68,6 +70,7 @@ export function sampleGround(x: number, z: number): GroundSample {
 
   // Bridges
   for (const s of BRIDGE_SEGMENTS) {
+    if (s.to === 'rainbow' && !worldRuntime.rainbowUnlocked) continue; // bridge not formed yet
     const dx = s.bx - s.ax;
     const dz = s.bz - s.az;
     const len2 = dx * dx + dz * dz || 1;


### PR DESCRIPTION
A 5th island that **forms once the child finishes their first level** — a free-play playground (rainbow arch, bouncy dome, slide, balloons) Belu can walk to and explore. A visible 'the world grew because of you' reward. Gated so a locked island is neither visible nor walkable. tsc + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)