### PR TITLE
Block Craft: Dig & Discover — treasure coins, new shapes, sleepy friends

### DIFF
--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -347,6 +347,7 @@
   <div id="scoreBar">
     <div class="scoreChip" id="starChip">⭐ 0</div>
     <div class="scoreChip" id="heartChip">💖 0</div>
+    <div class="scoreChip" id="coinChip" title="Dig up coins to unlock new shapes!">🪙 0</div>
     <div class="scoreChip" id="portalChip" title="Word power opens the wormhole!">🌀 0/5</div>
     <div class="scoreChip" id="questChip" title="Today's Adventures">📋 0/3</div>
     <div class="scoreChip" id="flowerChip" title="Days of adventures">🌻 0</div>
@@ -405,23 +406,24 @@
 <div id="flash"></div>
 
 <script src="lib/three.min.js"></script>
-<script src="js/data.js?v=31"></script>
-<script src="js/audio.js?v=31"></script>
-<script src="js/world.js?v=31"></script>
-<script src="js/animals.js?v=31"></script>
-<script src="js/squishy.js?v=31"></script>
-<script src="js/weather.js?v=31"></script>
-<script src="js/parks.js?v=31"></script>
-<script src="js/shops.js?v=31"></script>
-<script src="js/signs.js?v=31"></script>
-<script src="js/portal.js?v=31"></script>
-<script src="js/ui.js?v=31"></script>
-<script src="js/activities.js?v=31"></script>
-<script src="js/music.js?v=31"></script>
-<script src="js/pet.js?v=31"></script>
-<script src="js/stickers.js?v=31"></script>
-<script src="js/overnight.js?v=31"></script>
-<script src="js/photo.js?v=31"></script>
-<script src="js/main.js?v=31"></script>
+<script src="js/data.js?v=32"></script>
+<script src="js/audio.js?v=32"></script>
+<script src="js/world.js?v=32"></script>
+<script src="js/animals.js?v=32"></script>
+<script src="js/squishy.js?v=32"></script>
+<script src="js/weather.js?v=32"></script>
+<script src="js/parks.js?v=32"></script>
+<script src="js/shops.js?v=32"></script>
+<script src="js/signs.js?v=32"></script>
+<script src="js/portal.js?v=32"></script>
+<script src="js/ui.js?v=32"></script>
+<script src="js/activities.js?v=32"></script>
+<script src="js/music.js?v=32"></script>
+<script src="js/pet.js?v=32"></script>
+<script src="js/stickers.js?v=32"></script>
+<script src="js/overnight.js?v=32"></script>
+<script src="js/photo.js?v=32"></script>
+<script src="js/dig.js?v=32"></script>
+<script src="js/main.js?v=32"></script>
 </body>
 </html>

--- a/public/blockcraft/js/data.js
+++ b/public/blockcraft/js/data.js
@@ -54,14 +54,38 @@ ABC.BLOCK_DEFS = {
   lava:      { name:'Lava',         emoji:'🌋', color:'#ff6a2b', pat:'plain', glow:true },
   blackrock: { name:'Black Rock',   emoji:'⬛', color:'#2f2a2b', pat:'speck', speck:'#1d1a1b' },
   canvas:    { name:'Tent Cloth',   emoji:'⛺', color:'#e8584e', pat:'plain' },
+  /* ✨ Fun shapes — unlocked by digging up treasure (coins / shape-eggs) */
+  hexBlock:  { name:'Hexagon',  emoji:'⬡', color:'#74c0fc', pat:'plain', shape:'hexagon',  locked:true },
+  coneBlock: { name:'Cone',     emoji:'🔻', color:'#ffd43b', pat:'plain', shape:'cone',     locked:true },
+  ballBlock: { name:'Ball',     emoji:'🔵', color:'#69db7c', pat:'plain', shape:'ball',     locked:true },
+  pentBlock: { name:'Pentagon', emoji:'⬠', color:'#b197fc', pat:'plain', shape:'pentagon', locked:true },
+  triBlock:  { name:'Triangle', emoji:'🔺', color:'#ff922b', pat:'plain', shape:'triprism', locked:true },
+  /* 🪙 Buried treasure "tells" — VISIBLE glowing markers placed in the world; dig
+     them to get the reward. NOT in HOTBAR_ORDER, so kids can never place them. */
+  silverGlint:{ name:'Silver Coin', emoji:'🪙', color:'#dfe6ec', pat:'plain', shape:'knob', glow:true },
+  goldGlint:  { name:'Gold Coin',   emoji:'🪙', color:'#ffd43b', pat:'plain', shape:'knob', glow:true },
+  eggTell:    { name:'Shape Egg',   emoji:'🥚', color:'#eaf2ff', pat:'plain', shape:'knob', glow:true },
+  moundTell:  { name:'Sleepy Mound',emoji:'🌱', color:'#8fce6a', pat:'plain', shape:'knob' },
 };
 
