### PR TITLE
Helping Hands: fix flash of password gate on load

### DIFF
--- a/public/helpinghands/index.html
+++ b/public/helpinghands/index.html
@@ -442,7 +442,7 @@
 <div id="bgShapes"><i></i><i></i><i></i></div>
 
 <!-- 1. PASSWORD GATE -->
-<div id="gateScreen">
+<div id="gateScreen" hidden>
   <div class="gate-card" id="gateCard">
     <div class="gate-lock">🔒</div>
     <h2>Belu's Helping Hands</h2>
@@ -454,7 +454,7 @@
 </div>
 
 <!-- 2. TITLE -->
-<div id="titleScreen" class="screen" hidden>
+<div id="titleScreen" class="screen">
   <img id="logoImg" src="logo.png" alt="Aaria's Blue Elephant" onerror="this.style.display='none'">
   <h1 class="rainbow-text">Belu's Helping Hands</h1>
   <div class="byline">Built for <b>Aaria and Her Friends</b> 💖 — learn your world &amp; how to get help!</div>

--- a/public/helpinghands/js/main.js
+++ b/public/helpinghands/js/main.js
@@ -1560,8 +1560,13 @@ function boot() {
   wireGlobalBelu();
   wireGlobalChrome();
 
-  if (HH.REQUIRE_GATE === false || sessionStorage.getItem("hh_gate") === "1") {
-    $("gateScreen").hidden = true;
+  // gate is hidden in the markup so the public build never flashes it;
+  // review builds (REQUIRE_GATE=true) reveal it here instead
+  if (HH.REQUIRE_GATE && sessionStorage.getItem("hh_gate") !== "1") {
+    SCREEN_IDS.forEach(s => { $(s).hidden = true; });
+    $("beluBubble").hidden = true;
+    $("gateScreen").hidden = false;
+  } else {
     showScreen("titleScreen");
   }
 }


### PR DESCRIPTION
Gate hidden by default in markup; title screen is the no-JS default. Review builds reveal the gate from boot() when REQUIRE_GATE is set. Verified with network throttling that the gate never flashes.