### PR TITLE
Block Craft: enough time to read/listen + 🎛️ game-speed control

### DIFF
--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -358,6 +358,7 @@
     <button class="menuBtn deskOnly" id="oreoBtn">🍪<span class="btnTxt"> Oreo Kitchen</span></button>
     <button class="menuBtn deskOnly" id="kindBtn">💌<span class="btnTxt"> Kind Words</span></button>
     <button class="menuBtn deskOnly" id="stickersBtn" title="My Treasures">🏅</button>
+    <button class="menuBtn" id="speedBtn" title="Game speed — tap for more time 🐢 or faster 🚀">🎛️</button>
     <button class="menuBtn" id="skinToggleBtn" title="Switch Smooth / Classic look">🎨</button>
     <button class="menuBtn deskOnly" id="fsBtn" title="Full screen">⛶</button>
     <button class="menuBtn deskOnly" id="settingsBtn">⚙️</button>
@@ -406,24 +407,24 @@
 <div id="flash"></div>
 
 <script src="lib/three.min.js"></script>
-<script src="js/data.js?v=32"></script>
-<script src="js/audio.js?v=32"></script>
-<script src="js/world.js?v=32"></script>
-<script src="js/animals.js?v=32"></script>
-<script src="js/squishy.js?v=32"></script>
-<script src="js/weather.js?v=32"></script>
-<script src="js/parks.js?v=32"></script>
-<script src="js/shops.js?v=32"></script>
-<script src="js/signs.js?v=32"></script>
-<script src="js/portal.js?v=32"></script>
-<script src="js/ui.js?v=32"></script>
-<script src="js/activities.js?v=32"></script>
-<script src="js/music.js?v=32"></script>
-<script src="js/pet.js?v=32"></script>
-<script src="js/stickers.js?v=32"></script>
-<script src="js/overnight.js?v=32"></script>
-<script src="js/photo.js?v=32"></script>
-<script src="js/dig.js?v=32"></script>
-<script src="js/main.js?v=32"></script>
+<script src="js/data.js?v=33"></script>
+<script src="js/audio.js?v=33"></script>
+<script src="js/world.js?v=33"></script>
+<script src="js/animals.js?v=33"></script>
+<script src="js/squishy.js?v=33"></script>
+<script src="js/weather.js?v=33"></script>
+<script src="js/parks.js?v=33"></script>
+<script src="js/shops.js?v=33"></script>
+<script src="js/signs.js?v=33"></script>
+<script src="js/portal.js?v=33"></script>
+<script src="js/ui.js?v=33"></script>
+<script src="js/activities.js?v=33"></script>
+<script src="js/music.js?v=33"></script>
+<script src="js/pet.js?v=33"></script>
+<script src="js/stickers.js?v=33"></script>
+<script src="js/overnight.js?v=33"></script>
+<script src="js/photo.js?v=33"></script>
+<script src="js/dig.js?v=33"></script>
+<script src="js/main.js?v=33"></script>
 </body>
 </html>