-/* Hotbar order (unlocked-by-default first) */
+/* Hotbar order (unlocked-by-default first) — treasure markers are intentionally absent */
 ABC.HOTBAR_ORDER = ['grass','dirt','wood','plank','brick','gold','stone','glass','sand','snow',
   'leaf','flower','rainbow','star','water','red','blue','yellow','black','white',
   'redrock','sandstone','granite','moss','ice','lava','blackrock','canvas',
   'slab','wedge','stair','pillar','door','pane','knob',
+  'hexBlock','coneBlock','ballBlock','pentBlock','triBlock',
   'slimeGreen','slimePink','slimePurple','slimeBlue','oreo','oreoPink'];
+
+/* Shapes unlock in this fixed order (predictable: dig a 🥚 or fill the 🪙 bar) */
+ABC.SHAPE_UNLOCKS = ['hexBlock','coneBlock','ballBlock','pentBlock','triBlock'];
+ABC.COIN_THRESHOLDS = [6, 12, 20, 30, 42];     // coins needed to auto-unlock each (index-matched)
+/* what each dug treasure means (1:1, never random) */
+ABC.DIG_FIND = {
+  coin:   { emoji:'🪙', word:'a shiny silver coin' },
+  gold:   { emoji:'🪙', word:'a shiny GOLD coin' },
+  egg:    { emoji:'🥚', word:'a magic shape egg' },
+  friend: { emoji:'🌱', word:'a sleepy little friend' },
+};
 
 /* Color themes 🎨 — sky & world moods */
 ABC.THEMES = [

--- a/public/blockcraft/js/dig.js
+++ b/public/blockcraft/js/dig.js
@@ -1,0 +1,57 @@
+/* Aaria's Block Craft 3D — Dig & Discover 🪙
+   When you dig up a VISIBLE treasure marker (placed at world-gen), you get the one
+   fixed reward that marker always means — silver/gold coins, a shape egg, or a sleepy
+   animal friend. No random rolls: you see the glint/egg/mound before you dig it. */
+ABC.dig = (function () {
+  // marker block id -> reward kind (the marker you SEE is the reward you GET)
+  const KIND = { silverGlint: 'coin', goldGlint: 'gold', eggTell: 'egg', moundTell: 'friend' };
+
+  function kindForBlock(blockId) { return KIND[blockId] || null; }
+
+  // hatch the NEXT un-owned shape (eggs and the coin bar share one fixed order)
+  function hatchNextShape() {
+    const next = (ABC.SHAPE_UNLOCKS || []).find((id) => !ABC.state.unlocked.has(id));
+    if (next) {
+      ABC.state.foundShapes.add(next);
+      ABC.ui.unlockBlock(next);                  // adds + rebuilds hotbar + celebratory toast + saveSoon
+      ABC.ui.confetti && ABC.ui.confetti(16);
+      ABC.audio.sfx.fanfare && ABC.audio.sfx.fanfare();
+    } else {
+      // already have every shape — never a dead reward; gift a gold coin instead
+      ABC.ui.addCoins(5);
+    }
+  }
+
+  // a sleepy little friend wakes up — routes into the game's observe-and-help loop
+  function wakeFriend(cell) {
+    if (!ABC.animals || !ABC.animals.spawn) return;
+    const cute = Object.keys(ABC.ANIMAL_DEFS).filter((k) => ABC.ANIMAL_DEFS[k].cute && !ABC.ANIMAL_DEFS[k].special);
+    const kind = cute[Math.abs(cell.x * 31 + cell.z * 17) % cute.length];
+    const a = ABC.animals.spawn(kind, cell.x + 0.5, cell.z + 0.5);
+    const sleepy = (ABC.EMOTIONS || []).find((e) => e.key === 'sleepy') || (ABC.EMOTIONS || [])[0];
+    if (a && sleepy && ABC.animals.setEmotion) ABC.animals.setEmotion(a, sleepy);
+    ABC.ui.bellaSays && ABC.ui.bellaSays(
+      `You dug up a sleepy little friend! ${a ? a.def.emoji : '🐾'} Tap them to say hello and help!`, 5200);
+  }
+
+  // route a dug marker to its reward (called from main.js act() after a successful dig)
+  function reward(kind, cell) {
+    const f = (ABC.DIG_FIND && ABC.DIG_FIND[kind]) || { emoji: '✨', word: 'a surprise' };
+    if (kind === 'coin') {
+      ABC.ui.addCoins(1);
+      ABC.ui.toast(`🪙 You dug up ${f.word}!`, 2600);
+    } else if (kind === 'gold') {
+      ABC.ui.addCoins(5);
+      ABC.ui.confetti && ABC.ui.confetti(10);
+      ABC.ui.bellaSays && ABC.ui.bellaSays(`Wow — ${f.word}! That is worth five! ${f.emoji}`, 4200);
+    } else if (kind === 'egg') {
+      ABC.ui.bellaSays && ABC.ui.bellaSays(`A magic shape egg! Let's see what hatches… ${f.emoji}`, 3600);
+      hatchNextShape();
+    } else if (kind === 'friend') {
+      wakeFriend(cell);
+    }
+    ABC.saveSoon && ABC.saveSoon();
+  }
+
+  return { kindForBlock, reward, hatchNextShape, wakeFriend };
+})();

--- a/public/blockcraft/js/main.js
+++ b/public/blockcraft/js/main.js
@@ -470,6 +470,9 @@
           ABC.world.flush(); ABC.audio.sfx.remove(); saveSoon();
           pulverize(info.cell.x, info.cell.y, info.cell.z, t);   // 💥 crumble!
           collapseCheck(info.cell);                              // 🌳 unsupported parts fall
+          // 🪙 dig up buried treasure — the dug marker block IS the reward (no random roll)
+          const treasureKind = ABC.dig && ABC.dig.kindForBlock(t);
+          if (treasureKind) ABC.dig.reward(treasureKind, info.cell);
         } else if (info.cell.y === ABC.world.MIN_Y) {
           ABC.ui.toast('🪨 That is the super-strong bottom rock!', 2400);
         }
