### PR TITLE
Block Craft: declutter the playground (fewer animals, open spawn, sparser decor)

### DIFF
--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -405,23 +405,23 @@
 <div id="flash"></div>
 
 <script src="lib/three.min.js"></script>
-<script src="js/data.js?v=30"></script>
-<script src="js/audio.js?v=30"></script>
-<script src="js/world.js?v=30"></script>
-<script src="js/animals.js?v=30"></script>
-<script src="js/squishy.js?v=30"></script>
-<script src="js/weather.js?v=30"></script>
-<script src="js/parks.js?v=30"></script>
-<script src="js/shops.js?v=30"></script>
-<script src="js/signs.js?v=30"></script>
-<script src="js/portal.js?v=30"></script>
-<script src="js/ui.js?v=30"></script>
-<script src="js/activities.js?v=30"></script>
-<script src="js/music.js?v=30"></script>
-<script src="js/pet.js?v=30"></script>
-<script src="js/stickers.js?v=30"></script>
-<script src="js/overnight.js?v=30"></script>
-<script src="js/photo.js?v=30"></script>
-<script src="js/main.js?v=30"></script>
+<script src="js/data.js?v=31"></script>
+<script src="js/audio.js?v=31"></script>
+<script src="js/world.js?v=31"></script>
+<script src="js/animals.js?v=31"></script>
+<script src="js/squishy.js?v=31"></script>
+<script src="js/weather.js?v=31"></script>
+<script src="js/parks.js?v=31"></script>
+<script src="js/shops.js?v=31"></script>
+<script src="js/signs.js?v=31"></script>
+<script src="js/portal.js?v=31"></script>
+<script src="js/ui.js?v=31"></script>
+<script src="js/activities.js?v=31"></script>
+<script src="js/music.js?v=31"></script>
+<script src="js/pet.js?v=31"></script>
+<script src="js/stickers.js?v=31"></script>
+<script src="js/overnight.js?v=31"></script>
+<script src="js/photo.js?v=31"></script>
+<script src="js/main.js?v=31"></script>
 </body>
 </html>