--- a/public/blockcraft/js/audio.js
+++ b/public/blockcraft/js/audio.js
@@ -1,7 +1,24 @@
 /* Aaria's Block Craft 3D — audio: WebAudio synth SFX, gentle music, and text-to-speech */
 ABC.audio = (function () {
   let ctx = null, musicGain = null, musicTimer = null;
-  const S = { sound:true, music:false, readAloud:true, voiceMode:false };
+  const S = { sound:true, music:false, readAloud:true, voiceMode:false, speed:'normal' };
+
+  /* Game pace 🐢🐇🚀 — kids who need more time stay Relaxed; kids who want it
+     snappier go Fast. Scales how long messages linger AND the read-aloud rate.
+     Default 'normal' is already generous so nothing feels cut short. */
+  const SPEED = {
+    relaxed: { ico:'🐢', label:'Relaxed', dur:1.5,  rate:0.82 },
+    normal:  { ico:'🐇', label:'Normal',  dur:1.0,  rate:0.98 },
+    fast:    { ico:'🚀', label:'Fast',    dur:0.55, rate:1.35 },
+  };
+  const SPEED_ORDER = ['relaxed', 'normal', 'fast'];
+  function speedInfo() { return SPEED[S.speed] || SPEED.normal; }
+  function cycleSpeed() {
+    const i = SPEED_ORDER.indexOf(S.speed);
+    S.speed = SPEED_ORDER[(i + 1) % SPEED_ORDER.length];
+    return speedInfo();
+  }
+  function durMul() { return speedInfo().dur; }
 
   function ensureCtx() {
     if (!ctx) {
@@ -148,12 +165,17 @@ ABC.audio = (function () {
     if (!S.readAloud && !(opts && opts.force)) return;
     const clean = String(text).replace(/<[^>]*>/g, '').replace(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}✨⭐]/gu, '');
     if (!clean.trim()) return;
+    // DON'T cut a line short: if we're already reading something aloud and this
+    // isn't a forced read (a button the child tapped, or a dialog they opened),
+    // skip it — let the current line finish so the child can listen fully.
+    const force = opts && opts.force;
+    if (speechSynthesis.speaking && !force) return;
     speechSynthesis.cancel();
     // Chrome quirk: speaking immediately after cancel() silently drops the
     // utterance — queue it a tick later. Speak sentence-by-sentence with
     // natural micro-pauses, the way a person reads to a child.
     const useVoice = (opts && opts.voiceObj) || voice;
-    const baseRate = (opts && opts.rate) || 0.92;
+    const baseRate = ((opts && opts.rate) || 0.92) * speedInfo().rate;   // game-speed aware
     const basePitch = (opts && opts.pitch) || 1.0;
     setTimeout(() => {
       if (!voice) pickVoice();          // voices sometimes load late
@@ -247,5 +269,6 @@ ABC.audio = (function () {
 
   return { settings:S, ensureCtx, sfx, startMusic, say, sayBella, stopSay, listen, hasSR:!!SR,
            cycleVoice, animalCall, regionSound, voiceFor, seedFor,
+           speedInfo, cycleSpeed, durMul, SPEED_ORDER,
            voiceName: () => voice ? voice.name : 'default' };
 })();

--- a/public/blockcraft/js/main.js
+++ b/public/blockcraft/js/main.js
@@ -406,7 +406,7 @@
     g.strokeStyle = '#fff'; g.lineWidth = 2;
     g.beginPath(); g.moveTo(R * SC + SC/2, R * SC + SC/2);
     g.lineTo(R * SC + SC/2 - Math.sin(yaw) * SC * 3.2, R * SC + SC/2 - Math.cos(yaw) * SC * 3.2); g.stroke();
-    ABC.audio.say('Look — your world from the sky! The blue dot is you.');
+    ABC.audio.say('Look — your world from the sky! The blue dot is you.', { force: true });
     $('mapOk').onclick = () => ABC.ui.closeDialog();
   }
 
@@ -735,7 +735,7 @@
         foundShapes: [...ABC.state.foundShapes],
         tutorialDone: ABC.state.tutorialDone,
         settings: { sound: s.sound, music: s.music, readAloud: s.readAloud, voiceMode: s.voiceMode,
-                    theme: s.theme, voiceName: s.voiceName },
+                    theme: s.theme, voiceName: s.voiceName, speed: s.speed },
       }));
     } catch (e) { /* storage blocked — keep playing */ }
   }
@@ -889,6 +889,24 @@
     }
   };
   $('howBtn').onclick = () => ABC.ui.showHelp();