@@ -727,8 +730,9 @@
         placedCount: ABC.state.placedCount || 0,
         friends: ABC.state.friends || [],
         pocket: ABC.state.pocket || null,
-        stars: ABC.state.stars, hearts: ABC.state.hearts,
+        stars: ABC.state.stars, hearts: ABC.state.hearts, coins: ABC.state.coins,
         unlocked: [...ABC.state.unlocked], completed: [...ABC.state.completed],
+        foundShapes: [...ABC.state.foundShapes],
         tutorialDone: ABC.state.tutorialDone,
         settings: { sound: s.sound, music: s.music, readAloud: s.readAloud, voiceMode: s.voiceMode,
                     theme: s.theme, voiceName: s.voiceName },
@@ -769,6 +773,8 @@
       });
       ABC.state.stars = d.stars || 0;
       ABC.state.hearts = d.hearts || 0;
+      ABC.state.coins = d.coins || 0;
+      (d.foundShapes || []).forEach(s => ABC.state.foundShapes.add(s));
       (d.unlocked || []).forEach(b => ABC.state.unlocked.add(b));
       (d.completed || []).forEach(p => ABC.state.completed.add(p));
       ABC.state.tutorialDone = !!d.tutorialDone;

--- a/public/blockcraft/js/ui.js
+++ b/public/blockcraft/js/ui.js
@@ -1,8 +1,9 @@
 /* Aaria's Block Craft 3D — UI: HUD, dialogs, the expressive-communication engine */
 ABC.state = {
   playerName: 'Aaria',
-  stars: 0, hearts: 0,
+  stars: 0, hearts: 0, coins: 0,
   unlocked: new Set(),        // unlocked block ids (locked blocks)
+  foundShapes: new Set(),     // shapes hatched/unlocked via digging
   completed: new Set(),       // completed project ids
   tutorialDone: false,
 };