--- a/public/blockcraft/js/data.js
+++ b/public/blockcraft/js/data.js
@@ -726,7 +726,7 @@ ABC.QUEST_DEFS = [
 /* Wormhole portal — the reward for using expressive language 🌀 */
 ABC.PORTAL = {
   NEED: 5,                                  // expressive successes to open it
-  homePos: { x:-7, z:-10 },                 // near spawn
+  homePos: { x:-22, z:-18 },                // off to the side so spawn stays open
   islandPos: { x:36, y:25, z:40 },          // secret Sky Island (south edge, clear of the rainbow)
 };
 

--- a/public/blockcraft/js/main.js
+++ b/public/blockcraft/js/main.js
@@ -437,7 +437,7 @@
 
   /* ---------------- spawn an animal friend from the bag ---------------- */
   function placeAnimal(type, x, z) {
-    if (ABC.animals.list.length > 40) { ABC.ui.toast('🐾 The meadow is full of friends! Maybe dig some space first!', 3200); return; }
+    if (ABC.animals.list.length > 14) { ABC.ui.toast('🐾 The meadow is full of friends! Maybe send one home before adding more!', 3200); return; }
     const a = ABC.animals.spawn(type, x, z);
     ABC.state.friends = ABC.state.friends || [];
     ABC.state.friends.push({ kind: type, x, z, name: a.name });

--- a/public/blockcraft/js/parks.js
+++ b/public/blockcraft/js/parks.js
@@ -40,10 +40,10 @@ ABC.parks = (function () {
       visited.add(reg.key);
       ABC.saveSoon && ABC.saveSoon();
       ABC.ui.confetti(20);
-      // one signature animal greets you (fewer animals, more meaningful)
-      if (reg.animal && ABC.animals && ABC.animals.list.length < 22) {
-        const a = ABC.animals.spawn(reg.animal, Math.round(feet.x) + 3, Math.round(feet.z) + 3);
-        (ABC.state.friends = ABC.state.friends || []).push({ kind: reg.animal, x: a.group.position.x, z: a.group.position.z, name: a.name });
+      // one signature animal greets you — session-only, NOT saved forever, and
+      // capped low so the meadow never fills up with animals
+      if (reg.animal && ABC.animals && ABC.animals.list.length < 10) {
+        ABC.animals.spawn(reg.animal, Math.round(feet.x) + 3, Math.round(feet.z) + 3);
       }
       setTimeout(() => { if (!ABC.ui.isOpen()) describe(reg); }, 1800);
     }

--- a/public/blockcraft/js/shops.js
+++ b/public/blockcraft/js/shops.js
@@ -50,8 +50,8 @@ ABC.shops = (function () {
 
   function init(sc) { scene = sc; }
   function placeAll() {
-    // 🏘️ home village — a cozy cluster of stalls near spawn
-    ['home1', 'home2', 'home3'].forEach(k => {
+    // 🏘️ home village — two stalls near spawn (kept light so it's not crowded)
+    ['home1', 'home2'].forEach(k => {
       const s = ABC.SHOPS[k]; if (!s) return;
       vendor(s, s.at.x + 1, s.at.z + 1);
       place(s.at.x, s.at.z, s.name, 0xff6b6b, 0xffffff);

--- a/public/blockcraft/js/world.js
+++ b/public/blockcraft/js/world.js
@@ -711,8 +711,8 @@ ABC.world = (function () {
   function genHome(keys, x, z) {             // calm flat home meadow
     gset(keys, x, 0, z, 'grass');
     const sp = Math.hypot(x, z), h = hash2(x * 3 + 1, z * 3 + 7);
-    if (sp > 16 && treeCell(x, z, 9) && vnoise(x + 777, z - 777, 34) > 0.55) genTree(keys, x, z, 0);
-    else if (h < 0.013) gset(keys, x, 1, z, 'flower');
+    if (sp > 16 && treeCell(x, z, 13) && vnoise(x + 777, z - 777, 34) > 0.55) genTree(keys, x, z, 0);
+    else if (h < 0.007) gset(keys, x, 1, z, 'flower');
   }
   function genWild(keys, x, z) {             // rolling grasslands between home and parks
     const e = vnoise(x, z, 44);
@@ -722,8 +722,8 @@ ABC.world = (function () {
     else gset(keys, x, 0, z, 'grass');
     const hsh = hash2(x * 3 + 1, z * 3 + 7);
     if (hh === 0) {
-      if (treeCell(x, z, 10) && vnoise(x, z, 26) > 0.58) genTree(keys, x, z, 0);
-      else if (hsh < 0.008) gset(keys, x, 1, z, 'flower');
+      if (treeCell(x, z, 14) && vnoise(x, z, 26) > 0.58) genTree(keys, x, z, 0);
+      else if (hsh < 0.004) gset(keys, x, 1, z, 'flower');
     }
   }
   /* region terrain — each US national park looks distinct 🏞️ */
@@ -743,7 +743,7 @@ ABC.world = (function () {
         const cf = vnoise(x + 50, z - 20, 26);
         const mh = cf > 0.62 ? Math.round((cf - 0.62) * 70 * t) : 0;
         for (let y = 1; y <= mh; y++) gset(keys, x, y, z, (y > mh - 2 && mh > 7) ? 'snow' : 'granite');
-        if (mh === 0 && treeCell(x, z, 8) && vnoise(x, z, 26) > 0.55) genPine(keys, x, z, 0);
+        if (mh === 0 && treeCell(x, z, 11) && vnoise(x, z, 26) > 0.55) genPine(keys, x, z, 0);
         break;
       }
       case 'zion': {
@@ -769,14 +769,14 @@ ABC.world = (function () {
       }
       case 'olympic': {
         gset(keys, x, 0, z, 'moss');
-        if (treeCell(x, z, 6) && vnoise(x, z, 22) > 0.42) genPine(keys, x, z, 0);   // lush but spaced
+        if (treeCell(x, z, 9) && vnoise(x, z, 22) > 0.42) genPine(keys, x, z, 0);   // lush but spaced
         break;
       }
       case 'everglades': {
         if (vnoise(x, z, 14) < 0.46) {
           gset(keys, x, 0, z, 'water');
           if (hash2(x, z) < 0.05) { gset(keys, x, 1, z, 'leaf'); gset(keys, x, 2, z, 'leaf'); }  // reeds
-        } else { gset(keys, x, 0, z, 'grass'); if (treeCell(x, z, 8)) genTree(keys, x, z, 0); }
+        } else { gset(keys, x, 0, z, 'grass'); if (treeCell(x, z, 11)) genTree(keys, x, z, 0); }
         break;
       }
       case 'glacier': {
@@ -889,9 +889,9 @@ ABC.world = (function () {
     structMap = new Map();
     const ss = (x, y, z, t, r) => structMap.set(key(x, y, z), { t, r: r || 0 });
     const arch = [[-3,1],[-3,2],[-3,3],[-2,4],[-1,5],[0,5],[1,5],[2,4],[3,3],[3,2],[3,1]];
-    arch.forEach(([x,y]) => ss(x, y, -6, 'rainbow'));
-    [[6,-6],[7,-6],[6,-7]].forEach(([x,z]) => ss(x, 1, z, 'blue'));
-    ss(6,2,-6,'blue'); ss(6,3,-6,'star');
+    arch.forEach(([x,y]) => ss(x, y, -14, 'rainbow'));   // pushed back so spawn is open
+    [[8,-12],[9,-12],[8,-13]].forEach(([x,z]) => ss(x, 1, z, 'blue'));   // mascot garden, off to the side
+    ss(8,2,-12,'blue'); ss(8,3,-12,'star');
     for (let x=0;x<=3;x++) ss(-16+x,1,2,'plank');                       // Mr. Maple's stall
     ss(-16,1,5,'wood'); ss(-13,1,5,'wood'); ss(-16,2,5,'wood'); ss(-13,2,5,'wood');
     ss(-16,2,2,'wood'); ss(-13,2,2,'wood'); ss(-15,2,2,'star'); ss(-14,2,2,'gold');


### PR DESCRIPTION
Owner clarified the "too crowded" complaint was about the **playground** (animals/objects), not the controls. Skin-independent worldgen/spawn tuning so everyone benefits:

**Fewer animals**
- Park signature-animal greeters are now **session-only** (no longer permanently saved to the world — that was the real accumulation) and the live cap drops **22 → 10**.
- Placeable-friend cap **40 → 14**; home vendors **3 → 2**.

**Open spawn area**
- Rainbow arch pushed back (`z -6 → -14`), mascot garden moved aside, wormhole portal ring relocated `(-7,-10) → (-22,-18)` — you start in open space (with Bella the elephant greeting you).

**Sparser decor**
- Wider tree spacing (home 9→13, wild 10→14, Olympic 6→9, Yosemite/Everglades 8→11) and ~half the ground flowers.

Verified headless: fresh spawn is noticeably more open. Cache-bust `v30 → v31`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)