+
+  /* ---------------- game speed (🐢 more time · 🐇 normal · 🚀 faster) ---------------- */
+  ABC.refreshSpeedBtn = () => {
+    const b = $('speedBtn'); if (!b) return;
+    const info = ABC.audio.speedInfo();
+    b.textContent = '🎛️';                     // a dial — the speed control
+    b.title = `Game speed: ${info.label} — tap for more time 🐢 or faster 🚀`;
+  };
+  if ($('speedBtn')) {
+    $('speedBtn').onclick = () => {
+      const info = ABC.audio.cycleSpeed();
+      ABC.refreshSpeedBtn();
+      ABC.audio.sfx.pop();
+      saveSoon();
+      ABC.ui.toast(`${info.ico} Game speed: <b>${info.label}</b>`, 2600, false);
+    };
+    ABC.refreshSpeedBtn();
+  }
 
   /* ---------------- skin picker (title screen) ----------------
      The smooth skin rebuilds materials/geometry/renderer at startup, so flipping

--- a/public/blockcraft/js/ui.js
+++ b/public/blockcraft/js/ui.js
@@ -45,8 +45,12 @@ ABC.ui = (function () {
     t.className = 'toast';
     t.innerHTML = msg;
     $('toasts').appendChild(t);
+    // Give the child enough time to read: linger in proportion to length, with a
+    // generous floor — then scale by the chosen game speed (🐢 longer / 🚀 shorter).
+    const plain = msg.replace(/<[^>]*>/g, '');
+    const ms = Math.max(dur || 0, 3200, plain.length * 70 + 1800) * (ABC.audio.durMul ? ABC.audio.durMul() : 1);
     setTimeout(() => { t.style.transition = 'opacity .5s'; t.style.opacity = '0';
-      setTimeout(()=>t.remove(), 500); }, dur || 3200);
+      setTimeout(()=>t.remove(), 500); }, ms);
     if (speak) ABC.audio.say(msg);
   }
   function bellaSays(msg, dur) {
@@ -166,7 +170,7 @@ ABC.ui = (function () {
         <span class="speakIco" data-say="${i}">🔊</span></button>`;
     });
     openDialog(html);
-    ABC.audio.say(prompt.scene);
+    ABC.audio.say(prompt.scene, { force: true });
 
     box().querySelectorAll('.speakIco').forEach(s => {
       s.addEventListener('click', (e) => {
@@ -218,7 +222,7 @@ ABC.ui = (function () {
       <div id="vStatus" class="scene" style="min-height:28px; font-size:17px; color:#666;">Press the microphone, then say the sentence!</div>
       <div class="dlgRow"><button class="bigBtn" id="vChoices" style="font-size:16px; padding:10px 18px; background:linear-gradient(180deg,#d0ebff,#a5d8ff); color:#1864ab; box-shadow:0 4px 0 #4dabf7;">📋 Show choices instead</button></div>`;
     openDialog(html);
-    ABC.audio.say(prompt.scene + ' ... Press the microphone and say: ' + best.t);
+    ABC.audio.say(prompt.scene + ' ... Press the microphone and say: ' + best.t, { force: true });
 
     $('vSayIt').onclick = () => ABC.audio.say(best.t, { force: true });
     $('vChoices').onclick = () => choiceRound(prompt, onSuccess, opts, 0);
@@ -306,7 +310,7 @@ ABC.ui = (function () {
     });
     html += '</div>';
     openDialog(html);
-    ABC.audio.say(sceneText + ' ... Tap the words in order: ' + sentence);
+    ABC.audio.say(sceneText + ' ... Tap the words in order: ' + sentence, { force: true });
     $('sbHear').onclick = () => ABC.audio.say(sentence, { force: true });
 
     let missCount = 0;
@@ -355,7 +359,7 @@ ABC.ui = (function () {
     });
     html += '</div>';
     openDialog(html);
-    ABC.audio.say(sceneText, speakOpts);   // a vendor's greeting speaks in their own voice
+    ABC.audio.say(sceneText, Object.assign({ force: true }, speakOpts));   // a vendor's greeting speaks in their own voice
     box().querySelectorAll('.pickCard').forEach(b => {
       b.addEventListener('click', () => {
         ABC.audio.sfx.pop();
@@ -370,7 +374,7 @@ ABC.ui = (function () {
     openDialog(`<div class="bigEmoji">${emoji || '💬'}</div><h2>${title}</h2>
       <div class="scene">${bodyHtml}</div>
       <div class="dlgRow"><button class="bigBtn green" id="msgOk">${btnLabel || 'OK! 👍'}</button></div>`);
-    ABC.audio.say(title + '. ' + bodyHtml);
+    ABC.audio.say(title + '. ' + bodyHtml, { force: true });
     $('msgOk').onclick = () => { ABC.audio.sfx.pop(); closeDialog(); onClose && onClose(); };
   }
 
@@ -455,7 +459,7 @@ ABC.ui = (function () {
     html += '</div>';
     openDialog(ABC.tpl(html));
     ABC.audio.say(pocketOpened() ? 'What will you take out of your school bag?'
-                                 : 'Ooh — something is hiding in the surprise pocket!');
+                                 : 'Ooh — something is hiding in the surprise pocket!', { force: true });
     const pb = $('pocketBtn');
     if (pb && !pocketOpened()) pb.addEventListener('click', openPocket);
     box().querySelectorAll('.bagItem[data-kind]').forEach(b => {
@@ -552,8 +556,10 @@ ABC.ui = (function () {
     const s = ABC.audio.settings;
     const chk = (v) => v ? '✅' : '⬜';
     const skinNow = ABC.SMOOTH ? '✨ Smooth' : '🧱 Classic';
+    const sp = ABC.audio.speedInfo();
     openDialog(`<img src="logo.png" style="width:90px;border-radius:50%;box-shadow:0 4px 12px rgba(0,0,0,.2);" alt=""><h2>Settings</h2>
       <button class="choiceBtn" id="setName">✏️ Player name: <b>${esc(ABC.state.playerName)}</b> — tap to change</button>
+      <button class="choiceBtn" id="setSpeed">🎛️ Game speed: <b>${sp.ico} ${sp.label}</b> — tap to change (🐢 more time · 🚀 faster)</button>
       <button class="choiceBtn" id="setSkin">🎨 Block look: <b>${skinNow}</b> — tap to switch (Smooth = soft, rounded, gentle shadows)</button>
       <button class="choiceBtn" id="setVoice">${chk(s.voiceMode)} 🎤 Voice Mode — say sentences out loud ${ABC.audio.hasSR ? '' : '(needs Chrome/Edge)'}</button>
       <button class="choiceBtn" id="setRead">${chk(s.readAloud)} 🔊 Read everything aloud</button>
@@ -579,6 +585,14 @@ ABC.ui = (function () {
         toast(`Hi, <b>${esc(ABC.state.playerName)}</b>! 👋`, 3000, true);
         showSettings();
       };
+    });
+    wire('setSpeed', () => {
+      const info = ABC.audio.cycleSpeed();
+      ABC.saveSoon && ABC.saveSoon();
+      if (ABC.refreshSpeedBtn) ABC.refreshSpeedBtn();
+      ABC.audio.sfx.pop();
+      toast(`${info.ico} Game speed: <b>${info.label}</b>`, 2600, true);
+      showSettings();
     });
     wire('setSkin', () => {
       const next = ABC.SMOOTH ? 'classic' : 'smooth';


### PR DESCRIPTION
Player feedback: text was **too wordy** and **vanished too fast / got cut short** — no time to read or finish listening. This addresses the timing directly and adds a kid-controllable pace.

**Don't cut the read-aloud short**
- `say()` now only interrupts on a *forced* read (a 🔊 button the child taps, or a dialog they just opened). Ambient lines let the current one finish instead of cancelling it mid-sentence (the old `speechSynthesis.cancel()` on every call was the bug). Dialog/prompt reads are marked `force` so they still read promptly.

**On-screen text stays long enough**
- Toasts now linger in proportion to length (~70ms/char, generous floor) instead of a fixed short timeout.

**🎛️ Game-speed control (the kid-friendly fix you suggested)**
- 🐢 **Relaxed** (more time + slower voice) · 🐇 **Normal** (default, already generous) · 🚀 **Fast**.
- A **dial 🎛️ button** in the menu bar (one-tap cycle) + a Settings row, **persisted**. Scales both how long messages linger *and* the speech rate.

Cache-bust `v32 → v33`. Verified headless: button shows the dial, cycles Normal→Fast(×0.55)→Relaxed(×1.5)→Normal, durations + rate scale, speed persists to the save, `say()` works with the new guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)