@@ -84,6 +85,29 @@ ABC.ui = (function () {
   function refreshScore() {
     $('starChip').textContent = '⭐ ' + ABC.state.stars;
     $('heartChip').textContent = '💖 ' + ABC.state.hearts;
+    const coinEl = $('coinChip');
+    if (coinEl) {
+      coinEl.textContent = '🪙 ' + ABC.state.coins;
+      // show the First-Then goal so the next shape is always predictable
+      const next = ABC.SHAPE_UNLOCKS.findIndex((id) => !ABC.state.unlocked.has(id));
+      coinEl.title = next >= 0
+        ? `Dig up coins! ${Math.max(0, ABC.COIN_THRESHOLDS[next] - ABC.state.coins)} more to unlock the ${ABC.BLOCK_DEFS[ABC.SHAPE_UNLOCKS[next]].name} ${ABC.BLOCK_DEFS[ABC.SHAPE_UNLOCKS[next]].emoji}!`
+        : 'You found every shape! 🎉';
+    }
+  }
+  // coins come ONLY from digging up treasure; thresholds auto-unlock shapes (predictable)
+  function addCoins(n) {
+    ABC.state.coins += n;
+    refreshScore();
+    ABC.audio.sfx.ding();
+    for (let i = 0; i < ABC.SHAPE_UNLOCKS.length; i++) {
+      const id = ABC.SHAPE_UNLOCKS[i];
+      if (ABC.state.coins >= ABC.COIN_THRESHOLDS[i] && !ABC.state.unlocked.has(id)) {
+        ABC.state.foundShapes.add(id);
+        unlockBlock(id);   // adds + rebuilds hotbar + celebratory toast + saveSoon
+      }
+    }
+    ABC.saveSoon && ABC.saveSoon();
   }
   function addStars(n) {
     const before = ABC.state.stars;
@@ -598,7 +622,7 @@ ABC.ui = (function () {
   }
 
   return { openDialog, closeDialog, isOpen, toast, bellaSays, confetti, floatHearts,
-           refreshScore, addStars, addHearts, askExpressive, askBuilder, pickCard, message,
+           refreshScore, addStars, addHearts, addCoins, askExpressive, askBuilder, pickCard, message,
            buildHotbar, selectBlock, selectByIndex, getSelected, unlockBlock,
            getHand, setHand, openBag, openQuickMenu,
            showSettings, showHelp, pick, pick3, esc };

--- a/public/blockcraft/js/world.js
+++ b/public/blockcraft/js/world.js
@@ -277,6 +277,11 @@ ABC.world = (function () {
         return g;
       }
       case 'knob':   return new THREE.BoxGeometry(0.3, 0.3, 0.3);
+      case 'hexagon':  return new THREE.CylinderGeometry(0.5, 0.5, 1, 6);
+      case 'pentagon': return new THREE.CylinderGeometry(0.5, 0.5, 1, 5);
+      case 'triprism': return new THREE.CylinderGeometry(0.58, 0.58, 1, 3);
+      case 'cone':     return new THREE.ConeGeometry(0.5, 1, 18);
+      case 'ball':     return new THREE.SphereGeometry(0.5, 18, 14);
       default:       return blockGeo;
     }
   }
@@ -671,6 +676,17 @@ ABC.world = (function () {
     h = Math.imul(h ^ (h >>> 13), 1274126177);
     return ((h ^ (h >>> 16)) >>> 0) / 4294967296;
   }
+  /* Buried-treasure "tell": which VISIBLE marker (if any) sits on this cell.
+     Deterministic from hash2, so the same spot always holds the same thing — the
+     child SEES the glint/egg/mound and digs it (no random rolls). Rare, mostly silver. */
+  function treasureMarkerAt(x, z) {
+    const h = hash2(x * 31 + 5, z * 31 + 7);
+    if (h < 0.0012) return 'moundTell';    // rarest — a sleepy animal friend
+    if (h < 0.0032) return 'eggTell';      // a shape egg
+    if (h < 0.0070) return 'goldGlint';    // gold coin (+5)
+    if (h < 0.0180) return 'silverGlint';  // silver coin (+1)
+    return null;
+  }
   function vnoise(x, z, s) {
     const fx = x / s, fz = z / s, x0 = Math.floor(fx), z0 = Math.floor(fz);
     const tx = fx - x0, tz = fz - z0, sm = (t) => t * t * (3 - 2 * t);
@@ -711,6 +727,8 @@ ABC.world = (function () {
   function genHome(keys, x, z) {             // calm flat home meadow
     gset(keys, x, 0, z, 'grass');
     const sp = Math.hypot(x, z), h = hash2(x * 3 + 1, z * 3 + 7);
+    const tk = sp > 10 ? treasureMarkerAt(x, z) : null;   // off the spawn pad
+    if (tk) { gset(keys, x, 1, z, tk); return; }          // a visible treasure to dig up 🪙
     if (sp > 16 && treeCell(x, z, 13) && vnoise(x + 777, z - 777, 34) > 0.55) genTree(keys, x, z, 0);
     else if (h < 0.007) gset(keys, x, 1, z, 'flower');
   }
@@ -722,7 +740,9 @@ ABC.world = (function () {
     else gset(keys, x, 0, z, 'grass');
     const hsh = hash2(x * 3 + 1, z * 3 + 7);
     if (hh === 0) {
-      if (treeCell(x, z, 14) && vnoise(x, z, 26) > 0.58) genTree(keys, x, z, 0);
+      const tk = treasureMarkerAt(x, z);
+      if (tk) gset(keys, x, 1, z, tk);                    // visible treasure to dig up 🪙
+      else if (treeCell(x, z, 14) && vnoise(x, z, 26) > 0.58) genTree(keys, x, z, 0);
       else if (hsh < 0.004) gset(keys, x, 1, z, 'flower');
     }
   }


### PR DESCRIPTION
A new dig engagement loop for Aaria's Block Craft 3D — designed ASD-first (**visible & predictable, never random/loot**).

**🪙 Buried treasure (you see it before you dig it)**
- Glowing markers generate in the meadow: silver glint, gold glint, shape egg 🥚, sleepy mound 🌱. Dig one → the **one fixed reward** that marker always means. The reward is keyed to the dug block's id, so it can't be farmed by placing blocks.
- New **🪙 coin** counter (silver +1, gold +5). The chip shows a First-Then goal ("3 more to unlock the Hexagon ⬡").

**🔷 New shapes beyond cubes**
- Hexagon ⬡, Cone 🔻, Ball 🔵, Pentagon ⬠, Triangle 🔺 (cylinder already existed as `pillar`). Rendered via `geoFor` (`CylinderGeometry` N-gon / `ConeGeometry` / `SphereGeometry`).
- Unlocked two **visible, fixed-order** ways: hatch a shape egg, or fill the coin bar to a threshold — whichever happens first.

**🐾 Animal + expression tie-in**
- Digging a sleepy mound wakes a cute animal with a feeling, routing into the game's existing **observe-and-help → hearts** loop (the warm, language-rich moment) — no interruptive quiz on ordinary digs.

New file `js/dig.js`; `coins`/`foundShapes` persist. Markers excluded from the hotbar so kids can't place them. Cache-bust `v31 → v32`.

**Verified headless:** all 5 shapes unlock + place + render distinctly; markers generate & are visible; `reward('coin')+reward('gold')` = +6 and chip updates; `kindForBlock` maps markers→rewards and normal blocks→null (exploit-proof); no JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)