### PR TITLE
Helping Hands v2: walkable world, in-world enactment (no flash cards)

### DIFF
--- a/public/helpinghands/index.html
+++ b/public/helpinghands/index.html
@@ -163,6 +163,20 @@
   }
   .explore-bottombar { display: flex; align-items: center; justify-content: center; gap: 14px; padding: 12px; flex-wrap: wrap; }
 
+  /* ---------- world banner (Belu's Game + in-world scenarios) ---------- */
+  .world-banner {
+    position: absolute; left: 10px; right: 10px; bottom: 10px; z-index: 65;
+    background: #fff; border-radius: 22px; padding: 16px 18px; box-shadow: 0 10px 24px rgba(60,40,100,.28);
+    max-height: 62%; overflow-y: auto; animation: popIn .22s ease-out;
+  }
+  .banner-close-btn {
+    position: absolute; top: 10px; right: 10px; border: 0; background: rgba(95,61,196,.12); color: #5f3dc4;
+    width: 34px; height: 34px; border-radius: 50%; font-size: 14px; cursor: pointer; font-weight: 800;
+  }
+  .banner-text-row { display: flex; align-items: flex-start; gap: 10px; padding-right: 40px; }
+  .banner-text { font-size: 16px; font-weight: 800; color: #4c3a8f; line-height: 1.35; flex: 1; text-align: left; }
+  #worldBannerChoices:not(:empty), #worldBannerActions:not(:empty) { margin-top: 14px; }
+
   /* ---------- belu mascot bubble (global) ---------- */
   #beluBubble {
     position: fixed; left: 12px; bottom: 12px; z-index: 60; display: flex; align-items: flex-end; gap: 8px;
@@ -193,8 +207,6 @@
   .friend-line { font-size: 15px; color: #5c4a7d; line-height: 1.4; margin-bottom: 18px; }
   .modal-card .modal-actions { display: flex; flex-direction: column; gap: 10px; margin-top: 6px; }
 
-  .quiz-q-row { display: flex; align-items: center; gap: 10px; margin-bottom: 16px; }
-  .quiz-q { font-size: 18px; font-weight: 800; color: #4c3a8f; text-align: left; flex: 1; }
   .quiz-answers { display: flex; flex-direction: column; gap: 10px; }
   .choice-btn {
     border: 0; background: #f1edff; color: #3b2a55; font-weight: 700; font-size: 16px; text-align: left;
@@ -229,6 +241,8 @@
   .helper-chip.friend { box-shadow: 0 4px 10px rgba(60,40,100,.13), 0 0 0 3px #ffd43b; }
   .helper-chip.used { opacity: .4; }
   .lesson-card { background: #fff; border-radius: 24px; padding: 22px; max-width: 560px; box-shadow: 0 8px 20px rgba(60,40,100,.14); display: flex; flex-direction: column; gap: 14px; }
+  .belu-card-row { display: flex; align-items: center; gap: 8px; }
+  .belu-card-avatar { font-size: 32px; filter: drop-shadow(0 2px 3px rgba(0,0,0,.15)); }
   .signs-grid { display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; }
   .sign-chip { background: #fff7e0; border-radius: 16px; padding: 12px 14px; min-width: 100px; text-align: center; box-shadow: 0 3px 8px rgba(0,0,0,.08); }
   .sign-chip .em { font-size: 32px; }
@@ -351,12 +365,19 @@
     <canvas id="three"></canvas>
     <div id="worldLoadingNote" class="loading-note">🌍 The world is loading…</div>
     <div id="toastNote" class="toast-note" hidden></div>
+    <div id="worldBanner" class="world-banner" hidden>
+      <button id="worldBannerCloseBtn" class="banner-close-btn" hidden>✖</button>
+      <div class="banner-text-row">
+        <div id="worldBannerText" class="banner-text"></div>
+        <button id="worldBannerSpeakBtn" class="speak-btn" title="Read aloud">🔊</button>
+      </div>
+      <div id="worldBannerChoices" class="quiz-answers"></div>
+      <div id="worldBannerActions" class="resolve-actions"></div>
+    </div>
   </div>
   <div class="explore-bottombar">
-    <button id="roomPrevBtn" class="round-btn" hidden>◀</button>
     <button id="mapBtn" class="pill-btn" hidden>🏠 Map</button>
-    <button id="quizBtn" class="pill-btn" hidden>❓ Quiz</button>
-    <button id="roomNextBtn" class="round-btn" hidden>▶</button>
+    <button id="findGameBtn" class="pill-btn" hidden>⭐ Belu's Game</button>
   </div>
 </div>
 
@@ -424,18 +445,6 @@
       <button id="friendAddBtn" class="btn-primary">Add to my friends! 💙</button>
       <button id="friendCloseBtn" class="link-btn">Close</button>
     </div>
-  </div>
-</div>
-
-<!-- generic quiz modal (room quizzes, feelings quiz) -->
-<div id="quizModal" class="modal-overlay" hidden>
-  <div class="modal-card">
-    <div class="quiz-q-row">
-      <div id="quizQ" class="quiz-q"></div>
-      <button id="quizSpeakBtn" class="speak-btn" title="Read aloud">🔊</button>
-    </div>
-    <div id="quizAnswers" class="quiz-answers"></div>
-    <div id="quizFeedback" class="quiz-feedback" aria-live="polite"></div>
   </div>
 </div>
 

--- a/public/helpinghands/js/content.js
+++ b/public/helpinghands/js/content.js
@@ -190,6 +190,7 @@ HH.SCENARIOS = [
     tellTo: ["teacher", "mom"], keepTelling: true,
     busyLine: "Ms. Lee is helping another kid and says 'one minute' — but the bell rings and everyone leaves.",
     keepLine: "The first try did not work. Keep telling! Who else is on your hand?",
+    goLine: "School is over. Time to go home. Let's find Mom and tell her!",
     tellPrompt: "Who can you tell at home?",
     resolve: "You tell Mom everything at home. Mom hugs you and calls the school. The poking stops. Telling twice worked!",
   },
@@ -251,6 +252,39 @@ HH.SCENARIOS = [
     resolve: "Nurse Joy sits with you and listens to every word. 'You are not bad. You are brave,' she says. 'Grown-ups will help now.' And they do.",
   },
 ];
+
+/* ---------------- in-world enactment data ----------------
+   Discovery "find & do" tasks replace quiz cards: Belu asks, the
+   child WALKS to the right room and taps the glowing target object.
+   task = { ask, roomId, objIndex, praise } */
+HH.FIND_TASKS = {
+  house: [
+    { ask: "Where do we sleep? Walk there and tap the bed!", roomId: "bedroom", objIndex: 0, praise: "Yes! We sleep in the bedroom! 😴" },
+    { ask: "Time to brush our teeth! Find the toothbrush!", roomId: "bathroom", objIndex: 1, praise: "Yes! We brush teeth in the bathroom! 🪥" },
+    { ask: "Grown-ups cook food somewhere. Find the stove!", roomId: "kitchen", objIndex: 0, praise: "Yes! Cooking happens in the kitchen! 🍳" },
+    { ask: "Where do we eat together? Tap the table!", roomId: "dining", objIndex: 0, praise: "Yes! We eat in the dining room! 🍽️" },
+    { ask: "Let's play a puzzle! Where do we play and rest?", roomId: "living", objIndex: 2, praise: "Yes! We play in the living room! 🧩" },
+  ],
+  school: [
+    { ask: "Where do we learn? Walk there and tap the books!", roomId: "classroom", objIndex: 1, praise: "Yes! We learn in the classroom! 📚" },
+    { ask: "It is lunch time! Find your lunch tray!", roomId: "cafeteria", objIndex: 1, praise: "Yes! We eat lunch in the cafeteria! 🍎" },
+    { ask: "Recess time! Find the slide!", roomId: "playground", objIndex: 0, praise: "Yes! We play on the playground! 🛝" },
+    { ask: "Where does Principal Rivera work? Find the front desk!", roomId: "office", objIndex: 0, praise: "Yes! The office is where the principal works! 🏢" },
+    { ask: "You feel sick. Where can you rest? Find the rest bed!", roomId: "nurseroom", objIndex: 1, praise: "Yes! Nurse Joy helps you in the nurse's office! 🩹" },
+  ],
+};
+
+/* short speech-bubble lines for scenario actors (in-world, ≤7 words) */
+HH.SCENARIO_ACTORS = {
+  ball:     { emoji: "🧒", name: "Kai",  bubble: "Give me the ball! You're too slow!" },
+  cookies:  { emoji: "👧", name: "Mia",  bubble: "Give me your cookies. Don't tell!" },
+  leftout:  { emoji: "🧒", name: "Kids", bubble: "You can't play with us!" },
+  poker:    { emoji: "🧒", name: "Leo",  bubble: "*poke poke* Don't be a tattletale!" },
+  follower: { emoji: "🧍", name: "Stranger", bubble: "Come closer! I have candy…" },
+  aide:     { emoji: "🧑", name: "The grown-up", bubble: "Hurry up! *grabs arm* Don't tell!" },
+  cousin:   { emoji: "🧒", name: "Cousin", bubble: "It's just a game! *hits*" },
+  scaryhome:{ emoji: "🌧️", name: "At home", bubble: "…yelling again…" },
+};
 
 /* which helper stands in which room (placeId -> roomId -> helperId) */
 HH.HELPER_SPOTS = {

--- a/public/helpinghands/js/main.js
+++ b/public/helpinghands/js/main.js
@@ -294,10 +294,26 @@ function renderMenuCards() {
 function wireMenu() { renderMenuCards(); }
 
 /* ---------------------------------------------------------------
-   4. EXPLORE MY WORLD
+   4. EXPLORE MY WORLD (free-roam) + BELU'S GAME (find & do)
+   Quiz cards are gone — the child WALKS the world. Belu's Game asks
+   the child to find & tap the right object in the right room.
    --------------------------------------------------------------- */
 let worldReady = false;
-const exState = { place: null, roomIdx: 0 };
+const exState = { place: null, roomId: null };
+const visitedRoomsThisSession = new Set();
+let findState = { active: false, placeId: null, tasks: [], idx: 0, lastWrongAt: 0 };
+let scenarioState = null; // set while an in-world "Practice Being Brave" scenario is running
+
+function findRoomInfo(roomId) {
+  const placeIds = Object.keys(HH.PLACES);
+  for (let i = 0; i < placeIds.length; i++) {
+    const place = HH.PLACES[placeIds[i]];
+    if (!place.rooms) continue;
+    const room = place.rooms.find(r => r.id === roomId);
+    if (room) return { placeId: placeIds[i], room };
+  }
+  return null;
+}
 
 function initWorldOnce() {
   const note = $("worldLoadingNote");
@@ -309,7 +325,13 @@ function initWorldOnce() {
   HH.World.init({ canvas: $("three") }).then(() => {
     worldReady = true;
     note.hidden = true;
-    HH.World.setHandlers({ onBuilding: handleBuilding, onObject: handleObject, onHelper: handleHelper });
+    HH.World.setHandlers({
+      onBuilding: handleBuilding,
+      onObject: handleObject,
+      onHelper: handleHelper,
+      onActor: handleActor,
+      onRoomEnter: handleRoomEnter,
+    });
     HH.World.showHub();
     HH.World.resize();
   }).catch(err => {
@@ -323,17 +345,22 @@ function enterExplore() {
   goHub();
   if (window.HH && HH.World) HH.World.resize();
 }
+function exitOverlayModes() {
+  if (findState.active) quitFindGame();
+  if (scenarioState) { endScenario(); }
+}
 function goHub() {
-  exState.place = null; exState.roomIdx = 0;
+  exitOverlayModes();
+  exState.place = null; exState.roomId = null;
   if (window.HH && HH.World && worldReady) HH.World.showHub();
   $("roomHeader").hidden = true;
-  $("roomPrevBtn").hidden = true;
-  $("roomNextBtn").hidden = true;
-  $("quizBtn").hidden = true;
+  $("findGameBtn").hidden = true;
   $("mapBtn").hidden = true;
+  hideWorldBanner();
   setBelu("Tap a building to explore! 🏠🏫");
 }
 function handleBuilding(placeId) {
+  if (scenarioState) return;
   const place = HH.PLACES[placeId];
   if (!place) return;
   if (!place.unlocked) {
@@ -341,47 +368,49 @@ function handleBuilding(placeId) {
     setBelu(place.comingSoon || "Coming soon!");
     return;
   }
-  exState.place = placeId; exState.roomIdx = 0;
-  if (HH.World) HH.World.showRoom(placeId, 0);
-  renderRoom();
-}
-function renderRoom() {
-  const place = HH.PLACES[exState.place];
-  const room = place.rooms[exState.roomIdx];
-  const rh = $("roomHeader");
-  rh.hidden = false; rh.textContent = room.emoji + " " + room.name;
-  setBelu(room.action);
+  exState.place = placeId; exState.roomId = null;
+  if (window.HH && HH.World) HH.World.enterBuilding(placeId);
   $("mapBtn").hidden = false;
-  $("quizBtn").hidden = !room.quiz;
-  $("roomPrevBtn").hidden = false;
-  $("roomNextBtn").hidden = false;
+  const hasTasks = !!(HH.FIND_TASKS && HH.FIND_TASKS[placeId] && HH.FIND_TASKS[placeId].length);
+  $("findGameBtn").hidden = !hasTasks || findState.active;
+  $("roomHeader").hidden = true;
 }
-function stepRoom(delta) {
-  const place = HH.PLACES[exState.place];
-  if (!place) return;
-  const n = place.rooms.length;
-  exState.roomIdx = (exState.roomIdx + delta + n) % n;
-  if (HH.World) HH.World.showRoom(exState.place, exState.roomIdx);
-  renderRoom();
+function handleRoomEnter(roomId) {
+  if (scenarioState) return; // scenarios control their own room chrome
+  exState.roomId = roomId;
+  const info = findRoomInfo(roomId);
+  const rh = $("roomHeader");
+  if (info) {
+    rh.hidden = false;
+    rh.textContent = info.room.emoji + " " + info.room.name;
+    if (!visitedRoomsThisSession.has(roomId)) {
+      visitedRoomsThisSession.add(roomId);
+      if (!findState.active) setBelu(info.room.action);
+    }
+  } else {
+    rh.hidden = true;
+    if (!findState.active) setBelu("Walk through a door! 🚪");
+  }
 }
-function handleObject(objIndex) {
-  const place = HH.PLACES[exState.place];
-  if (!place) return;
-  const room = place.rooms[exState.roomIdx];
-  const obj = room.objects && room.objects[objIndex];
+function handleObject(roomId, objIndex) {
+  if (scenarioState) return;
+  if (findState.active) { handleFindObjectTap(roomId, objIndex); return; }
+  const info = findRoomInfo(roomId);
+  const obj = info && info.room.objects && info.room.objects[objIndex];
   if (!obj) return;
-  setBelu(obj[0] + " " + obj[1]);
+  const label = obj[0] + " " + obj[1];
+  setBelu(label);
+  if (window.HH && HH.World) HH.World.say("me", label, 2500);
 }
-function handleHelper(helperId) { openFriendCard(helperId); }
-function startRoomQuiz() {
-  const place = HH.PLACES[exState.place];
-  if (!place) return;
-  const room = place.rooms[exState.roomIdx];
-  if (!room.quiz) return;
-  openQuiz(room.quiz.q, room.quiz.a, () => {
-    if (!save.quizzed.includes(room.id)) save.quizzed.push(room.id);
-    awardSticker(1);
-  });
+function handleHelper(helperId) {
+  if (scenarioState) { handleScenarioHelperTap(helperId); return; }
+  openFriendCard(helperId);
+}
+function handleActor(actorId) {
+  if (scenarioState && scenarioState.scenario.id === actorId) {
+    const actor = HH.SCENARIO_ACTORS[actorId];
+    if (actor && window.HH && HH.World) HH.World.say(actorId, actor.bubble, 2500);
+  }
 }
 let toastTimer = null;
 function showToast(text) {
@@ -390,23 +419,97 @@ function showToast(text) {
   clearTimeout(toastTimer);
   toastTimer = setTimeout(() => { t.hidden = true; }, 3200);
 }
-function openQuiz(q, answers, onCorrect) {
-  const modal = $("quizModal");
-  $("quizQ").textContent = q;
-  $("quizSpeakBtn").onclick = () => speak(q);
-  const feedback = $("quizFeedback");
-  buildChoices($("quizAnswers"), answers, feedback, () => {
-    setTimeout(() => { modal.hidden = true; if (onCorrect) onCorrect(); }, 900);
-  });
-  modal.hidden = false;
+
+/* ---- world banner: bottom overlay used by Belu's Game + in-world scenarios ---- */
+function showWorldBanner(text, opts) {
+  opts = opts || {};
+  const banner = $("worldBanner");
+  $("worldBannerText").textContent = text || "";
+  $("worldBannerSpeakBtn").onclick = () => speak(text || "");
+  $("worldBannerCloseBtn").hidden = !opts.onClose;
+  $("worldBannerCloseBtn").onclick = opts.onClose || null;
+  $("worldBannerChoices").innerHTML = "";
+  $("worldBannerActions").innerHTML = "";
+  banner.hidden = false;
 }
+function setBannerText(text) { $("worldBannerText").textContent = text || ""; }
+function hideWorldBanner() {
+  $("worldBanner").hidden = true;
+  $("worldBannerChoices").innerHTML = "";
+  $("worldBannerActions").innerHTML = "";
+}
+function bannerChoices(options, onCorrect) {
+  buildChoices($("worldBannerChoices"), options, null, onCorrect);
+}
+function bannerActionButton(label, cls, onClick) {
+  const btn = document.createElement("button");
+  btn.className = cls || "btn-primary";
+  btn.textContent = label;
+  btn.addEventListener("click", onClick);
+  $("worldBannerActions").appendChild(btn);
+  return btn;
+}
+
+/* ---- Belu's Game: find & do (replaces the old room quiz cards) ---- */
+function startFindGame() {
+  const placeId = exState.place;
+  const tasks = HH.FIND_TASKS && HH.FIND_TASKS[placeId];
+  if (!placeId || !tasks || !tasks.length) return;
+  findState = { active: true, placeId, tasks, idx: 0, lastWrongAt: 0 };
+  $("findGameBtn").hidden = true;
+  showFindTask();
+}
+function showFindTask() {
+  const task = findState.tasks[findState.idx];
+  if (!task) { finishFindGame(); return; }
+  setBelu(task.ask);
+  showWorldBanner(task.ask, { onClose: quitFindGame });
+  if (window.HH && HH.World) HH.World.setTarget({ roomId: task.roomId, objIndex: task.objIndex });
+}
+function handleFindObjectTap(roomId, objIndex) {
+  const task = findState.tasks[findState.idx];
+  if (!task) return;
+  if (roomId === task.roomId && objIndex === task.objIndex) {
+    SND.chime();
+    awardSticker(1);
+    setBelu(task.praise);
+    setBannerText(task.praise);
+    if (window.HH && HH.World) HH.World.setTarget(null);
+    findState.idx++;
+    setTimeout(showFindTask, 1500);
+  } else {
+    const now = Date.now();
+    if (now - findState.lastWrongAt > 2500) {
+      findState.lastWrongAt = now;
+      SND.tryTone();
+      setBelu("Hmm, not that one — keep looking! 💙");
+    }
+  }
+}
+function finishFindGame() {
+  const placeId = findState.placeId;
+  findState.active = false;
+  hideWorldBanner();
+  if (window.HH && HH.World) HH.World.setTarget(null);
+  const place = HH.PLACES[placeId];
+  if (placeId && !save.quizzed.includes(placeId)) save.quizzed.push(placeId);
+  saveSave();
+  confettiBig(); SND.chime();
+  setBelu("You know your whole " + (place ? place.name : "place") + "! 🌟");
+  if (place && exState.place === placeId) $("findGameBtn").hidden = false;
+}
+function quitFindGame() {
+  findState.active = false;
+  hideWorldBanner();
+  if (window.HH && HH.World) HH.World.setTarget(null);
+  if (exState.place && HH.FIND_TASKS && HH.FIND_TASKS[exState.place]) $("findGameBtn").hidden = false;
+  setBelu("Let's keep exploring! 🌍");
+}
+
 function wireExplore() {
   $("mapBtn").addEventListener("click", goHub);
-  $("quizBtn").addEventListener("click", startRoomQuiz);
-  $("roomPrevBtn").addEventListener("click", () => stepRoom(-1));
-  $("roomNextBtn").addEventListener("click", () => stepRoom(1));
+  $("findGameBtn").addEventListener("click", startFindGame);
   window.addEventListener("resize", () => { if (window.HH && HH.World && worldReady) HH.World.resize(); });
-  $("quizModal").addEventListener("click", e => { if (e.target.id === "quizModal") $("quizModal").hidden = true; });
   initWorldOnce();
 }
 
@@ -539,9 +642,15 @@ function startFeelingsLesson() {
   $("handBody").innerHTML = "";
   setBelu(HH.FEELINGS.intro, { onNext: renderFeelingsSigns });
 }
+function beluCardRow() {
+  const row = document.createElement("div"); row.className = "belu-card-row";
+  row.innerHTML = '<span class="belu-card-avatar">🐘</span>';
+  return row;
+}
 function renderFeelingsSigns() {
   const body = $("handBody"); body.innerHTML = "";
   const card = document.createElement("div"); card.className = "lesson-card";
+  card.appendChild(beluCardRow());
   const grid = document.createElement("div"); grid.className = "signs-grid";
   HH.FEELINGS.signs.forEach(s => {
     const chip = document.createElement("div"); chip.className = "sign-chip";
@@ -560,6 +669,7 @@ function renderFeelingsSigns() {
 function renderFeelingsQuiz() {
   const body = $("handBody"); body.innerHTML = "";
   const card = stepCardShell("Quick Check");
+  card.appendChild(beluCardRow());
   speakRow(card, HH.FEELINGS.quiz.q);
   const answers = document.createElement("div"); answers.className = "quiz-answers";
   const feedback = document.createElement("div"); feedback.className = "quiz-feedback";
@@ -637,6 +747,10 @@ function wireHand() { /* interactions wired per-render */ }
 
 /* ---------------------------------------------------------------
    6. PRACTICE BEING BRAVE
+   Enacted IN-WORLD: the child walks to the actor, feels/reacts via
+   banner choices, then walks to & taps the right helper to "tell".
+   Falls back to the old step-card flow only if a scenario's place
+   or room is not walkable (shouldn't happen for the tier-A set).
    --------------------------------------------------------------- */
 let practiceState = null;
 
@@ -665,6 +779,10 @@ function visibleScenarios() {
   const showTierB = !!HH.ENABLE_TIER_B;
   return HH.SCENARIOS.filter(sc => showTierB || sc.tier !== "B");
 }
+function scenarioIsWalkable(sc) {
+  const place = HH.PLACES[sc.place];
+  return !!(place && place.rooms && place.rooms.some(r => r.id === sc.room) && window.HH && HH.World && worldReady);
+}
 function renderScenarioPicker(body) {
   setBelu("Pick a story to practice! 💪");
   const grid = document.createElement("div"); grid.className = "scenario-grid";
@@ -678,13 +796,18 @@ function renderScenarioPicker(body) {
     const em = document.createElement("div"); em.className = "em"; em.textContent = sc.emoji;
     const tt = document.createElement("div"); tt.className = "tt"; tt.textContent = sc.title;
     card.appendChild(em); card.appendChild(tt);
-    card.addEventListener("click", () => {
-      practiceState = { scenario: sc, step: "see", usedTell: [], tellPhase: "ask1" };
-      renderPractice();
-    });
+    card.addEventListener("click", () => attemptStartScenario(sc));
     grid.appendChild(card);
   });
   body.appendChild(grid);
+}
+function attemptStartScenario(sc) {
+  if (scenarioIsWalkable(sc)) {
+    startScenarioInWorld(sc);
+  } else {
+    practiceState = { scenario: sc, step: "see", usedTell: [], tellPhase: "ask1" };
+    renderPractice();
+  }
 }
 function renderSeeStep(body) {
   const sc = practiceState.scenario;
@@ -830,6 +953,158 @@ function renderResolveStep(body) {
 }
 function wirePractice() { /* interactions wired per-render */ }
 
+/* -------- in-world flow: enact the scenario in the 3D world -------- */
+function startScenarioInWorld(sc) {
+  if (findState.active) quitFindGame();
+  if (window.HH && HH.World) HH.World.removeActor(sc.id); // defensive: idempotent if not present
+  scenarioState = { scenario: sc, step: "see", usedTell: [], tellPhase: "ask1" };
+  showScreen("exploreScreen");
+  $("mapBtn").hidden = true;
+  $("findGameBtn").hidden = true;
+  $("roomHeader").hidden = true;
+  if (window.HH && HH.World) {
+    HH.World.enterBuilding(sc.place);
+    HH.World.teleport(sc.room);
+    HH.World.spawnActor(sc.id, sc.room);
+  }
+  runScenarioSee();
+}
+function runScenarioSee() {
+  const sc = scenarioState.scenario;
+  const actor = HH.SCENARIO_ACTORS[sc.id];
+  if (actor && window.HH && HH.World) HH.World.say(sc.id, actor.bubble, 4500);
+  showWorldBanner(sc.setup, { onClose: quitScenario });
+  bannerActionButton("Next ➡️", "btn-primary", () => { scenarioState.step = "feel"; runScenarioFeel(); });
+  setBelu(sc.setup);
+}
+function runScenarioFeel() {
+  const sc = scenarioState.scenario;
+  showWorldBanner(sc.feelQ, { onClose: quitScenario });
+  bannerChoices(sc.feelA, () => {
+    setTimeout(() => { scenarioState.step = "react"; runScenarioReact(); }, 800);
+  });
+  setBelu(sc.feelQ);
+}
+function runScenarioReact() {
+  const sc = scenarioState.scenario;
+  showWorldBanner(sc.reactQ, { onClose: quitScenario });
+  bannerChoices(sc.reactA, () => {
+    // the correct reaction always moves the child away from the situation
+    if (window.HH && HH.World) HH.World.removeActor(sc.id);
+    setTimeout(() => { scenarioState.step = "reactWhy"; runScenarioReactWhy(); }, 800);
+  });
+  setBelu(sc.reactQ);
+}
+function runScenarioReactWhy() {
+  const sc = scenarioState.scenario;
+  showWorldBanner(sc.reactWhy, { onClose: quitScenario });
+  bannerActionButton("Next ➡️", "btn-primary", () => { startTellStep(); });
+  setBelu(sc.reactWhy);
+}
+function startTellStep() {
+  const sc = scenarioState.scenario;
+  scenarioState.step = "tell";
+  scenarioState.tellPhase = "ask1";
+  showWorldBanner(sc.tellPrompt, { onClose: quitScenario });
+  setBelu(sc.tellPrompt);
+  if (window.HH && HH.World) HH.World.setTarget({ helperId: sc.tellTo[0] });
+}
+function helperPlaceOf(helperId) {
+  for (const placeId in HH.HELPER_SPOTS) {
+    const rooms = HH.HELPER_SPOTS[placeId];
+    for (const roomId in rooms) if (rooms[roomId] === helperId) return placeId;
+  }
+  return null;
+}
+function handleScenarioHelperTap(helperId) {
+  if (!scenarioState || scenarioState.step !== "tell") return;
+  const sc = scenarioState.scenario;
+  const phase = scenarioState.tellPhase;
+  const expected = phase === "ask2" ? sc.tellTo[1] : sc.tellTo[0];
+  if (helperId !== expected) {
+    SND.tryTone();
+    setBannerText("Try another helper! 💙");
+    return;
+  }
+  scenarioState.usedTell.push(helperId);
+  SND.chime();
+  confettiBig();
+  if (sc.keepTelling && scenarioState.usedTell.length === 1) {
+    if (window.HH && HH.World) {
+      HH.World.setTarget(null);
+      HH.World.say(helperId, sc.busyLine, 3000);
+    }
+    setBannerText(sc.busyLine);
+    setBelu(sc.busyLine);
+    setTimeout(() => {
+      scenarioState.tellPhase = "keep";
+      setBannerText(sc.keepLine);
+      setBelu(sc.keepLine);
+      setTimeout(() => {
+        scenarioState.tellPhase = "ask2";
+        const nextHelper = sc.tellTo[1];
+        const nextPlace = helperPlaceOf(nextHelper);
+        if (nextPlace && nextPlace !== sc.place && window.HH && HH.World) {
+          // the next helper lives in a different building — go there!
+          const line = sc.goLine || "Let's go find another helper!";
+          setBannerText(line);
+          setBelu(line);
+          speak(line);
+          setTimeout(() => {
+            HH.World.enterBuilding(nextPlace);
+            setBannerText(sc.tellPrompt);
+            HH.World.setTarget({ helperId: nextHelper });
+          }, 2600);
+        } else {
+          setBannerText("Who else can you tell?");
+          setBelu("Who else can you tell?");
+          if (window.HH && HH.World) HH.World.setTarget({ helperId: nextHelper });
+        }
+      }, 1800);
+    }, 3000);
+  } else {
+    scenarioState.step = "resolve";
+    runScenarioResolve();
+  }
+}
+function runScenarioResolve() {
+  const sc = scenarioState.scenario;
+  const helperId = scenarioState.usedTell[scenarioState.usedTell.length - 1];
+  if (window.HH && HH.World) {
+    HH.World.setTarget(null);
+    HH.World.say(helperId, "You were brave to tell me. 💙", 4000);
+  }
+  if (!save.done.includes(sc.id)) save.done.push(sc.id);
+  saveSave();
+  awardSticker(1);
+  confettiBig(); SND.chime();
+  const aff = HH.AFFIRMATIONS[Math.floor(Math.random() * HH.AFFIRMATIONS.length)];
+  showWorldBanner(sc.resolve + "  " + aff, {});
+  bannerActionButton("Play again 🔁", "btn-secondary", () => { startScenarioInWorld(sc); });
+  bannerActionButton("More stories ➡️", "btn-primary", () => {
+    endScenario();
+    showScreen("practiceScreen");
+    practiceState = { scenario: null, step: "pick", usedTell: [], tellPhase: "ask1" };
+    renderPractice();
+  });
+  setBelu(sc.resolve);
+}
+function endScenario() {
+  if (scenarioState) {
+    const sc = scenarioState.scenario;
+    if (window.HH && HH.World) { HH.World.removeActor(sc.id); HH.World.setTarget(null); }
+  }
+  scenarioState = null;
+  hideWorldBanner();
+}
+function quitScenario() {
+  endScenario();
+  showScreen("practiceScreen");
+  practiceState = { scenario: null, step: "pick", usedTell: [], tellPhase: "ask1" };
+  renderPractice();
+  setBelu("Let's pick another story! 💪");
+}
+
 /* ---------------------------------------------------------------
    7. GROWN-UPS CORNER (adult-gated, sober styling)
    --------------------------------------------------------------- */
@@ -893,7 +1168,7 @@ function wireGlobalChrome() {
     const mute = e.target.closest(".mute-btn");
     if (mute) { toggleMute(); return; }
     const back = e.target.closest(".btn-back[data-target='menu']");
-    if (back) { showScreen("menuScreen"); return; }
+    if (back) { exitOverlayModes(); showScreen("menuScreen"); return; }
   });
 }
 
@@ -928,9 +1203,13 @@ boot();
 
 /* test hooks (harmless in production; used by headless verification) */
 window.__HHTEST = {
-  handleBuilding, handleObject, handleHelper, stepRoom, showScreen,
+  handleBuilding, handleObject, handleHelper, handleActor, handleRoomEnter, showScreen,
+  startFindGame, quitFindGame,
+  attemptStartScenario, quitScenario, handleScenarioHelperTap,
   get exState() { return exState; },
   get worldReady() { return worldReady; },
+  get findState() { return findState; },
+  get scenarioState() { return scenarioState; },
 };
 
 })();

--- a/public/helpinghands/js/world.js
+++ b/public/helpinghands/js/world.js
@@ -1,7 +1,11 @@
 // Belu's Helping Hands — HH.World
-// Plain script, no imports. THREE is a global (r128 API). Depends on HH.PLACES / HH.HELPERS / HH.HELPER_SPOTS
-// from content.js. Builds a bright outdoor hub with 6 building slots and per-room interiors,
-// with tap-to-raycast handlers for buildings / objects / helpers.
+// Plain script, no imports. THREE is a global (r128 API). Depends on HH.PLACES / HH.HELPERS /
+// HH.HELPER_SPOTS / HH.SCENARIO_ACTORS from content.js.
+//
+// Builds a bright outdoor hub with 6 building slots (unchanged look) PLUS walkable, connected
+// building interiors: a central hallway with rooms attached left/right/top through real wall
+// gaps (doors), simple circle-vs-wall collision, a kid avatar + Belu the elephant who walk
+// around, a follow camera, floor target rings, and speech bubbles.
 (function () {
   'use strict';
   window.HH = window.HH || {};
@@ -166,25 +170,42 @@
     return t;
   }
 
-  function brickTexture(hex) {
-    return canvasTex(function (ctx, w, h) {
-      ctx.fillStyle = hex; ctx.fillRect(0, 0, w, h);
-    }, 4, 4);
-  }
-
   // =========================================================================
   // module state
   // =========================================================================
   var renderer = null, scene = null, camera = null, canvasEl = null;
   var raycaster = new THREE.Raycaster();
   var pointerV2 = new THREE.Vector2();
-  var handlers = { onBuilding: function () {}, onObject: function () {}, onHelper: function () {} };
-  var animItems = []; // { obj, fn(t) }
+  var handlers = { onBuilding: function () {}, onObject: function () {}, onHelper: function () {}, onActor: function () {}, onRoomEnter: function () {} };
+  var animItems = []; // { obj, fn(t,dt), ownerId? }
   var tappables = []; // meshes/sprites registered for raycast
-  var currentRoot = null; // Group currently in scene (hub or room)
+  var currentRoot = null; // Group currently in scene (hub or interior)
   var clock = new THREE.Clock();
-  var camSwayBase = null; // {pos, lookAt}
+  var camSwayBase = null; // {pos, look} — hub gentle sway
+  var camLookCurrent = null; // interior follow-cam smoothed look target
   var rafId = null;
+
+  var mode = 'hub'; // 'hub' | 'interior'
+  var currentPlaceId = null;
+  var currentLayout = null;
+  var currentRoomId = null;
+
+  var collisionRects = []; // [{xMin,xMax,zMin,zMax}] axis-aligned wall footprints
+  var wallTargetGroup = null; // group new wall meshes are added to while building
+
+  var avatar = null; // { group, pos, facing, walking, bobPhase }
+  var belu = null;   // { group, pos }
+  var helpersRegistry = {}; // helperId -> { group }
+  var actorsRegistry = {};  // actorId -> { group }
+  var objectsRegistry = {}; // "roomId:idx" -> sprite Object3D
+
+  var keysDown = {};
+  var joystickVec = { x: 0, z: 0 };
+  var joystickEl = null, joystickKnob = null;
+
+  var targetState = null; // { ring, arrow, baseArrowY }
+  var speechBubbles = []; // [{id, sprite, t0, pop, life, expireAt, tw, th}]
+  var speechByChar = {};
 
   function clearAnim() { animItems = []; }
   function clearTappables() { tappables = []; }
@@ -214,6 +235,12 @@
     tappables.push(obj3d);
   }
 
+  function hashStr(s) {
+    var h = 0;
+    for (var i = 0; i < s.length; i++) { h = ((h << 5) - h + s.charCodeAt(i)) | 0; }
+    return h;
+  }
+
   // =========================================================================
   // clouds (hub sky decoration)
   // =========================================================================
@@ -231,20 +258,17 @@
   }
 
   // =========================================================================
-  // HUB SCENE
+  // HUB SCENE (unchanged look)
   // =========================================================================
   function buildHub() {
     var root = new THREE.Group(); root.name = 'hub';
 
-    // sky background
     scene.background = skyTexture();
 
-    // sun
     var sun = mesh(new THREE.SphereGeometry(6, 20, 16), stdMat('#fff3a0', { emissive: true, emissiveHex: '#ffe066', emissiveIntensity: 0.9, roughness: 0.5 }));
     sun.position.set(-40, 46, -70);
     root.add(sun);
 
-    // clouds drifting
     var clouds = [];
     for (var i = 0; i < 6; i++) {
       var c = makeCloud();
@@ -260,12 +284,10 @@
       });
     }});
 
-    // ground
     var ground = mesh(new THREE.CircleGeometry(120, 48), stdMat('#ffffff', { map: grassTexture(26), roughness: 0.95 }));
     ground.rotation.x = -Math.PI / 2;
     root.add(ground);
 
-    // a simple stepping-stone path toward the buildings (individual round stones, spaced apart)
     var stoneMat = stdMat('#efe2c2', { roughness: 0.9 });
     for (var p = 0; p < 7; p++) {
       var pr = mesh(new THREE.CircleGeometry(1.5, 16), stoneMat);
@@ -274,7 +296,6 @@
       root.add(pr);
     }
 
-    // a few decorative trees/bushes scattered around
     function addTree(x, z, scale) {
       var g = new THREE.Group();
       var trunk = mesh(new THREE.CylinderGeometry(0.35, 0.45, 2.2, 8), stdMat('#a9784f', { roughness: 0.8 }));
@@ -294,10 +315,9 @@
       addTree(t[0], t[1], t[2]);
     });
 
-    // ---- 6 buildings placed in a gentle arc ----
     var order = ['house', 'school', 'library', 'clinic', 'firestation', 'police'];
     var radius = 30;
-    var arcSpan = Math.PI * 0.72; // total angular spread
+    var arcSpan = Math.PI * 0.72;
     var startAngle = Math.PI / 2 + arcSpan / 2;
     order.forEach(function (placeId, idx) {
       var place = HH.PLACES[placeId];
@@ -308,11 +328,10 @@
       var z = -Math.sin(angle) * radius - 6;
       var bldg = place.unlocked ? buildUnlockedBuilding(placeId, place) : buildLockedBuilding(placeId, place);
       bldg.position.set(x, 0, z);
-      bldg.lookAt(0, 0, 6); // face generally toward the camera/viewer
+      bldg.lookAt(0, 0, 6);
       root.add(bldg);
     });
 
-    // hemisphere + ambient + directional light
     root.add(new THREE.AmbientLight(0xfff6e0, 0.65));
     var hemi = new THREE.HemisphereLight(0xbfe3ff, 0x8fce6a, 0.55);
     root.add(hemi);
@@ -337,19 +356,16 @@
       var body = mesh(new THREE.BoxGeometry(W, H, D), stdMat(col.wall, { roughness: 0.8 }));
       body.position.y = H / 2;
       g.add(body);
-      // roof (cone-ish using pyramid via cylinder with 4 segments)
       var roof = mesh(new THREE.ConeGeometry(6.2, 3.2, 4), stdMat(col.roof, { roughness: 0.7 }));
       roof.position.y = H + 1.4;
       roof.rotation.y = Math.PI / 4;
       g.add(roof);
-      // door
       var door = mesh(new THREE.PlaneGeometry(1.6, 2.6), stdMat(col.door, { roughness: 0.7 }));
       door.position.set(0, 1.3, D / 2 + 0.01);
       g.add(door);
       var knob = mesh(new THREE.SphereGeometry(0.09, 8, 8), stdMat('#ffd43b', { metalness: 0.5, roughness: 0.3 }));
       knob.position.set(0.55, 1.3, D / 2 + 0.08);
       g.add(knob);
-      // windows
       [-2.6, 2.6].forEach(function (wx) {
         var winFrame = mesh(new THREE.BoxGeometry(1.5, 1.5, 0.15), stdMat('#ffffff', { roughness: 0.6 }));
         winFrame.position.set(wx, 3.1, D / 2 + 0.02);
@@ -358,7 +374,6 @@
         winGlass.position.set(wx, 3.1, D / 2 + 0.1);
         g.add(winGlass);
       });
-      // chimney
       var chim = mesh(new THREE.BoxGeometry(0.7, 1.6, 0.7), stdMat('#c96a4a', { roughness: 0.8 }));
       chim.position.set(2.2, H + 2.2, -1);
       g.add(chim);
@@ -373,15 +388,13 @@
       registerTappable(sign, { placeId: placeId, kind: 'building' });
 
     } else if (placeId === 'school') {
-      var W = 12, D = 8, H = 6.5;
-      var body = mesh(new THREE.BoxGeometry(W, H, D), stdMat('#f6cfe0', { roughness: 0.8 }));
-      body.position.y = H / 2;
-      g.add(body);
-      // flat roof band trim
-      var roofTrim = mesh(new THREE.BoxGeometry(W + 0.4, 0.6, D + 0.4), stdMat('#4dabf7', { roughness: 0.7 }));
-      roofTrim.position.y = H + 0.3;
+      var W2 = 12, D2 = 8, H2 = 6.5;
+      var body2 = mesh(new THREE.BoxGeometry(W2, H2, D2), stdMat('#f6cfe0', { roughness: 0.8 }));
+      body2.position.y = H2 / 2;
+      g.add(body2);
+      var roofTrim = mesh(new THREE.BoxGeometry(W2 + 0.4, 0.6, D2 + 0.4), stdMat('#4dabf7', { roughness: 0.7 }));
+      roofTrim.position.y = H2 + 0.3;
       g.add(roofTrim);
-      // "SCHOOL" banner band across the front
       var bandTex = canvasTex(function (ctx, w, h) {
         ctx.fillStyle = '#4dabf7'; ctx.fillRect(0, 0, w, h);
         ctx.fillStyle = '#ffffff';
@@ -389,42 +402,39 @@
         ctx.font = 'bold 90px "Comic Sans MS", sans-serif';
         ctx.fillText('SCHOOL', w / 2, h / 2 + 6);
       }, 1024, 200);
-      var band = mesh(new THREE.PlaneGeometry(W * 0.85, 1.4), stdMat('#ffffff', { map: bandTex }));
-      band.position.set(0, H - 0.9, D / 2 + 0.02);
+      var band = mesh(new THREE.PlaneGeometry(W2 * 0.85, 1.4), stdMat('#ffffff', { map: bandTex }));
+      band.position.set(0, H2 - 0.9, D2 / 2 + 0.02);
       g.add(band);
-      // entrance door (double)
       [-0.9, 0.9].forEach(function (dx) {
         var door = mesh(new THREE.PlaneGeometry(1.5, 2.8), stdMat('#e8574b', { roughness: 0.7 }));
-        door.position.set(dx, 1.4, D / 2 + 0.03);
+        door.position.set(dx, 1.4, D2 / 2 + 0.03);
         g.add(door);
         registerTappable(door, { placeId: placeId, kind: 'building' });
       });
-      // windows row
       for (var wi = -2; wi <= 2; wi++) {
         if (wi === 0) continue;
-        var winFrame = mesh(new THREE.BoxGeometry(1.3, 1.3, 0.15), stdMat('#ffffff', { roughness: 0.6 }));
-        winFrame.position.set(wi * 2.2, 4.2, D / 2 + 0.02);
-        g.add(winFrame);
-        var winGlass = mesh(new THREE.PlaneGeometry(1.05, 1.05), stdMat('#8fd6ff', { emissive: true, emissiveHex: '#bfe9ff', emissiveIntensity: 0.3, roughness: 0.3 }));
-        winGlass.position.set(wi * 2.2, 4.2, D / 2 + 0.1);
-        g.add(winGlass);
+        var winFrame2 = mesh(new THREE.BoxGeometry(1.3, 1.3, 0.15), stdMat('#ffffff', { roughness: 0.6 }));
+        winFrame2.position.set(wi * 2.2, 4.2, D2 / 2 + 0.02);
+        g.add(winFrame2);
+        var winGlass2 = mesh(new THREE.PlaneGeometry(1.05, 1.05), stdMat('#8fd6ff', { emissive: true, emissiveHex: '#bfe9ff', emissiveIntensity: 0.3, roughness: 0.3 }));
+        winGlass2.position.set(wi * 2.2, 4.2, D2 / 2 + 0.1);
+        g.add(winGlass2);
       }
-      // flag pole
       var pole = mesh(new THREE.CylinderGeometry(0.08, 0.08, 7, 8), stdMat('#d9d9d9', { metalness: 0.4, roughness: 0.4 }));
-      pole.position.set(W / 2 + 1.5, 3.5, D / 2 + 1);
+      pole.position.set(W2 / 2 + 1.5, 3.5, D2 / 2 + 1);
       g.add(pole);
       var flag = mesh(new THREE.PlaneGeometry(1.4, 0.9), stdMat('#ffd43b', { roughness: 0.6, side: THREE.DoubleSide }));
-      flag.position.set(W / 2 + 2.2, 6.5, D / 2 + 1);
+      flag.position.set(W2 / 2 + 2.2, 6.5, D2 / 2 + 1);
       g.add(flag);
       animItems.push({ fn: function (t) { flag.rotation.y = Math.sin(t * 1.6) * 0.25; } });
 
-      registerTappable(body, { placeId: placeId, kind: 'building' });
+      registerTappable(body2, { placeId: placeId, kind: 'building' });
       registerTappable(band, { placeId: placeId, kind: 'building' });
 
-      var sign = makeSignSprite(place.emoji, place.name, { bg: '#eef7ff', border: '#4dabf7' }, 3.6);
-      sign.position.set(0, H + 3.4, 0);
-      g.add(sign);
-      registerTappable(sign, { placeId: placeId, kind: 'building' });
+      var sign2 = makeSignSprite(place.emoji, place.name, { bg: '#eef7ff', border: '#4dabf7' }, 3.6);
+      sign2.position.set(0, H2 + 3.4, 0);
+      g.add(sign2);
+      registerTappable(sign2, { placeId: placeId, kind: 'building' });
     }
 
     return g;
@@ -443,19 +453,16 @@
     var door = mesh(new THREE.PlaneGeometry(1.3, 2.0), stdMat('#5f6673', { roughness: 0.8 }));
     door.position.set(0, 1.0, D / 2 + 0.01);
     g.add(door);
-    // small dark windows either side, for texture/interest
     [-1.9, 1.9].forEach(function (wx) {
       var win = mesh(new THREE.PlaneGeometry(0.9, 0.9), stdMat('#4a5866', { roughness: 0.6 }));
       win.position.set(wx, 2.4, D / 2 + 0.01);
       g.add(win);
     });
 
-    // big emoji sign of the place's own emoji
     var emojiSign = makeEmojiSprite(place.emoji, 2.2);
     emojiSign.position.set(0, H + 1.7, 0.3);
     g.add(emojiSign);
 
-    // padlock overlay, front and center, large and unmistakable
     var lock = padlockSprite();
     lock.scale.set(2.2, 2.2, 1);
     lock.position.set(0, H * 0.55, D / 2 + 0.7);
@@ -473,7 +480,7 @@
   }
 
   // =========================================================================
-  // ROOM SCENES
+  // ROOM PALETTES (also used for interior wall colors)
   // =========================================================================
   var ROOM_PALETTES = {
     bedroom:   { wall: '#4f95dc', wall2: '#3f82c9', floor: '#d8a15c' },
@@ -488,65 +495,9 @@
     nurseroom: { wall: '#3dc088', wall2: '#2fae77', floor: '#bcdec4' },
   };
 
-  function buildRoomShell(roomId) {
-    var pal = ROOM_PALETTES[roomId] || { wall: '#f7d9ba', wall2: '#f6cfe0', floor: '#e8c58a' };
-    var g = new THREE.Group();
-    var ROOM_W = 13, ROOM_H = 8.5, ROOM_D = 8;
-
-    if (roomId === 'playground') {
-      // outdoor: grass + sky background, no walls
-      scene.background = skyTexture();
-      var ground = mesh(new THREE.PlaneGeometry(40, 30), stdMat('#ffffff', { map: grassTexture(10), roughness: 0.95 }));
-      ground.rotation.x = -Math.PI / 2;
-      g.add(ground);
-      return { root: g, floorY: 0, backZ: -ROOM_D / 2, roomW: ROOM_W };
-    }
-
-    scene.background = new THREE.Color(pal.wall).lerp(new THREE.Color('#ffffff'), 0.25);
-
-    // floor
-    var floor = mesh(new THREE.PlaneGeometry(ROOM_W, ROOM_D), stdMat(pal.floor, { roughness: 0.85 }));
-    floor.rotation.x = -Math.PI / 2;
-    g.add(floor);
-
-    // back wall
-    var back = mesh(new THREE.BoxGeometry(ROOM_W, ROOM_H, 0.3), stdMat(pal.wall, { roughness: 0.85 }));
-    back.position.set(0, ROOM_H / 2, -ROOM_D / 2);
-    g.add(back);
-
-    // two side walls (partial, leaving front open toward camera) — use wall2 for a touch of variation
-    var sideL = mesh(new THREE.BoxGeometry(0.3, ROOM_H, ROOM_D), stdMat(pal.wall2, { roughness: 0.85 }));
-    sideL.position.set(-ROOM_W / 2, ROOM_H / 2, 0);
-    g.add(sideL);
-    var sideR = mesh(new THREE.BoxGeometry(0.3, ROOM_H, ROOM_D), stdMat(pal.wall2, { roughness: 0.85 }));
-    sideR.position.set(ROOM_W / 2, ROOM_H / 2, 0);
-    g.add(sideR);
-
-    // ceiling lid so the pale scene backdrop never peeks through above the walls
-    var ceil = mesh(new THREE.BoxGeometry(ROOM_W, 0.3, ROOM_D), stdMat(pal.wall2, { roughness: 0.9 }));
-    ceil.position.set(0, ROOM_H + 0.15, 0);
-    g.add(ceil);
-
-    // window on the back wall with sky view
-    var winFrame = mesh(new THREE.BoxGeometry(3.2, 2.4, 0.15), stdMat('#ffffff', { roughness: 0.6 }));
-    winFrame.position.set(ROOM_W / 2 - 2.8, ROOM_H - 2.4, -ROOM_D / 2 + 0.2);
-    g.add(winFrame);
-    var winGlass = mesh(new THREE.PlaneGeometry(2.8, 2.0), stdMat('#ffffff', { map: windowSkyTexture(), roughness: 0.4 }));
-    winGlass.position.set(ROOM_W / 2 - 2.8, ROOM_H - 2.4, -ROOM_D / 2 + 0.28);
-    g.add(winGlass);
-
-    // baseboard trim
-    var trim = mesh(new THREE.BoxGeometry(ROOM_W, 0.35, 0.32), stdMat('#ffffff', { roughness: 0.6 }));
-    trim.position.set(0, 0.17, -ROOM_D / 2 + 0.05);
-    g.add(trim);
-
-    return { root: g, floorY: 0, backZ: -ROOM_D / 2, roomW: ROOM_W, roomD: ROOM_D, roomH: ROOM_H };
-  }
-
-  // ---- furniture builders keyed by room id ----
+  // ---- furniture builders keyed by room id (unchanged: local coords, shell.roomW/roomD) ----
   var FURNITURE_BUILDERS = {
     bedroom: function (g, shell) {
-      // bed
       var bed = new THREE.Group();
       var frame = mesh(new THREE.BoxGeometry(3.2, 0.6, 2.2), stdMat('#c8996a', { roughness: 0.7 }));
       frame.position.y = 0.3;
@@ -562,7 +513,6 @@
       bed.add(blanket);
       bed.position.set(-4.2, 0, -shell.roomD / 2 + 1.6);
       g.add(bed);
-      // nightstand + lamp
       var stand = mesh(new THREE.BoxGeometry(1.0, 1.0, 0.9), stdMat('#e8a659', { roughness: 0.6 }));
       stand.position.set(-2.2, 0.5, -shell.roomD / 2 + 1.1);
       g.add(stand);
@@ -596,10 +546,10 @@
       g.add(mirror);
 
       var tub = mesh(new THREE.BoxGeometry(2.6, 0.9, 1.4), stdMat('#ffe066', { roughness: 0.4 }));
-      tub.position.set(5.0, 0.45, -shell.roomD / 2 + 1.2);
+      tub.position.set(4.6, 0.45, -shell.roomD / 2 + 1.2);
       g.add(tub);
       var tubBasin = mesh(new THREE.BoxGeometry(2.2, 0.4, 1.0), stdMat('#ffffff', { roughness: 0.4 }));
-      tubBasin.position.set(5.0, 0.75, -shell.roomD / 2 + 1.2);
+      tubBasin.position.set(4.6, 0.75, -shell.roomD / 2 + 1.2);
       g.add(tubBasin);
 
       return { toilet: new THREE.Vector3(-5.2, 1.2, -shell.roomD / 2 + 1.2), toothbrush: new THREE.Vector3(1.9, 1.3, -shell.roomD / 2 + 0.9), soap: new THREE.Vector3(1.1, 1.3, -shell.roomD / 2 + 0.9) };
@@ -629,14 +579,14 @@
       var handle = mesh(new THREE.BoxGeometry(0.08, 0.7, 0.08), stdMat('#7a8a99', { metalness: 0.5, roughness: 0.3 }));
       handle.position.set(0.55, 1.4, 0.58);
       fridge.add(handle);
-      fridge.position.set(4.8, 0, -shell.roomD / 2 + 1.1);
+      fridge.position.set(4.6, 0, -shell.roomD / 2 + 1.1);
       g.add(fridge);
 
       var counter = mesh(new THREE.BoxGeometry(2.6, 1.0, 0.8), stdMat('#ffd699', { roughness: 0.5 }));
       counter.position.set(0.3, 0.5, -shell.roomD / 2 + 0.9);
       g.add(counter);
 
-      return { stove: new THREE.Vector3(-4.6, 1.8, -shell.roomD / 2 + 1.0), fridge: new THREE.Vector3(4.8, 2.6, -shell.roomD / 2 + 1.1), bowl: new THREE.Vector3(0.3, 1.3, -shell.roomD / 2 + 0.9) };
+      return { stove: new THREE.Vector3(-4.6, 1.8, -shell.roomD / 2 + 1.0), fridge: new THREE.Vector3(4.6, 2.6, -shell.roomD / 2 + 1.1), bowl: new THREE.Vector3(0.3, 1.3, -shell.roomD / 2 + 0.9) };
     },
     dining: function (g, shell) {
       var table = mesh(new THREE.CylinderGeometry(1.6, 1.5, 0.15, 20), stdMat('#e8a659', { roughness: 0.5 }));
@@ -680,12 +630,12 @@
       g.add(sofa);
 
       var shelf = mesh(new THREE.BoxGeometry(1.6, 1.8, 0.4), stdMat('#c8996a', { roughness: 0.6 }));
-      shelf.position.set(5.0, 0.9, -shell.roomD / 2 + 0.5);
+      shelf.position.set(4.6, 0.9, -shell.roomD / 2 + 0.5);
       g.add(shelf);
       var bookCols = ['#ff6b6b', '#4dabf7', '#51cf66'];
       bookCols.forEach(function (c, i) {
         var bk = mesh(new THREE.BoxGeometry(0.5, 0.7, 0.3), stdMat(c, { roughness: 0.6 }));
-        bk.position.set(4.5 + i * 0.5, 1.6, -shell.roomD / 2 + 0.55);
+        bk.position.set(4.1 + i * 0.5, 1.6, -shell.roomD / 2 + 0.55);
         g.add(bk);
       });
 
@@ -694,7 +644,7 @@
       rug.position.set(0.5, 0.02, 1.0);
       g.add(rug);
 
-      return { sofa: new THREE.Vector3(-3.0, 1.9, -shell.roomD / 2 + 1.4), books: new THREE.Vector3(4.9, 2.2, -shell.roomD / 2 + 0.55), puzzle: new THREE.Vector3(0.5, 0.3, 1.0) };
+      return { sofa: new THREE.Vector3(-3.0, 1.9, -shell.roomD / 2 + 1.4), books: new THREE.Vector3(4.5, 2.2, -shell.roomD / 2 + 0.55), puzzle: new THREE.Vector3(0.5, 0.3, 1.0) };
     },
     classroom: function (g, shell) {
       var board = mesh(new THREE.BoxGeometry(4.5, 2.2, 0.12), stdMat('#2f7d4f', { roughness: 0.7 }));
@@ -751,11 +701,11 @@
       chute.position.set(1.2, 1.1, 0);
       chute.rotation.z = -0.55;
       slide.add(chute);
-      slide.position.set(-3.5, 0, -3);
+      slide.position.set(-2.0, 0, 4);
       g.add(slide);
 
       var ball = mesh(new THREE.SphereGeometry(0.5, 16, 12), stdMat('#ff6b6b', { roughness: 0.4 }));
-      ball.position.set(1.5, 0.5, -1.5);
+      ball.position.set(2.0, 0.5, 3.0);
       g.add(ball);
 
       var tree = new THREE.Group();
@@ -768,10 +718,10 @@
         leaf.position.y = 2.6 + i * 1.0;
         tree.add(leaf);
       }
-      tree.position.set(4.5, 0, -2.5);
+      tree.position.set(4.5, 0, 5.5);
       g.add(tree);
 
-      return { slide: new THREE.Vector3(-2.5, 3.4, -3), ball: new THREE.Vector3(1.5, 1.9, -1.5), tree: new THREE.Vector3(4.5, 4.6, -2.5) };
+      return { slide: new THREE.Vector3(-1.2, 3.4, 4), ball: new THREE.Vector3(2.0, 1.9, 3.0), tree: new THREE.Vector3(4.5, 4.6, 5.5) };
     },
     office: function (g, shell) {
       var desk = mesh(new THREE.BoxGeometry(2.4, 0.9, 1.1), stdMat('#e6ddff', { roughness: 0.6 }));
@@ -790,14 +740,11 @@
       chair.position.set(-2.0, 0, -shell.roomD / 2 + 2.0);
       g.add(chair);
 
-      var doorFrame = mesh(new THREE.BoxGeometry(1.6, 2.6, 0.15), stdMat('#c8996a', { roughness: 0.6 }));
-      doorFrame.position.set(3.4, 1.3, -shell.roomD / 2 + 0.2);
-      g.add(doorFrame);
-      var doorPanel = mesh(new THREE.PlaneGeometry(1.3, 2.3), stdMat('#e8a659', { roughness: 0.6 }));
-      doorPanel.position.set(3.4, 1.3, -shell.roomD / 2 + 0.3);
-      g.add(doorPanel);
+      var cabinet = mesh(new THREE.BoxGeometry(1.2, 1.6, 0.6), stdMat('#c8996a', { roughness: 0.6 }));
+      cabinet.position.set(4.4, 0.8, -shell.roomD / 2 + 0.6);
+      g.add(cabinet);
 
-      return { desk: new THREE.Vector3(-2.6, 1.5, -shell.roomD / 2 + 0.9), phone: new THREE.Vector3(-0.9, 1.0, -shell.roomD / 2 + 1.5), door: new THREE.Vector3(3.4, 1.7, -shell.roomD / 2 + 0.3) };
+      return { desk: new THREE.Vector3(-2.6, 1.5, -shell.roomD / 2 + 0.9), phone: new THREE.Vector3(-0.9, 1.0, -shell.roomD / 2 + 1.5), door: new THREE.Vector3(4.4, 1.9, -shell.roomD / 2 + 0.6) };
     },
     nurseroom: function (g, shell) {
       var cot = new THREE.Group();
@@ -824,7 +771,6 @@
     }
   };
 
-  // fallback slots evenly spaced if a room id has no dedicated furniture builder
   function fallbackSlots(count, shell) {
     var slots = [];
     for (var i = 0; i < count; i++) {
@@ -834,75 +780,72 @@
     return slots;
   }
 
-  // ---- floating tappable object sprite with gentle bob ----
-  function addObjectSprite(g, emoji, index, placeId, position) {
-    var spr = makeEmojiSprite(emoji, 1.9);
+  // ---- tappable object sprite anchored to furniture, tiny bob (spec: max ±0.03) ----
+  function addObjectSprite(g, emoji, index, placeId, position, roomId) {
+    var spr = makeEmojiSprite(emoji, 1.7);
     spr.position.copy(position);
     var baseY = position.y;
     var phase = Math.random() * Math.PI * 2;
     g.add(spr);
     animItems.push({ fn: function (t) {
-      spr.position.y = baseY + Math.sin(t * 1.6 + phase) * 0.14;
+      spr.position.y = baseY + Math.sin(t * 1.6 + phase) * 0.03;
     }});
-    registerTappable(spr, { objIndex: index, placeId: placeId, kind: 'object' });
+    registerTappable(spr, { objIndex: index, placeId: placeId, roomId: roomId, kind: 'object' });
     return spr;
   }
 
-  // ---- helper character: capsule/cylinder body + emoji-face sprite head ----
-  function addHelperCharacter(g, helperId, helper, position) {
+  // ---- generic character builder: body + arms + emoji head + name label ----
+  // used for HELPER_SPOTS characters and scenario actors alike.
+  function addCharacter(parentGroup, id, emoji, name, position, kind) {
     var charGroup = new THREE.Group();
     charGroup.position.copy(position);
 
     var bodyColors = ['#4dabf7', '#ff9fb0', '#ffd43b', '#69db7c', '#b197fc', '#ff8787'];
-    var colorHex = bodyColors[Math.abs(hashStr(helperId)) % bodyColors.length];
+    var colorHex = bodyColors[Math.abs(hashStr(id)) % bodyColors.length];
 
-    // body — capsule if available (r128 has THREE.CapsuleGeometry? not guaranteed pre-r142) fallback to cylinder + sphere cap
     var bodyH = 1.5;
     var body;
     if (THREE.CapsuleGeometry) {
-      body = mesh(new THREE.CapsuleGeometry(0.45, bodyH - 0.9, 6, 12), stdMat(colorHex, { roughness: 0.6 }));
-      body.position.y = bodyH / 2 + 0.1;
+      body = mesh(new THREE.CapsuleGeometry(0.42, bodyH - 0.84, 6, 12), stdMat(colorHex, { roughness: 0.6 }));
+      body.position.y = bodyH / 2 + 0.08;
+      charGroup.add(body);
     } else {
-      var cyl = mesh(new THREE.CylinderGeometry(0.45, 0.5, bodyH, 14), stdMat(colorHex, { roughness: 0.6 }));
+      var cyl = mesh(new THREE.CylinderGeometry(0.42, 0.46, bodyH, 14), stdMat(colorHex, { roughness: 0.6 }));
       cyl.position.y = bodyH / 2;
       charGroup.add(cyl);
-      var cap = mesh(new THREE.SphereGeometry(0.45, 14, 10), stdMat(colorHex, { roughness: 0.6 }));
+      var cap = mesh(new THREE.SphereGeometry(0.42, 14, 10), stdMat(colorHex, { roughness: 0.6 }));
       cap.position.y = bodyH;
       charGroup.add(cap);
       body = null;
     }
-    if (body) charGroup.add(body);
 
-    // arms — simple boxes, one will "wave"
     var armMat = stdMat(colorHex, { roughness: 0.6 });
-    var armL = mesh(new THREE.BoxGeometry(0.18, 0.75, 0.18), armMat);
-    armL.position.set(-0.55, bodyH * 0.62, 0);
-    armL.geometry.translate(0, -0.35, 0); // pivot at shoulder
+    var armL = mesh(new THREE.BoxGeometry(0.16, 0.7, 0.16), armMat);
+    armL.position.set(-0.52, bodyH * 0.62, 0);
+    armL.geometry.translate(0, -0.33, 0);
     charGroup.add(armL);
-    var armR = mesh(new THREE.BoxGeometry(0.18, 0.75, 0.18), armMat);
-    armR.position.set(0.55, bodyH * 0.62, 0);
-    armR.geometry.translate(0, -0.35, 0);
+    var armR = mesh(new THREE.BoxGeometry(0.16, 0.7, 0.16), armMat);
+    armR.position.set(0.52, bodyH * 0.62, 0);
+    armR.geometry.translate(0, -0.33, 0);
     charGroup.add(armR);
 
-    // head — emoji face sprite
-    var head = makeEmojiSprite(helper.emoji, 1.3);
-    head.position.set(0, bodyH + 0.55, 0);
+    var head = makeEmojiSprite(emoji, 1.25);
+    head.position.set(0, bodyH + 0.5, 0);
     charGroup.add(head);
 
-    // name label above head
-    var label = makeSignSprite(null, helper.name, { bg: '#ffffff', border: '#4a3222' }, 1.7);
-    label.position.set(0, bodyH + 1.5, 0);
+    var label = makeSignSprite(null, name, { bg: '#ffffff', border: '#4a3222' }, 1.6);
+    label.position.set(0, bodyH + 1.4, 0);
     charGroup.add(label);
 
-    g.add(charGroup);
+    parentGroup.add(charGroup);
+    charGroup.userData.bubbleHeight = bodyH + 2.3;
 
     var basePos = position.clone();
     var phase = Math.random() * Math.PI * 2;
     var waveClock = 0, waving = false, waveDuration = 1.1, nextWaveAt = 2 + Math.random() * 3;
-    animItems.push({ fn: function (t, dt) {
-      charGroup.position.y = basePos.y + Math.sin(t * 1.3 + phase) * 0.08;
-      head.position.y = bodyH + 0.55 + Math.sin(t * 1.3 + phase) * 0.02;
-      // occasional wave: rotate right arm
+    animItems.push({ ownerId: id, fn: function (t, dt) {
+      charGroup.position.y = basePos.y + Math.sin(t * 1.3 + phase) * 0.06;
+      head.position.y = bodyH + 0.5 + Math.sin(t * 1.3 + phase) * 0.02;
       if (!waving && t > nextWaveAt) { waving = true; waveClock = 0; }
       if (waving) {
         waveClock += dt;
@@ -912,103 +855,596 @@
       }
     }});
 
-    [body, head, label].forEach(function (m) {
-      if (m) registerTappable(m, { helperId: helperId, kind: 'helper' });
+    charGroup.children.forEach(function (child) {
+      if (child.isMesh || child.isSprite) {
+        registerTappable(child, kind === 'actor' ? { actorId: id, kind: 'actor' } : { helperId: id, kind: 'helper' });
+      }
     });
-    // also make the group's cylinder/cap children tappable if no capsule
-    if (!body) {
-      charGroup.children.forEach(function (child) {
-        if (child.isMesh) registerTappable(child, { helperId: helperId, kind: 'helper' });
-      });
-    }
+
+    if (kind === 'actor') actorsRegistry[id] = { group: charGroup, roomId: null };
+    else helpersRegistry[id] = { group: charGroup };
 
     return charGroup;
   }
 
-  function hashStr(s) {
-    var h = 0;
-    for (var i = 0; i < s.length; i++) { h = ((h << 5) - h + s.charCodeAt(i)) | 0; }
-    return h;
+  // =========================================================================
+  // WALKABLE INTERIOR — data-driven floor plan (small layout table)
+  // =========================================================================
+  // Each building lists its rooms with a side: 'L' (left of hallway),
+  // 'R' (right of hallway), or 'T' (attached beyond the far/top end of the
+  // hallway). Order matters only within a side (fills bands nearest the
+  // entrance first). Room ids MUST match HH.PLACES[placeId].rooms[].id.
+  var BUILDING_SIDES = {
+    house: [
+      { id: 'bedroom', side: 'L' },
+      { id: 'kitchen', side: 'R' },
+      { id: 'bathroom', side: 'L' },
+      { id: 'dining', side: 'R' },
+      { id: 'living', side: 'T' }
+    ],
+    school: [
+      { id: 'classroom', side: 'L' },
+      { id: 'office', side: 'R' },
+      { id: 'cafeteria', side: 'L' },
+      { id: 'nurseroom', side: 'R' },
+      { id: 'playground', side: 'T', yard: true }
+    ]
+  };
+
+  var LAY_ROOM_W = 13, LAY_ROOM_D = 8, LAY_HALL_W = 3.6, LAY_DOOR_GAP = 1.8;
+  var INTERIOR_WALL_H = 3.0; // kept low so the elevated follow-camera is never blocked
+  var WALL_THICK = 0.3;
+
+  function makeRoomEntry(s, cx, cz, side) {
+    var yard = !!s.yard;
+    var padX = yard ? 16 : 0, padZ = yard ? 26 : 0;
+    return {
+      id: s.id, cx: cx, cz: cz, w: LAY_ROOM_W, d: LAY_ROOM_D, side: side, yard: yard,
+      boundsXMin: cx - LAY_ROOM_W / 2 - padX, boundsXMax: cx + LAY_ROOM_W / 2 + padX,
+      boundsZMin: cz - LAY_ROOM_D / 2, boundsZMax: cz + LAY_ROOM_D / 2 + padZ
+    };
   }
 
-  function buildRoom(placeId, roomIndex) {
-    var place = HH.PLACES[placeId];
-    if (!place || !place.rooms || !place.rooms[roomIndex]) {
-      console.warn('[HH.World] unknown room', placeId, roomIndex);
-      return new THREE.Group();
-    }
-    var room = place.rooms[roomIndex];
-    var shell = buildRoomShell(room.id);
-    var g = shell.root;
+  function makeLayout(sides) {
+    var L = sides.filter(function (s) { return s.side === 'L'; });
+    var R = sides.filter(function (s) { return s.side === 'R'; });
+    var T = sides.filter(function (s) { return s.side === 'T'; });
+    var bandCount = Math.max(L.length, R.length);
+    var bandZ = [];
+    var z = LAY_ROOM_D / 2 + 1.5;
+    for (var i = 0; i < bandCount; i++) { bandZ.push(z); z += LAY_ROOM_D + 2; }
+    var hallLen = (bandZ.length ? bandZ[bandZ.length - 1] + LAY_ROOM_D / 2 : LAY_ROOM_D) + 1.5;
+    var rooms = [];
+    L.forEach(function (s, i) { rooms.push(makeRoomEntry(s, -(LAY_HALL_W / 2 + LAY_ROOM_W / 2), bandZ[i], 'L')); });
+    R.forEach(function (s, i) { rooms.push(makeRoomEntry(s, (LAY_HALL_W / 2 + LAY_ROOM_W / 2), bandZ[i], 'R')); });
+    var tW = T.length * LAY_ROOM_W + Math.max(0, T.length - 1) * 2;
+    T.forEach(function (s, i) {
+      var cx = -tW / 2 + LAY_ROOM_W / 2 + i * (LAY_ROOM_W + 2);
+      rooms.push(makeRoomEntry(s, cx, hallLen + LAY_ROOM_D / 2, 'T'));
+    });
+    return { rooms: rooms, hallLen: hallLen, hallW: LAY_HALL_W, doorGap: LAY_DOOR_GAP };
+  }
 
-    var slots = null;
-    if (FURNITURE_BUILDERS[room.id]) {
-      slots = FURNITURE_BUILDERS[room.id](g, shell);
+  function findLayoutRoom(roomId) {
+    if (!currentLayout) return null;
+    for (var i = 0; i < currentLayout.rooms.length; i++) {
+      if (currentLayout.rooms[i].id === roomId) return currentLayout.rooms[i];
     }
-    var slotKeys = slots ? Object.keys(slots) : [];
-    var fallback = fallbackSlots((room.objects || []).length, shell);
+    return null;
+  }
 
-    (room.objects || []).forEach(function (entry, idx) {
-      var emoji = entry[0];
-      var pos;
-      if (slots && slotKeys[idx]) {
-        pos = slots[slotKeys[idx]];
-      } else {
-        pos = fallback[idx];
+  function computeRoom(pos) {
+    if (!currentLayout) return 'hall';
+    for (var i = 0; i < currentLayout.rooms.length; i++) {
+      var r = currentLayout.rooms[i];
+      if (pos.x >= r.boundsXMin && pos.x <= r.boundsXMax && pos.z >= r.boundsZMin && pos.z <= r.boundsZMax) return r.id;
+    }
+    return 'hall';
+  }
+
+  // ---- wall + collision helpers ----
+  function addWorldWall(xMin, xMax, zMin, zMax, colorHex) {
+    var dx = xMax - xMin, dz = zMax - zMin;
+    if (dx <= 0.02 || dz <= 0.02) return;
+    var wall = mesh(new THREE.BoxGeometry(dx, INTERIOR_WALL_H, dz), stdMat(colorHex || '#e8d9c0', { roughness: 0.85 }));
+    wall.position.set((xMin + xMax) / 2, INTERIOR_WALL_H / 2, (zMin + zMax) / 2);
+    if (wallTargetGroup) wallTargetGroup.add(wall);
+    collisionRects.push({ xMin: xMin, xMax: xMax, zMin: zMin, zMax: zMax });
+  }
+  function addInvisibleWall(xMin, xMax, zMin, zMax) {
+    collisionRects.push({ xMin: xMin, xMax: xMax, zMin: zMin, zMax: zMax });
+  }
+  function splitRangeWithGaps(start, end, gaps) {
+    var segs = [];
+    var cur = start;
+    var sorted = gaps.slice().sort(function (a, b) { return a[0] - b[0]; });
+    sorted.forEach(function (g) {
+      var gs = Math.max(g[0], start), ge = Math.min(g[1], end);
+      if (gs > cur) segs.push([cur, gs]);
+      cur = Math.max(cur, ge);
+    });
+    if (cur < end) segs.push([cur, end]);
+    return segs;
+  }
+  function addWallLineX(zc, xStart, xEnd, gaps, colorHex) {
+    splitRangeWithGaps(xStart, xEnd, gaps).forEach(function (s) {
+      addWorldWall(s[0], s[1], zc - WALL_THICK / 2, zc + WALL_THICK / 2, colorHex);
+    });
+  }
+  function addWallLineZ(xc, zStart, zEnd, gaps, colorHex) {
+    splitRangeWithGaps(zStart, zEnd, gaps).forEach(function (s) {
+      addWorldWall(xc - WALL_THICK / 2, xc + WALL_THICK / 2, s[0], s[1], colorHex);
+    });
+  }
+  function resolveCollision(pos, radius) {
+    for (var iter = 0; iter < 2; iter++) {
+      for (var i = 0; i < collisionRects.length; i++) {
+        var w = collisionRects[i];
+        var cx = Math.max(w.xMin, Math.min(pos.x, w.xMax));
+        var cz = Math.max(w.zMin, Math.min(pos.z, w.zMax));
+        var dx = pos.x - cx, dz = pos.z - cz;
+        var distSq = dx * dx + dz * dz;
+        if (distSq < radius * radius) {
+          var dist = Math.sqrt(distSq);
+          if (dist < 1e-4) { pos.x += radius; continue; }
+          var push = (radius - dist) / dist;
+          pos.x += dx * push;
+          pos.z += dz * push;
+        }
       }
-      addObjectSprite(g, emoji, idx, placeId, pos);
+    }
+  }
+
+  function buildLayoutRoom(root, placeId, place, room) {
+    var pal = ROOM_PALETTES[room.id] || { wall: '#e6c9a0', wall2: '#dcb98c', floor: '#e8c58a' };
+    var xMin = room.cx - room.w / 2, xMax = room.cx + room.w / 2;
+    var zMin = room.cz - room.d / 2, zMax = room.cz + room.d / 2;
+    var g = new THREE.Group();
+    g.position.set(room.cx, 0, room.cz);
+    root.add(g);
+
+    if (room.yard) {
+      var grass = mesh(new THREE.PlaneGeometry(40, 34), stdMat('#ffffff', { map: grassTexture(9), roughness: 0.95 }));
+      grass.rotation.x = -Math.PI / 2;
+      grass.position.set(0, 0, room.d / 2 + 9);
+      g.add(grass);
+    } else {
+      var floor = mesh(new THREE.PlaneGeometry(room.w, room.d), stdMat(pal.floor, { roughness: 0.85 }));
+      floor.rotation.x = -Math.PI / 2;
+      g.add(floor);
+      // ceiling-height wall cap trim isn't drawn (open-top "dollhouse" rooms keep the
+      // elevated follow-camera unobstructed); windows/skylight glow come from the sky bg.
+    }
+
+    if (room.side === 'L') {
+      addWallLineZ(xMin, zMin, zMax, [], pal.wall);
+      addWallLineX(zMin, xMin, xMax, [], pal.wall);
+      addWallLineX(zMax, xMin, xMax, [], pal.wall);
+    } else if (room.side === 'R') {
+      addWallLineZ(xMax, zMin, zMax, [], pal.wall);
+      addWallLineX(zMin, xMin, xMax, [], pal.wall);
+      addWallLineX(zMax, xMin, xMax, [], pal.wall);
+    } else if (room.side === 'T') {
+      addWallLineZ(xMin, zMin, zMax, [], pal.wall);
+      addWallLineZ(xMax, zMin, zMax, [], pal.wall);
+      addWallLineX(zMax, xMin, xMax, [], pal.wall);
+      if (!room.yard) {
+        var gw = LAY_DOOR_GAP;
+        addWallLineX(zMin, xMin, xMax, [[room.cx - gw / 2, room.cx + gw / 2]], pal.wall);
+      }
+      // yard rooms are fully open on the hallway side — a real doorway to the outdoors
+    }
+    if (room.yard) {
+      addInvisibleWall(room.cx - 20, room.cx - 19.7, zMax - 0.5, zMax + 33);
+      addInvisibleWall(room.cx + 19.7, room.cx + 20, zMax - 0.5, zMax + 33);
+      addInvisibleWall(room.cx - 20, room.cx + 20, zMax + 32.5, zMax + 33);
+    }
+
+    var placeRoom = null;
+    (place.rooms || []).forEach(function (r) { if (r.id === room.id) placeRoom = r; });
+    var shellInfo = { roomW: room.w, roomD: room.d, roomH: INTERIOR_WALL_H + 3 };
+    var slots = null;
+    if (FURNITURE_BUILDERS[room.id]) slots = FURNITURE_BUILDERS[room.id](g, shellInfo);
+    var slotKeys = slots ? Object.keys(slots) : [];
+    var objs = (placeRoom && placeRoom.objects) || [];
+    var fallback = fallbackSlots(objs.length, shellInfo);
+    objs.forEach(function (entry, idx) {
+      var emoji = entry[0];
+      var pos = (slots && slotKeys[idx]) ? slots[slotKeys[idx]] : fallback[idx];
+      var spr = addObjectSprite(g, emoji, idx, placeId, pos, room.id);
+      objectsRegistry[room.id + ':' + idx] = spr;
     });
 
-    // helper character, if this room has one
     var helperSpots = HH.HELPER_SPOTS || {};
     var helperId = helperSpots[placeId] && helperSpots[placeId][room.id];
     if (helperId && HH.HELPERS && HH.HELPERS[helperId]) {
-      var helperPos = new THREE.Vector3(shell.roomW ? shell.roomW / 4.4 : 2.5, 0, (shell.roomD || 8) / 2 - 3.6);
-      addHelperCharacter(g, helperId, HH.HELPERS[helperId], helperPos);
+      var helperPos = new THREE.Vector3(room.w / 4.4, 0, room.d / 2 - 3.6);
+      addCharacter(g, helperId, HH.HELPERS[helperId].emoji, HH.HELPERS[helperId].name, helperPos, 'helper');
+    }
+  }
+
+  function buildInteriorRoot(placeId) {
+    var place = HH.PLACES[placeId];
+    var sides = BUILDING_SIDES[placeId] || [];
+    var layout = makeLayout(sides);
+    var root = new THREE.Group(); root.name = 'interior:' + placeId;
+    collisionRects = [];
+    wallTargetGroup = root;
+    scene.background = skyTexture();
+
+    // porch / entrance patch, just south of the hallway mouth
+    var porch = mesh(new THREE.PlaneGeometry(layout.hallW + 3, 3.6), stdMat('#ffffff', { map: grassTexture(3), roughness: 0.95 }));
+    porch.rotation.x = -Math.PI / 2;
+    porch.position.set(0, 0, -1.8);
+    root.add(porch);
+    addInvisibleWall(-layout.hallW / 2 - 2.4, layout.hallW / 2 + 2.4, -3.7, -3.5);
+
+    var hallFloor = mesh(new THREE.PlaneGeometry(layout.hallW, layout.hallLen), stdMat('#f6ead0', { roughness: 0.85 }));
+    hallFloor.rotation.x = -Math.PI / 2;
+    hallFloor.position.set(0, 0, layout.hallLen / 2);
+    root.add(hallFloor);
+
+    if (place) {
+      var entrySign = makeSignSprite(place.emoji, place.name, { bg: '#fff7e6', border: '#8a5a26' }, 3.0);
+      entrySign.position.set(0, 3.8, -3.0);
+      root.add(entrySign);
     }
 
-    // lighting for room (kept modest so mid-tone wall/floor colors read clearly, not blown to white)
-    g.add(new THREE.AmbientLight(0xfff6e0, 0.4));
-    var hemi = new THREE.HemisphereLight(0xbfe3ff, 0xffe8cc, 0.35);
-    g.add(hemi);
-    var dir = new THREE.DirectionalLight(0xfff2d9, 0.55);
-    dir.position.set(6, 10, 8);
-    g.add(dir);
+    var Lrooms = layout.rooms.filter(function (r) { return r.side === 'L'; });
+    var Rrooms = layout.rooms.filter(function (r) { return r.side === 'R'; });
+    var Trooms = layout.rooms.filter(function (r) { return r.side === 'T'; });
+    var hallWallColor = '#c98a52';
+    addWallLineZ(-layout.hallW / 2, 0, layout.hallLen, Lrooms.map(function (r) { return [r.cz - layout.doorGap / 2, r.cz + layout.doorGap / 2]; }), hallWallColor);
+    addWallLineZ(layout.hallW / 2, 0, layout.hallLen, Rrooms.map(function (r) { return [r.cz - layout.doorGap / 2, r.cz + layout.doorGap / 2]; }), hallWallColor);
+    if (!Trooms.length) {
+      addWallLineX(layout.hallLen, -layout.hallW / 2, layout.hallW / 2, [], hallWallColor);
+    }
 
-    return g;
+    layout.rooms.forEach(function (room) { buildLayoutRoom(root, placeId, place, room); });
+
+    root.add(new THREE.AmbientLight(0xfff6e0, 0.6));
+    var hemi = new THREE.HemisphereLight(0xbfe3ff, 0xffe8cc, 0.5);
+    root.add(hemi);
+    var dir = new THREE.DirectionalLight(0xfff2d9, 0.7);
+    dir.position.set(10, 18, 8);
+    root.add(dir);
+
+    wallTargetGroup = null;
+    return { root: root, layout: layout };
   }
 
   // =========================================================================
-  // camera framing helpers
+  // AVATAR + BELU
+  // =========================================================================
+  function buildAvatar() {
+    var g = new THREE.Group(); g.name = 'avatar';
+    var bodyH = 1.15;
+    var bodyMat = stdMat('#ff9152', { roughness: 0.6 });
+    if (THREE.CapsuleGeometry) {
+      var body = mesh(new THREE.CapsuleGeometry(0.36, bodyH - 0.72, 6, 12), bodyMat);
+      body.position.y = bodyH / 2 + 0.32;
+      g.add(body);
+    } else {
+      var cyl = mesh(new THREE.CylinderGeometry(0.36, 0.4, bodyH, 14), bodyMat);
+      cyl.position.y = bodyH / 2 + 0.32;
+      g.add(cyl);
+      var cap = mesh(new THREE.SphereGeometry(0.36, 14, 10), bodyMat);
+      cap.position.y = bodyH + 0.32;
+      g.add(cap);
+    }
+    var legMat = stdMat('#4a6fa5', { roughness: 0.7 });
+    [-0.15, 0.15].forEach(function (lx) {
+      var leg = mesh(new THREE.CylinderGeometry(0.11, 0.11, 0.5, 8), legMat);
+      leg.position.set(lx, 0.25, 0);
+      g.add(leg);
+    });
+    var face = makeEmojiSprite('🙂', 1.0);
+    face.position.set(0, bodyH + 0.75, 0);
+    g.add(face);
+    g.userData.bubbleHeight = bodyH + 1.5;
+    return { group: g, pos: new THREE.Vector3(), facing: 0, walking: false, bobPhase: 0 };
+  }
+
+  function buildBelu() {
+    var g = new THREE.Group(); g.name = 'belu';
+    var bodyMat = stdMat('#5f8fe0', { roughness: 0.55 });
+    var body = mesh(new THREE.SphereGeometry(0.5, 16, 14), bodyMat);
+    body.position.y = 0.55;
+    body.scale.set(1, 0.92, 1.1);
+    g.add(body);
+    var head = mesh(new THREE.SphereGeometry(0.36, 16, 14), bodyMat);
+    head.position.set(0, 0.95, 0.42);
+    g.add(head);
+    [-1, 1].forEach(function (side) {
+      var ear = mesh(new THREE.SphereGeometry(0.28, 12, 10), stdMat('#7fa8ee', { roughness: 0.6 }));
+      ear.scale.set(1, 1.3, 0.25);
+      ear.position.set(side * 0.5, 1.0, 0.3);
+      ear.rotation.y = side * 0.5;
+      g.add(ear);
+    });
+    var trunk = mesh(new THREE.CylinderGeometry(0.09, 0.13, 0.55, 8), bodyMat);
+    trunk.position.set(0, 0.65, 0.68);
+    trunk.rotation.x = 0.6;
+    g.add(trunk);
+    [-0.13, 0.13].forEach(function (ex) {
+      var eye = mesh(new THREE.SphereGeometry(0.05, 8, 8), stdMat('#28324a', { roughness: 0.3 }));
+      eye.position.set(ex, 1.02, 0.72);
+      g.add(eye);
+    });
+    var legMat = stdMat('#4f7fd4', { roughness: 0.6 });
+    [[-0.25, -0.2], [0.25, -0.2], [-0.25, 0.25], [0.25, 0.25]].forEach(function (p) {
+      var leg = mesh(new THREE.CylinderGeometry(0.13, 0.13, 0.35, 8), legMat);
+      leg.position.set(p[0], 0.18, p[1]);
+      g.add(leg);
+    });
+    g.userData.bubbleHeight = 1.7;
+    return { group: g, pos: new THREE.Vector3() };
+  }
+
+  var AVATAR_SPEED = 3.0, AVATAR_RADIUS = 0.4;
+  function updateAvatarMovement(dt) {
+    var mv = { x: 0, z: 0 };
+    if (keysDown['arrowup'] || keysDown['w']) mv.z += 1;
+    if (keysDown['arrowdown'] || keysDown['s']) mv.z -= 1;
+    if (keysDown['arrowleft'] || keysDown['a']) mv.x -= 1;
+    if (keysDown['arrowright'] || keysDown['d']) mv.x += 1;
+    if (Math.abs(joystickVec.x) > 0.08 || Math.abs(joystickVec.z) > 0.08) {
+      mv.x += joystickVec.x; mv.z += joystickVec.z;
+    }
+    var len = Math.hypot(mv.x, mv.z);
+    var moving = len > 0.001;
+    if (moving) {
+      mv.x /= len; mv.z /= len;
+      var pos = avatar.pos.clone();
+      pos.x += mv.x * AVATAR_SPEED * dt;
+      pos.z += mv.z * AVATAR_SPEED * dt;
+      resolveCollision(pos, AVATAR_RADIUS);
+      avatar.pos.copy(pos);
+      avatar.facing = Math.atan2(mv.x, mv.z);
+    }
+    avatar.walking = moving;
+    avatar.bobPhase += dt * (moving ? 7 : 0);
+    var bob = moving ? Math.abs(Math.sin(avatar.bobPhase)) * 0.08 : 0;
+    avatar.group.position.set(avatar.pos.x, bob, avatar.pos.z);
+    var cur = avatar.group.rotation.y;
+    var diff = Math.atan2(Math.sin(avatar.facing - cur), Math.cos(avatar.facing - cur));
+    avatar.group.rotation.y = cur + diff * Math.min(1, dt * 10);
+    avatar.group.rotation.x = moving ? 0.08 : 0;
+
+    var newRoom = computeRoom(avatar.pos);
+    if (newRoom !== currentRoomId) {
+      currentRoomId = newRoom;
+      handlers.onRoomEnter(newRoom);
+    }
+  }
+
+  function updateBelu(dt, t) {
+    var forward = new THREE.Vector3(Math.sin(avatar.facing), 0, Math.cos(avatar.facing));
+    var desired = new THREE.Vector3(avatar.pos.x, 0, avatar.pos.z).addScaledVector(forward, -1.2);
+    var f = 1 - Math.pow(0.0008, dt);
+    belu.pos.lerp(desired, f);
+    var bob = Math.sin(t * 2.2) * 0.05;
+    belu.group.position.set(belu.pos.x, bob, belu.pos.z);
+    var lookPt = new THREE.Vector3(avatar.pos.x, belu.group.position.y, avatar.pos.z);
+    if (lookPt.distanceTo(belu.group.position) > 0.05) belu.group.lookAt(lookPt);
+  }
+
+  var CAM_OFFSET_Y = 9, CAM_OFFSET_Z = -8; // elevated 3/4 follow — shallow enough that the
+  // low (3.0-unit) interior walls rarely cross the avatar->camera sightline.
+  function updateCameraFollow(dt) {
+    var offset = new THREE.Vector3(0, CAM_OFFSET_Y, CAM_OFFSET_Z);
+    var desiredPos = new THREE.Vector3(avatar.pos.x, 0, avatar.pos.z).add(offset);
+    var f = 1 - Math.pow(0.0006, dt);
+    camera.position.lerp(desiredPos, f);
+    var lookTarget = new THREE.Vector3(avatar.pos.x, 1.0, avatar.pos.z);
+    if (!camLookCurrent) camLookCurrent = lookTarget.clone();
+    camLookCurrent.lerp(lookTarget, f);
+    camera.lookAt(camLookCurrent);
+  }
+
+  function snapCameraToAvatar() {
+    camera.position.set(avatar.pos.x, CAM_OFFSET_Y, avatar.pos.z + CAM_OFFSET_Z);
+    camLookCurrent = new THREE.Vector3(avatar.pos.x, 1.0, avatar.pos.z);
+    camera.lookAt(camLookCurrent);
+  }
+
+  // =========================================================================
+  // camera framing helpers (hub)
   // =========================================================================
   function setCameraForHub() {
+    camera.fov = 45;
+    camera.updateProjectionMatrix();
     camera.position.set(0, 18, 42);
     camSwayBase = { pos: camera.position.clone(), look: new THREE.Vector3(0, 6, 0) };
     camera.lookAt(camSwayBase.look);
   }
-  function setCameraForRoom(roomId) {
-    if (roomId === 'playground') {
-      camera.position.set(0, 6, 14);
-      camSwayBase = { pos: camera.position.clone(), look: new THREE.Vector3(0, 2.5, -3) };
-    } else {
-      camera.position.set(0, 4.8, 9.2);
-      camSwayBase = { pos: camera.position.clone(), look: new THREE.Vector3(0, 3.0, -1.5) };
+
+  // =========================================================================
+  // target ring + arrow ("go here")
+  // =========================================================================
+  function clearTargetVisuals() {
+    if (targetState) {
+      if (targetState.glow.parent) targetState.glow.parent.remove(targetState.glow);
+      if (targetState.ring.parent) targetState.ring.parent.remove(targetState.ring);
+      if (targetState.arrow.parent) targetState.arrow.parent.remove(targetState.arrow);
+      targetState = null;
     }
-    camera.lookAt(camSwayBase.look);
   }
+  function setTargetAt(worldPos) {
+    clearTargetVisuals();
+    var glow = new THREE.Mesh(
+      new THREE.CircleGeometry(0.95, 28),
+      new THREE.MeshBasicMaterial({ color: 0xffd400, transparent: true, opacity: 0.35, side: THREE.DoubleSide, depthWrite: false })
+    );
+    glow.rotation.x = -Math.PI / 2;
+    glow.position.set(worldPos.x, 0.035, worldPos.z);
+    currentRoot.add(glow);
+    var ring = new THREE.Mesh(
+      new THREE.RingGeometry(0.55, 0.78, 32),
+      new THREE.MeshBasicMaterial({ color: 0xff9500, transparent: true, opacity: 0.95, side: THREE.DoubleSide, depthWrite: false })
+    );
+    ring.rotation.x = -Math.PI / 2;
+    ring.position.set(worldPos.x, 0.05, worldPos.z);
+    currentRoot.add(ring);
+    var arrow = makeEmojiSprite('👇', 1.4);
+    var baseArrowY = worldPos.y + 1.5;
+    arrow.position.set(worldPos.x, baseArrowY, worldPos.z);
+    currentRoot.add(arrow);
+    targetState = { glow: glow, ring: ring, arrow: arrow, baseArrowY: baseArrowY };
+  }
+
+  // =========================================================================
+  // speech bubbles
+  // =========================================================================
+  function resolveCharGroup(id) {
+    if (id === 'me') return avatar ? avatar.group : null;
+    if (id === 'belu') return belu ? belu.group : null;
+    if (helpersRegistry[id]) return helpersRegistry[id].group;
+    if (actorsRegistry[id]) return actorsRegistry[id].group;
+    return null;
+  }
+  function wrapWords(ctx, text, maxWidth) {
+    var words = String(text || '').split(/\s+/).filter(Boolean);
+    var lines = [], line = '';
+    words.forEach(function (w) {
+      var test = line ? line + ' ' + w : w;
+      if (ctx.measureText(test).width > maxWidth && line) {
+        lines.push(line); line = w;
+      } else line = test;
+    });
+    if (line) lines.push(line);
+    if (!lines.length) lines.push('');
+    return lines;
+  }
+  var speechTexCache = {};
+  function speechTexture(text) {
+    if (speechTexCache[text]) return speechTexCache[text];
+    var fontSize = 44, maxWidth = 520, padding = 34;
+    var probe = makeCanvas(8, 8).getContext('2d');
+    probe.font = 'bold ' + fontSize + 'px "Comic Sans MS","Trebuchet MS",sans-serif';
+    var lines = wrapWords(probe, text, maxWidth);
+    var lineH = fontSize * 1.22;
+    var w = maxWidth + padding * 2;
+    var bodyH = lines.length * lineH + padding * 2;
+    var h = bodyH + 34;
+    var t = canvasTex(function (ctx) {
+      ctx.font = 'bold ' + fontSize + 'px "Comic Sans MS","Trebuchet MS",sans-serif';
+      ctx.fillStyle = '#ffffff';
+      roundRect(ctx, 6, 6, w - 12, bodyH - 12, 30);
+      ctx.fill();
+      ctx.strokeStyle = '#4a3222'; ctx.lineWidth = 6;
+      roundRect(ctx, 6, 6, w - 12, bodyH - 12, 30);
+      ctx.stroke();
+      ctx.beginPath();
+      ctx.moveTo(w / 2 - 18, bodyH - 10);
+      ctx.lineTo(w / 2 + 18, bodyH - 10);
+      ctx.lineTo(w / 2, bodyH + 26);
+      ctx.closePath();
+      ctx.fillStyle = '#ffffff';
+      ctx.fill();
+      ctx.strokeStyle = '#4a3222'; ctx.lineWidth = 6; ctx.stroke();
+      ctx.fillStyle = '#2c2416';
+      ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+      lines.forEach(function (ln, i) {
+        ctx.fillText(ln, w / 2, padding + lineH * i + lineH / 2);
+      });
+    }, w, h);
+    speechTexCache[text] = t;
+    return t;
+  }
+  function removeSpeechFor(id) {
+    var rec = speechByChar[id];
+    if (rec) {
+      if (rec.sprite.parent) rec.sprite.parent.remove(rec.sprite);
+      var idx = speechBubbles.indexOf(rec);
+      if (idx >= 0) speechBubbles.splice(idx, 1);
+      delete speechByChar[id];
+    }
+  }
+  function easeOutBack(x) {
+    x = Math.max(0, Math.min(1, x));
+    var c1 = 1.4, c3 = c1 + 1;
+    return 1 + c3 * Math.pow(x - 1, 3) + c1 * Math.pow(x - 1, 2);
+  }
+  function sayOnChar(id, text, ms) {
+    var charGroup = resolveCharGroup(id);
+    if (!charGroup) return;
+    removeSpeechFor(id);
+    var tex = speechTexture(text);
+    var mat = new THREE.SpriteMaterial({ map: tex, transparent: true, depthWrite: false });
+    var spr = new THREE.Sprite(mat);
+    var aspect = tex.image.width / tex.image.height;
+    var th = 1.5, tw = th * aspect;
+    spr.scale.set(0.001, 0.001, 1);
+    var bh = charGroup.userData.bubbleHeight || 2.0;
+    spr.position.set(0, bh, 0);
+    charGroup.add(spr);
+    var t0 = elapsedTotal;
+    var rec = { id: id, sprite: spr, t0: t0, pop: 0.22, expireAt: t0 + (ms || 2600) / 1000, tw: tw, th: th };
+    speechByChar[id] = rec;
+    speechBubbles.push(rec);
+  }
+
+  // =========================================================================
+  // touch joystick (bottom-left, interiors only)
+  // =========================================================================
+  function ensureJoystick() {
+    if (joystickEl) return;
+    var container = canvasEl.parentElement || document.body;
+    if (container && getComputedStyle(container).position === 'static') container.style.position = 'relative';
+    joystickEl = document.createElement('div');
+    joystickEl.style.cssText = 'position:absolute; left:18px; bottom:18px; width:112px; height:112px; border-radius:50%; background:rgba(255,255,255,0.25); border:3px solid rgba(255,255,255,0.6); touch-action:none; z-index:40; display:none;';
+    var knob = document.createElement('div');
+    knob.style.cssText = 'position:absolute; left:50%; top:50%; width:52px; height:52px; margin:-26px; border-radius:50%; background:rgba(255,255,255,0.9); border:3px solid rgba(120,120,120,0.4);';
+    joystickEl.appendChild(knob);
+    if (container) container.appendChild(joystickEl);
+    joystickKnob = knob;
+
+    var active = false, cx0 = 0, cy0 = 0, radius = 46;
+    function setVec(dx, dy) {
+      var len = Math.hypot(dx, dy);
+      if (len > radius) { dx = dx / len * radius; dy = dy / len * radius; }
+      knob.style.transform = 'translate(' + dx + 'px,' + dy + 'px)';
+      joystickVec.x = dx / radius;
+      joystickVec.z = dy / radius;
+    }
+    function reset() { joystickVec.x = 0; joystickVec.z = 0; knob.style.transform = 'translate(0,0)'; }
+    joystickEl.addEventListener('pointerdown', function (ev) {
+      active = true;
+      try { joystickEl.setPointerCapture(ev.pointerId); } catch (e) {}
+      var r = joystickEl.getBoundingClientRect();
+      cx0 = r.left + r.width / 2; cy0 = r.top + r.height / 2;
+      setVec(ev.clientX - cx0, ev.clientY - cy0);
+    });
+    joystickEl.addEventListener('pointermove', function (ev) { if (active) setVec(ev.clientX - cx0, ev.clientY - cy0); });
+    function end() { active = false; reset(); }
+    joystickEl.addEventListener('pointerup', end);
+    joystickEl.addEventListener('pointercancel', end);
+    joystickEl.addEventListener('pointerleave', function () { if (active) end(); });
+  }
+  function showJoystick(show) {
+    if (!joystickEl) return;
+    joystickEl.style.display = show ? 'block' : 'none';
+    if (!show) { joystickVec.x = 0; joystickVec.z = 0; }
+  }
+
+  function onKeyDown(ev) { keysDown[ev.key.toLowerCase()] = true; }
+  function onKeyUp(ev) { keysDown[ev.key.toLowerCase()] = false; }
 
   // =========================================================================
   // render loop
   // =========================================================================
+  var elapsedTotal = 0; // NOTE: THREE.Clock.getElapsedTime() internally calls getDelta(), so
+  // calling both per frame would starve the real getDelta() reading — track elapsed ourselves.
   function tick() {
     rafId = requestAnimationFrame(tick);
-    var t = clock.getElapsedTime();
     var dt = Math.min(clock.getDelta(), 0.05);
+    elapsedTotal += dt;
+    var t = elapsedTotal;
     for (var i = 0; i < animItems.length; i++) animItems[i].fn(t, dt);
 
-    // gentle camera sway (<=2 degrees) around the fixed framing
-    if (camSwayBase) {
-      var swayAmt = (Math.PI / 180) * 1.4; // ~1.4 degrees
+    if (mode === 'hub' && camSwayBase) {
+      var swayAmt = (Math.PI / 180) * 1.4;
       var angle = Math.sin(t * 0.25) * swayAmt;
       var radius = camSwayBase.pos.distanceTo(camSwayBase.look);
       var dir3 = new THREE.Vector3().subVectors(camSwayBase.pos, camSwayBase.look).normalize();
@@ -1016,6 +1452,31 @@
       camera.position.copy(camSwayBase.look).add(rotated.multiplyScalar(radius));
       camera.position.y = camSwayBase.pos.y + Math.sin(t * 0.18) * 0.15;
       camera.lookAt(camSwayBase.look);
+    } else if (mode === 'interior' && avatar) {
+      updateAvatarMovement(dt);
+      updateBelu(dt, t);
+      updateCameraFollow(dt);
+    }
+
+    if (targetState) {
+      var pulse = 1 + 0.15 * Math.sin(t * 3.2);
+      targetState.ring.scale.set(pulse, pulse, 1);
+      targetState.ring.material.opacity = 0.75 + 0.2 * Math.sin(t * 3.2);
+      var glowPulse = 1 + 0.3 * Math.sin(t * 3.2 + 0.6);
+      targetState.glow.scale.set(glowPulse, glowPulse, 1);
+      targetState.arrow.position.y = targetState.baseArrowY + Math.abs(Math.sin(t * 2.4)) * 0.3;
+    }
+
+    for (var si = speechBubbles.length - 1; si >= 0; si--) {
+      var rec = speechBubbles[si];
+      var age = t - rec.t0;
+      var s = age < rec.pop ? easeOutBack(age / rec.pop) : 1;
+      rec.sprite.scale.set(rec.tw * s, rec.th * s, 1);
+      if (t > rec.expireAt) {
+        if (rec.sprite.parent) rec.sprite.parent.remove(rec.sprite);
+        speechBubbles.splice(si, 1);
+        delete speechByChar[rec.id];
+      }
     }
 
     renderer.render(scene, camera);
@@ -1039,9 +1500,11 @@
     if (data.kind === 'building' && data.placeId) {
       handlers.onBuilding(data.placeId);
     } else if (data.kind === 'object' && data.objIndex !== undefined) {
-      handlers.onObject(data.objIndex);
+      handlers.onObject(data.roomId, data.objIndex);
     } else if (data.kind === 'helper' && data.helperId) {
       handlers.onHelper(data.helperId);
+    } else if (data.kind === 'actor' && data.actorId) {
+      handlers.onActor(data.actorId);
     }
   }
 
@@ -1065,6 +1528,9 @@
         HH.World.resize();
 
         canvasEl.addEventListener('pointerdown', onPointerDown, { passive: true });
+        window.addEventListener('keydown', onKeyDown);
+        window.addEventListener('keyup', onKeyUp);
+        ensureJoystick();
 
         if (!rafId) tick();
 
@@ -1088,19 +1554,112 @@
     showHub: function () {
       clearAnim();
       clearTappables();
+      mode = 'hub';
+      currentPlaceId = null;
+      currentLayout = null;
+      currentRoomId = null;
+      collisionRects = [];
+      avatar = null; belu = null;
+      helpersRegistry = {}; actorsRegistry = {}; objectsRegistry = {};
+      targetState = null;
+      speechBubbles = []; speechByChar = {};
+      showJoystick(false);
       var root = buildHub();
       setRoot(root);
       setCameraForHub();
     },
 
-    showRoom: function (placeId, roomIndex) {
+    enterBuilding: function (placeId) {
+      if (!HH.PLACES[placeId]) return;
       clearAnim();
       clearTappables();
-      var place = HH.PLACES[placeId];
-      var room = place && place.rooms && place.rooms[roomIndex];
-      var g = buildRoom(placeId, roomIndex);
-      setRoot(g);
-      setCameraForRoom(room ? room.id : null);
+      helpersRegistry = {}; actorsRegistry = {}; objectsRegistry = {};
+      targetState = null;
+      speechBubbles = []; speechByChar = {};
+      camSwayBase = null;
+      camLookCurrent = null;
+
+      mode = 'interior';
+      currentPlaceId = placeId;
+      var built = buildInteriorRoot(placeId);
+      currentLayout = built.layout;
+      setRoot(built.root);
+
+      avatar = buildAvatar();
+      belu = buildBelu();
+      currentRoot.add(avatar.group);
+      currentRoot.add(belu.group);
+      avatar.pos.set(0, 0, 1.0);
+      belu.pos.set(0, 0, -0.2);
+      avatar.group.position.copy(avatar.pos);
+      belu.group.position.copy(belu.pos);
+
+      camera.fov = 56;
+      camera.updateProjectionMatrix();
+      snapCameraToAvatar();
+
+      currentRoomId = 'hall';
+      handlers.onRoomEnter('hall');
+      showJoystick(true);
+    },
+
+    teleport: function (roomId) {
+      if (!avatar) return;
+      var r = findLayoutRoom(roomId);
+      if (r) avatar.pos.set(r.cx, 0, Math.min(r.cz, r.boundsZMax - 1));
+      else avatar.pos.set(0, 0, 1.0);
+      avatar.group.position.set(avatar.pos.x, 0, avatar.pos.z);
+      if (belu) {
+        belu.pos.set(avatar.pos.x, 0, avatar.pos.z - 1.2);
+        belu.group.position.copy(belu.pos);
+      }
+      snapCameraToAvatar();
+      currentRoomId = computeRoom(avatar.pos);
+      handlers.onRoomEnter(currentRoomId);
+    },
+
+    getRoom: function () {
+      return currentRoomId || 'hall';
+    },
+
+    setTarget: function (t) {
+      if (!currentRoot) return;
+      if (!t) { clearTargetVisuals(); return; }
+      var worldPos = null;
+      if (t.helperId && helpersRegistry[t.helperId]) {
+        worldPos = new THREE.Vector3();
+        helpersRegistry[t.helperId].group.getWorldPosition(worldPos);
+      } else if (t.roomId !== undefined && t.objIndex !== undefined) {
+        var spr = objectsRegistry[t.roomId + ':' + t.objIndex];
+        if (spr) { worldPos = new THREE.Vector3(); spr.getWorldPosition(worldPos); }
+      }
+      if (!worldPos) { clearTargetVisuals(); return; }
+      setTargetAt(worldPos);
+    },
+
+    say: function (id, text, ms) {
+      sayOnChar(id, text, ms);
+    },
+
+    spawnActor: function (actorId, roomId) {
+      if (!currentRoot || !HH.SCENARIO_ACTORS || !HH.SCENARIO_ACTORS[actorId]) return;
+      var actorDef = HH.SCENARIO_ACTORS[actorId];
+      var r = findLayoutRoom(roomId);
+      var pos;
+      if (r) pos = new THREE.Vector3(r.cx + 1.6, 0, Math.min(r.cz + 1.0, r.boundsZMax - 1));
+      else pos = new THREE.Vector3(1.6, 0, 3.0);
+      var grp = addCharacter(currentRoot, actorId, actorDef.emoji, actorDef.name, pos, 'actor');
+      actorsRegistry[actorId] = { group: grp, roomId: roomId };
+    },
+
+    removeActor: function (actorId) {
+      var rec = actorsRegistry[actorId];
+      if (!rec) return;
+      removeSpeechFor(actorId);
+      if (rec.group.parent) rec.group.parent.remove(rec.group);
+      tappables = tappables.filter(function (o) { return !(o.userData && o.userData.actorId === actorId); });
+      animItems = animItems.filter(function (a) { return a.ownerId !== actorId; });
+      delete actorsRegistry[actorId];
     },
 
     setHandlers: function (h) {
@@ -1108,6 +1667,8 @@
       handlers.onBuilding = h.onBuilding || function () {};
       handlers.onObject = h.onObject || function () {};
       handlers.onHelper = h.onHelper || function () {};
+      handlers.onActor = h.onActor || function () {};
+      handlers.onRoomEnter = h.onRoomEnter || function () {};
     }
   };
 })();


### PR DESCRIPTION
## Summary
Reworks Belu's Helping Hands per AJ's feedback: walkable house/school floor plans (joystick + keyboard, collision, Belu follows), quiz cards replaced by find-and-do tasks answered by walking, scenarios enacted in-world with actor characters and walk-to-the-helper telling — including a cross-building "go home and tell Mom" keep-telling beat. Objects are anchored to furniture. Game remains password-gated and unlisted.

## Test plan
- [x] Real-keyboard walking test: hall → bedroom → kitchen via door gaps; collision holds at walls
- [x] Find-and-do: all 5 house tasks complete with stickers; wrong taps get gentle nudges
- [x] The Pencil Poker end-to-end incl. school→home transition and second tell (screenshots)
- [x] Zero console errors under SwiftShader; 60fps