### PR TITLE
Nilu's World: Sharing Shore zone + engagement/retention data layer

### DIFF
--- a/components/game/BelusWorld/belu/achievements.ts
+++ b/components/game/BelusWorld/belu/achievements.ts
@@ -1,0 +1,139 @@
+// ---------------------------------------------------------------------------
+// One-time achievements — gentle "look what you did!" moments, decoupled from
+// the star/level ladder. All additive: an achievement is earned once, kept
+// forever, and there is nothing to miss or lose. Checks read the existing
+// progress + memory state, so earning them requires no new bookkeeping in the
+// play layers.
+// ---------------------------------------------------------------------------
+
+import {
+  type GameProgress,
+  ZONES,
+  MAX_LEVEL,
+  completedLevels,
+  totalCompletedLevels,
+  isIslandComplete,
+  getGrowth,
+  plantStage,
+  PLANT_MAX_STAGE,
+} from './progress';
+import type { BeluMemory } from './memory';
+
+export interface Achievement {
+  id: string;
+  name: string;
+  icon: string;
+  /** kid-facing, literal, always positive */
+  blurb: string;
+  check: (p: GameProgress, m: BeluMemory) => boolean;
+}
+
+export const ACHIEVEMENTS: Achievement[] = [
+  {
+    id: 'first_level',
+    name: 'First Adventure',
+    icon: '🌟',
+    blurb: 'You finished your very first level!',
+    check: (p) => totalCompletedLevels(p) >= 1,
+  },
+  {
+    id: 'first_friend',
+    name: 'Friend Helper',
+    icon: '💛',
+    blurb: 'You helped an animal friend feel better!',
+    check: (p) => p.healedFriends.length >= 1,
+  },
+  {
+    id: 'five_levels',
+    name: 'Busy Explorer',
+    icon: '🧭',
+    blurb: 'Five levels finished — you are on a roll!',
+    check: (p) => totalCompletedLevels(p) >= 5,
+  },
+  {
+    id: 'island_bloom',
+    name: 'Island Gardener',
+    icon: '🌷',
+    blurb: 'You made a whole island bloom!',
+    check: (p) => ZONES.some((z) => isIslandComplete(p, z)),
+  },
+  {
+    id: 'all_islands',
+    name: 'World Bloomer',
+    icon: '🌈',
+    blurb: 'Every single island is fully bloomed. Wow!',
+    check: (p) => ZONES.every((z) => isIslandComplete(p, z)),
+  },
+  {
+    id: 'every_island_started',
+    name: 'Bridge Walker',
+    icon: '🌉',
+    blurb: 'You played on every island in the world!',
+    check: (p) => ZONES.every((z) => completedLevels(p, z) >= 1),
+  },
+  {
+    id: 'sparkle_10',
+    name: 'Sparkle Keeper',
+    icon: '✨',
+    blurb: 'Ten sparkles glowing in the jar!',
+    check: (p) => p.jarSparkles >= 10,
+  },
+  {
+    id: 'sparkle_50',
+    name: 'Sparkle Star',
+    icon: '🌠',
+    blurb: 'FIFTY sparkles! The jar is shining bright.',
+    check: (p) => p.jarSparkles >= 50,
+  },
+  {
+    id: 'garden_flower',
+    name: 'Flower Grower',
+    icon: '🌸',
+    blurb: 'A seed you planted opened into a flower!',
+    check: (p) => p.garden.some((pl) => plantStage(pl.plantedDate) >= PLANT_MAX_STAGE),
+  },
+  {
+    id: 'wardrobe_5',
+    name: 'Snappy Dresser',
+    icon: '🎩',
+    blurb: 'Five wardrobe treasures for Nilu!',
+    check: (p) => p.unlocked.length >= 5,
+  },
+  {
+    id: 'visits_3',
+    name: 'Coming Back',
+    icon: '🗓️',
+    blurb: 'You have visited on three different days!',
+    check: (_p, m) => m.visitDays >= 3,
+  },
+  {
+    id: 'visits_7',
+    name: 'True Friend',
+    icon: '💙',
+    blurb: 'Seven visit days — Nilu is so happy to know you!',
+    check: (_p, m) => m.visitDays >= 7,
+  },
+  {
+    id: 'grown_up',
+    name: 'All Grown Up',
+    icon: '🐘',
+    blurb: 'You helped Nilu grow all the way up!',
+    check: (p) => getGrowth(p).stage >= 3,
+  },
+  {
+    id: 'star_quest',
+    name: 'Star Quester',
+    icon: '⭐',
+    blurb: 'You finished a golden Star Quest!',
+    check: (p) => p.starQuests.doneZones.length >= 1,
+  },
+];
+
+export function achievementById(id: string): Achievement | undefined {
+  return ACHIEVEMENTS.find((a) => a.id === id);
+}
+
+/** Achievements whose condition just became true but aren't earned yet. */
+export function newlyEarned(p: GameProgress, m: BeluMemory): Achievement[] {
+  return ACHIEVEMENTS.filter((a) => !p.achievementsEarned.includes(a.id) && a.check(p, m));
+}

--- a/components/game/BelusWorld/belu/dialogue.ts
+++ b/components/game/BelusWorld/belu/dialogue.ts
@@ -23,8 +23,8 @@ const DB: Record<string, Partial<Record<0 | 1 | 2 | 3, Line[]>>> = {
 
   greeting_first: {
     0: [
-      "Oh! H-hello... I didn't know anyone else knew about this island.",
-      "Um... hi. I'm Nilu. This is Harmony Island. I... I'm glad you found it.",
+      "Oh! H-hello... I didn't know anyone else knew about the sky islands.",
+      "Um... hi. I'm Nilu. These are my sky islands. I... I'm glad you found them.",
     ],
   },
 
@@ -183,6 +183,25 @@ const DB: Record<string, Partial<Record<0 | 1 | 2 | 3, Line[]>>> = {
     ],
   },
 
+  zone_shore: {
+    0: [
+      "This is Sharing Shore. The friends here like to play together... taking turns is tricky for me.",
+      "The beach! Everyone shares the toys here. We can practice together, if you want.",
+    ],
+    1: [
+      "Sharing Shore! Taking turns used to feel SO hard. It gets easier every time.",
+      "Beach day! Want to see who gets the next turn with the ball?",
+    ],
+    2: [
+      "Sharing Shore! Remember — waiting for a turn means your turn is coming. That took me ages to learn.",
+      "I shared my snack with the crab yesterday. He gave me a shell. Sharing comes back around!",
+    ],
+    3: [
+      "SHARING SHORE! Best island. Warm sand, good friends, and everybody gets a turn.",
+      "The bunny challenged me to a sandcastle contest. We ended up building ONE castle together. Even better.",
+    ],
+  },
+
   explorer_mode: {
     0: ["We can just... walk around? And see things?", "I like exploring. It feels calmer than having a plan."],
     1: ["Explorer mode! Let's see what we discover together.", "Who knows what we'll find? I love not knowing."],
@@ -237,6 +256,7 @@ export function getZoneDialogue(zone: string, ctx: DialogueContext): string {
     mountain: 'zone_mountain',
     cove: 'zone_cove',
     forest: 'zone_forest',
+    shore: 'zone_shore',
   };
   return getDialogue(keyMap[zone] ?? 'zone_meadow', ctx);
 }

--- a/components/game/BelusWorld/belu/memory.ts
+++ b/components/game/BelusWorld/belu/memory.ts
@@ -1,6 +1,12 @@
+import { todayKey } from './progress';
+
 export interface BeluMemory {
   playerName: string | null;
   visitCount: number;
+  /** distinct real calendar days the child has visited (additive-only — a gap
+   *  in play is never counted, shown, or shamed) */
+  visitDays: number;
+  lastVisitDay: string | null;
   lastVisit: string | null;
   zonesVisited: string[];
   lastZone: string | null;
@@ -18,6 +24,8 @@ const KEY = 'belus_world_memory_v1';
 const defaults: BeluMemory = {
   playerName: null,
   visitCount: 0,
+  visitDays: 0,
+  lastVisitDay: null,
   lastVisit: null,
   zonesVisited: [],
   lastZone: null,
@@ -48,7 +56,20 @@ export function recordVisit(m: BeluMemory): BeluMemory {
   const visitCount = m.visitCount + 1;
   const personalityStage: 0 | 1 | 2 | 3 =
     visitCount >= 16 ? 3 : visitCount >= 8 ? 2 : visitCount >= 3 ? 1 : 0;
-  const updated = { ...m, visitCount, personalityStage, lastVisit: new Date().toISOString() };
+  // count distinct calendar days (several sessions in one day = one visit day).
+  // Older saves have no visitDays: seed from visitCount so a long-time player's
+  // chip starts near their history instead of at 1 (generous, never shaming).
+  const today = todayKey();
+  const priorDays = m.visitDays > 0 ? m.visitDays : m.visitCount;
+  const visitDays = m.lastVisitDay === today ? priorDays : priorDays + 1;
+  const updated = {
+    ...m,
+    visitCount,
+    personalityStage,
+    visitDays,
+    lastVisitDay: today,
+    lastVisit: new Date().toISOString(),
+  };
   saveMemory(updated);
   return updated;
 }

--- a/components/game/BelusWorld/belu/progress.ts
+++ b/components/game/BelusWorld/belu/progress.ts
@@ -8,13 +8,13 @@
 // No timers, no losing, no farming the same level past 3 stars.
 // ---------------------------------------------------------------------------
 
-export type ActivityZone = 'meadow' | 'mountain' | 'cove' | 'forest';
+export type ActivityZone = 'meadow' | 'mountain' | 'cove' | 'forest' | 'shore';
 
-export const ZONES: ActivityZone[] = ['meadow', 'mountain', 'cove', 'forest'];
+export const ZONES: ActivityZone[] = ['meadow', 'mountain', 'cove', 'forest', 'shore'];
 export const MAX_LEVEL = 5;
 export const MAX_STARS_PER_LEVEL = 3;
 export const MAX_STARS_PER_ISLAND = MAX_LEVEL * MAX_STARS_PER_LEVEL; // 15
-export const MAX_TOTAL_STARS = MAX_STARS_PER_ISLAND * ZONES.length; // 60
+export const MAX_TOTAL_STARS = MAX_STARS_PER_ISLAND * ZONES.length; // 75
 
 export interface IslandProgress {
   /** best stars earned on each level (index 0..MAX_LEVEL-1); 0 = not completed */
@@ -33,14 +33,27 @@ export const COSMETICS: Cosmetic[] = [
   { id: 'cap', name: 'Explorer Cap', icon: '🧢', slot: 'head' },
   { id: 'bow', name: 'Cute Bow', icon: '🎀', slot: 'head' },
   { id: 'party', name: 'Party Hat', icon: '🥳', slot: 'head' },
+  { id: 'flowercrown', name: 'Flower Crown', icon: '🌸', slot: 'head' },
+  { id: 'sunhat', name: 'Sunny Hat', icon: '👒', slot: 'head' },
+  { id: 'beanie', name: 'Cozy Beanie', icon: '🧶', slot: 'head' },
   { id: 'crown', name: 'Golden Crown', icon: '👑', slot: 'head' },
   { id: 'wizard', name: 'Wizard Hat', icon: '🧙', slot: 'head' },
   { id: 'glasses', name: 'Cool Shades', icon: '🕶️', slot: 'face' },
+  { id: 'goggles', name: 'Swim Goggles', icon: '🥽', slot: 'face' },
+  { id: 'hearts', name: 'Heart Glasses', icon: '💖', slot: 'face' },
   { id: 'cape', name: 'Hero Cape', icon: '🦸', slot: 'back' },
+  { id: 'scarf', name: 'Rainbow Scarf', icon: '🧣', slot: 'back' },
+  { id: 'backpack', name: 'Explorer Backpack', icon: '🎒', slot: 'back' },
+  { id: 'balloon', name: 'Sky Balloon', icon: '🎈', slot: 'back' },
   { id: 'wings', name: 'Fairy Wings', icon: '🧚', slot: 'back' },
 ];
-/** the order items unlock as the child completes levels */
-export const UNLOCK_ORDER = ['cap', 'bow', 'glasses', 'cape', 'party', 'crown', 'wings', 'wizard'];
+/** the order items unlock as the child completes levels — slots interleaved so
+ *  every few levels the reward feels different (a hat, then something for the
+ *  back, then the face…). 16 items across 25 total levels. */
+export const UNLOCK_ORDER = [
+  'cap', 'bow', 'glasses', 'scarf', 'party', 'flowercrown', 'cape', 'sunhat',
+  'goggles', 'crown', 'backpack', 'beanie', 'hearts', 'wings', 'balloon', 'wizard',
+];
 
 export interface EquippedCosmetics {
   head?: string;
@@ -78,6 +91,13 @@ export interface GameProgress {
   healedFriends: string[];
   /** local date of the last once-a-day friend "visit moment" (petal gift) */
   lastVisitMomentDate: string | null;
+  /** highest growth stage Nilu has EVER reached — growth never goes backwards,
+   *  even if star thresholds are rebalanced in an update */
+  growthFloor: number;
+  /** one-time achievement ids the child has earned (additive, never removed) */
+  achievementsEarned: string[];
+  /** today's Star Quests: which fully-bloomed islands' daily quest is done */
+  starQuests: { date: string; doneZones: string[] };
 }
 
 const KEY = 'belus_world_progress_v1';
@@ -93,6 +113,7 @@ function defaults(): GameProgress {
       mountain: emptyIsland(),
       cove: emptyIsland(),
       forest: emptyIsland(),
+      shore: emptyIsland(),
     },
     unlocked: [],
     equipped: {},
@@ -102,6 +123,9 @@ function defaults(): GameProgress {
     dailySparkles: { date: '', found: [] },
     healedFriends: [],
     lastVisitMomentDate: null,
+    growthFloor: 0,
+    achievementsEarned: [],
+    starQuests: { date: '', doneZones: [] },
   };
 }
 
@@ -137,6 +161,23 @@ export function loadProgress(): GameProgress {
     }
     if (Array.isArray(parsed.healedFriends)) base.healedFriends = parsed.healedFriends;
     if (typeof parsed.lastVisitMomentDate === 'string') base.lastVisitMomentDate = parsed.lastVisitMomentDate;
+    if (Array.isArray(parsed.achievementsEarned)) base.achievementsEarned = parsed.achievementsEarned;
+    if (parsed.starQuests && typeof parsed.starQuests.date === 'string' && Array.isArray(parsed.starQuests.doneZones)) {
+      base.starQuests = { date: parsed.starQuests.date, doneZones: parsed.starQuests.doneZones };
+    }
+    if (typeof parsed.growthFloor === 'number') {
+      base.growthFloor = Math.max(0, Math.min(3, parsed.growthFloor));
+    } else {
+      // migrate pre-rebalance saves: the growth stage the child ALREADY reached
+      // under the old thresholds becomes the floor, so Nilu never shrinks back.
+      const legacyStars = totalStars(base);
+      const legacy = [0, 12, 28, 48];
+      let stage = 0;
+      for (let i = legacy.length - 1; i >= 0; i--) {
+        if (legacyStars >= legacy[i]) { stage = i; break; }
+      }
+      base.growthFloor = stage;
+    }
     return base;
   } catch {
     return defaults();
@@ -202,8 +243,11 @@ export interface GrowthInfo {
   scale: number;
 }
 
-// star thresholds for each growth stage
-const GROWTH_THRESHOLDS = [0, 12, 28, 48];
+// Star thresholds for each growth stage. Tuned so the FINAL stage lands near
+// the end of the whole journey (22 of 25 levels) instead of leaving the last
+// islands with no growth payoff. Existing players are protected by
+// `growthFloor` — a stage once reached is never lost.
+const GROWTH_THRESHOLDS = [0, 15, 36, 66];
 const GROWTH_LABELS = ['Baby Nilu', 'Little Nilu', 'Big Nilu', 'Grown-Up Nilu'];
 const GROWTH_SCALES = [0.7, 0.85, 1.0, 1.15];
 
@@ -228,7 +272,18 @@ export function growthFromStars(stars: number): GrowthInfo {
 }
 
 export function getGrowth(p: GameProgress): GrowthInfo {
-  return growthFromStars(totalStars(p));
+  const info = growthFromStars(totalStars(p));
+  const floor = Math.max(0, Math.min(3, p.growthFloor ?? 0)) as GrowthStage;
+  if (floor <= info.stage) return info;
+  // the floor wins: growth NEVER goes backwards (e.g. after a rebalance)
+  const nextAt = floor < 3 ? GROWTH_THRESHOLDS[floor + 1] : null;
+  return {
+    stage: floor,
+    label: GROWTH_LABELS[floor],
+    nextAt,
+    progress: nextAt === null ? 1 : 0,
+    scale: GROWTH_SCALES[floor],
+  };
 }
 
 // ---- Home garden + sparkle jar + friendships (all additive, never decay) ----
@@ -314,6 +369,8 @@ export interface AwardResult {
   growthAfter: GrowthStage;
   /** a cosmetic unlocked by finishing this level for the first time, if any */
   unlockedItem?: Cosmetic;
+  /** sparkles gifted for replaying an already-finished level (0 on first plays) */
+  replaySparkles: number;
 }
 
 /** Record a finished level. levelIdx is 0-based. stars is 1..3. Keeps the best. */
@@ -332,8 +389,14 @@ export function awardLevel(
   const wasIncomplete = prevBest === 0;
   // every finished level also yields a seed for the Home garden
   next.seeds = (p.seeds ?? 0) + 1;
+  // replaying a finished level is never wasted: it harvests jar sparkles, so
+  // revisiting a favourite island keeps feeding the Home garden economy
+  const replaySparkles = wasIncomplete ? 0 : 3;
+  next.jarSparkles = (p.jarSparkles ?? 0) + replaySparkles;
   next.islands[zone].levelStars[levelIdx] = Math.max(prevBest, Math.min(MAX_STARS_PER_LEVEL, stars));
   const growthAfter = getGrowth(next).stage;
+  // a stage once reached is never lost
+  next.growthFloor = Math.max(p.growthFloor ?? 0, growthAfter);
 
   // first-time level completion unlocks the next cosmetic
   let unlockedItem: Cosmetic | undefined;
@@ -357,7 +420,38 @@ export function awardLevel(
     growthBefore,
     growthAfter,
     unlockedItem,
+    replaySparkles,
   };
+}
+
+// ---- daily Star Quests (endgame remix content on fully-bloomed islands) ----
+
+/** Is the once-a-day Star Quest on this island still waiting today? Only
+ *  fully-bloomed islands host one — it's the endgame's daily ritual. */
+export function starQuestAvailable(p: GameProgress, zone: ActivityZone, date: string = todayKey()): boolean {
+  if (!isIslandComplete(p, zone)) return false;
+  const done = p.starQuests.date === date ? p.starQuests.doneZones : [];
+  return !done.includes(zone);
+}
+
+export const STAR_QUEST_SPARKLES = 5;
+
+/** Mark today's Star Quest on an island done: a generous sparkle + seed gift. */
+export function completeStarQuest(p: GameProgress, zone: ActivityZone, date: string = todayKey()): GameProgress {
+  const done = p.starQuests.date === date ? p.starQuests.doneZones : [];
+  if (done.includes(zone)) return p;
+  return {
+    ...p,
+    starQuests: { date, doneZones: [...done, zone] },
+    jarSparkles: p.jarSparkles + STAR_QUEST_SPARKLES,
+    seeds: p.seeds + 1,
+  };
+}
+
+/** Record a one-time achievement (no-op if already earned). */
+export function earnAchievement(p: GameProgress, id: string): GameProgress {
+  if (p.achievementsEarned.includes(id)) return p;
+  return { ...p, achievementsEarned: [...p.achievementsEarned, id] };
 }
 
 export function equipCosmetic(p: GameProgress, slot: CosmeticSlot, id: string | null): GameProgress {

--- a/components/game/BelusWorld/index.tsx
+++ b/components/game/BelusWorld/index.tsx
@@ -96,6 +96,7 @@ const STICKER_KEYS: Record<ActivityZone, string> = {
   mountain: '⛰️',
   cove: '🌊',
   forest: '🌳',
+  shore: '🏖️',
 };
 
 interface RewardInfo {

--- a/components/game/BelusWorld/three/quest/QuestLayer.tsx
+++ b/components/game/BelusWorld/three/quest/QuestLayer.tsx
@@ -21,7 +21,7 @@ import AnswerOrb, { type OrbStatus } from './AnswerOrb';
 import QuestNPC, { type Mood } from './QuestNPC';
 import BreatheOrb from './BreatheOrb';
 
-const ALL_ZONES: ActivityZone[] = ['meadow', 'mountain', 'cove', 'forest'];
+const ALL_ZONES: ActivityZone[] = ['meadow', 'mountain', 'cove', 'forest', 'shore'];
 
 // idle "host" friends so each island feels inhabited before you arrive
 const HOSTS: Record<ActivityZone, { face: string; mood: Mood }> = {
@@ -29,6 +29,7 @@ const HOSTS: Record<ActivityZone, { face: string; mood: Mood }> = {
   mountain: { face: '🐿️', mood: 'happy' },
   cove: { face: '🐢', mood: 'calm' },
   forest: { face: '🦊', mood: 'happy' },
+  shore: { face: '🦀', mood: 'happy' },
 };
 
 const PICK_RADIUS = 2.4; // how close Nilu must walk to choose an orb (generous +
@@ -400,6 +401,7 @@ export default function QuestLayer(props: Props) {
     mountain: ISLANDS.mountain.accent,
     cove: ISLANDS.cove.accent,
     forest: ISLANDS.forest.accent,
+    shore: ISLANDS.shore.accent,
   };
 
   return (

--- a/components/game/BelusWorld/three/quest/quests.ts
+++ b/components/game/BelusWorld/three/quest/quests.ts
@@ -539,12 +539,148 @@ const FOREST: Quest[] = [
 ];
 
 // ===========================================================================
+// SHARING SHORE — Sharing & Taking Turns
+// ===========================================================================
+
+const SHORE: Quest[] = [
+  {
+    zone: 'shore', level: 1, goal: 'Whose turn is it?',
+    intro: "My beach friends are playing catch! Help me see whose turn it is.",
+    outro: 'You know all about turns now. Turn-taking makes games fun for everyone!',
+    moment: 'learned about turns at the shore',
+    rounds: [
+      { kind: 'choice', say: 'Crab just threw the ball to Seal. Whose turn is it now?',
+        npc: { face: '🦀', mood: MOOD('happy'), thought: { emoji: '⚽' } },
+        options: [
+          { emoji: '🦭', caption: "Seal's turn", correct: true },
+          { emoji: '🦀', caption: "Crab's turn" },
+        ], doneLine: "Yes! Seal has the ball, so it's Seal's turn!" },
+      { kind: 'choice', say: 'Seal threw it back! Whose turn is it now?',
+        npc: { face: '🦭', mood: MOOD('excited'), thought: { emoji: '⚽' } },
+        options: [
+          { emoji: '🦀', caption: "Crab's turn", correct: true },
+          { emoji: '🦭', caption: "Seal's turn" },
+        ], doneLine: 'Yes! Back and forth — that is taking turns!' },
+      { kind: 'choice', say: 'Crab says YOU can play too! Crab goes, Seal goes... who goes next?',
+        npc: { face: '🦀', mood: MOOD('happy'), thought: { emoji: '🫵' } },
+        options: [
+          { emoji: '🙋', caption: 'My turn', correct: true },
+          { emoji: '🦀', caption: "Crab's turn" },
+        ], doneLine: 'Your turn! Everyone gets a turn when we share the game. 🎉' },
+    ],
+  },
+  {
+    zone: 'shore', level: 2, goal: 'Share the shells',
+    intro: "I found SO many shells! Sharing means everyone gets some. Let's give some to my friends.",
+    outro: 'You shared with every friend. Look how happy they are!',
+    moment: 'shared my shells at the shore',
+    rounds: [
+      { kind: 'multiPick', say: 'Walk into a shell to give it away — one for each friend!', picks: 3,
+        npc: { face: '🐢', mood: MOOD('happy') },
+        options: [
+          { emoji: '🐚', caption: 'for Turtle' },
+          { emoji: '🐚', caption: 'for Crab' },
+          { emoji: '🐚', caption: 'for Seal' },
+        ],
+        doneLine: 'A shell for everyone! Sharing feels good. 💖' },
+      { kind: 'choice', say: 'Turtle only has one bucket, and you want to build too. What is the sharing way?',
+        npc: { face: '🐢', mood: MOOD('happy'), thought: { emoji: '🪣' } },
+        options: [
+          { emoji: '🤝', caption: 'use it together', correct: true },
+          { emoji: '🏃', caption: 'grab it and run' },
+        ], doneLine: 'Yes! We can use it together — that is sharing!' },
+      { kind: 'choice', say: 'Seal wants to see your shiny shell. You can share a LOOK! What do you say?',
+        npc: { face: '🦭', mood: MOOD('happy'), thought: { emoji: '✨' } },
+        options: [
+          { emoji: '🫴', caption: 'here, look!', correct: true },
+          { emoji: '🙈', caption: 'no, mine!' },
+        ], doneLine: '"Here, look!" You shared and it is still yours. 🌟' },
+    ],
+  },
+  {
+    zone: 'shore', level: 3, goal: 'Waiting is okay',
+    intro: "Sometimes we wait for our turn. Waiting is hard for me too! Let's practice together.",
+    outro: 'You waited SO well. Waiting means your turn is coming!',
+    moment: 'practiced waiting at the shore',
+    rounds: [
+      { kind: 'choice', say: 'Crab is on the slide. You want a turn! What do we do first?',
+        npc: { face: '🦀', mood: MOOD('happy'), thought: { emoji: '🛝' } },
+        options: [
+          { emoji: '⏳', caption: 'wait my turn', correct: true },
+          { emoji: '😤', caption: 'push past' },
+        ], doneLine: 'Yes — we wait, and our turn comes!' },
+      { kind: 'breathe', say: 'Waiting time! Take slow breaths with me while Crab finishes.',
+        npc: { face: '🐘', mood: MOOD('calm') }, cycles: 2,
+        doneLine: 'Look — Crab is done. Now it is YOUR turn! 🛝' },
+      { kind: 'choice', say: 'Turtle is still using the bucket. What can you do while you wait?',
+        npc: { face: '🐢', mood: MOOD('calm'), thought: { emoji: '🪣' } },
+        options: [
+          { emoji: '🏖️', caption: 'play nearby', correct: true },
+          { emoji: '😡', caption: 'yell at Turtle' },
+        ], doneLine: 'Playing nearby makes waiting easy — and your turn still comes!' },
+    ],
+  },
+  {
+    zone: 'shore', level: 4, goal: 'Ask for a turn',
+    intro: "When we want a turn, we can ASK with kind words. Let's build the asking words!",
+    outro: 'You asked so kindly! Kind words open the way to turns.',
+    moment: 'asked for a turn at the shore',
+    rounds: [
+      { kind: 'sequence', say: 'Say it with me: "my turn please". Walk into the words in order.',
+        npc: { face: '🦭', mood: MOOD('happy') },
+        pool: [{ emoji: '🏃', caption: 'run' }, { emoji: '🙋', caption: 'my turn' }, { emoji: '🙏', caption: 'please' }],
+        order: ['my turn', 'please'], doneLine: '"My turn please!" Seal smiles and hands it over. 🌟' },
+      { kind: 'sequence', say: 'Crab asked YOU for a turn! Say: "your turn now".',
+        npc: { face: '🦀', mood: MOOD('happy') },
+        pool: [{ emoji: '🐚', caption: 'shell' }, { emoji: '🫵', caption: 'your turn' }, { emoji: '⏰', caption: 'now' }],
+        order: ['your turn', 'now'], doneLine: '"Your turn now!" Giving a turn is a gift. 💖' },
+      { kind: 'choice', say: 'You asked, but Turtle says "not yet — one more minute." What do we do?',
+        npc: { face: '🐢', mood: MOOD('calm'), thought: { emoji: '⏳' } },
+        options: [
+          { emoji: '👍', caption: 'okay, I can wait', correct: true },
+          { emoji: '😭', caption: 'grab it anyway' },
+        ], doneLine: 'You waited kindly — and Turtle remembered your turn!' },
+    ],
+  },
+  {
+    zone: 'shore', level: 5, goal: 'Build together',
+    intro: "Bunny wants to build a sandcastle... and so do I! Let's build ONE castle — together!",
+    outro: 'We built it TOGETHER. Sharing made it twice as good. 🏰',
+    moment: 'built a sandcastle with a friend',
+    rounds: [
+      { kind: 'choice', say: 'One pile of sand, two builders. How do we start?',
+        npc: { face: '🐰', mood: MOOD('excited'), thought: { emoji: '🏰' } },
+        options: [
+          { emoji: '🤝', caption: 'build together', correct: true },
+          { emoji: '🧱', caption: 'build a wall between us' },
+        ], doneLine: 'Together! Two builders make one AMAZING castle.' },
+      { kind: 'multiPick', say: 'Take turns adding parts! Walk into each turn to build.', picks: 4,
+        npc: { face: '🐰', mood: MOOD('happy') },
+        options: [
+          { emoji: '🏰', caption: 'my tower' },
+          { emoji: '🐰', caption: "Bunny's wall" },
+          { emoji: '🚩', caption: 'my flag' },
+          { emoji: '🐚', caption: "Bunny's shells" },
+        ],
+        doneLine: 'Turn by turn, the castle grew! 🏰' },
+      { kind: 'choice', say: 'The castle is done! Bunny looks so proud. What do we say?',
+        npc: { face: '🐰', mood: MOOD('proud'), thought: { emoji: '🏰' } },
+        options: [
+          { emoji: '🎉', caption: 'we did it!', correct: true },
+          { emoji: '😤', caption: 'mine is better' },
+        ], doneLine: '"WE did it!" That is the best part of sharing. 💜' },
+    ],
+  },
+];
+
+// ===========================================================================
 
 export const QUESTS: Record<ActivityZone, Quest[]> = {
   meadow: MEADOW,
   mountain: MOUNTAIN,
   cove: COVE,
   forest: FOREST,
+  shore: SHORE,
 };
 
 /** Get the quest for a zone at a 1-based level (clamped to the available set). */

--- a/components/game/BelusWorld/three/worldConfig.ts
+++ b/components/game/BelusWorld/three/worldConfig.ts
@@ -5,7 +5,7 @@
 // the ground-collision math, and the gameplay all read from one source.
 // ---------------------------------------------------------------------------
 
-export type ZoneId = 'home' | 'meadow' | 'mountain' | 'cove' | 'forest' | 'rainbow';
+export type ZoneId = 'home' | 'meadow' | 'mountain' | 'cove' | 'forest' | 'shore' | 'rainbow';
 
 export interface IslandDef {
   id: ZoneId;
@@ -98,6 +98,20 @@ export const ISLANDS: Record<ZoneId, IslandDef> = {
     label: 'Friendship Forest',
     emoji: '🌳',
   },
+  // The fifth learning island — sharing, turn-taking and waiting, practiced on
+  // a sunny beach. Sits south of home, between the cove and the forest.
+  shore: {
+    id: 'shore',
+    cx: 2,
+    cz: 44,
+    radius: 9.5,
+    top: 0.5,
+    grass: '#f2dfa9',
+    rock: '#b09a72',
+    accent: '#ffb066',
+    label: 'Sharing Shore',
+    emoji: '🏖️',
+  },
   // A reward island that only FORMS once the child masters their first island.
   // It's a free-play playground (no lesson) Nilu can walk to and explore — a
   // visible "the world grew because of you" payoff. Sits out beyond home.
@@ -124,13 +138,14 @@ export const BRIDGES: BridgeDef[] = [
   { from: 'home', to: 'mountain', halfWidth: 2.2, colors: RAINBOW_STRIPES },
   { from: 'home', to: 'cove', halfWidth: 2.2, colors: RAINBOW_STRIPES },
   { from: 'home', to: 'forest', halfWidth: 2.2, colors: RAINBOW_STRIPES },
+  { from: 'home', to: 'shore', halfWidth: 2.2, colors: RAINBOW_STRIPES },
   // bridge to the reward island — only walkable once it's unlocked
   { from: 'home', to: 'rainbow', halfWidth: 2.4, colors: RAINBOW_STRIPES },
 ];
 
 // The zone islands that host a learning activity (everything except home + the
 // reward island). The rainbow playground has no lesson — it's just to explore.
-export const ZONE_ISLANDS: ZoneId[] = ['meadow', 'mountain', 'cove', 'forest'];
+export const ZONE_ISLANDS: ZoneId[] = ['meadow', 'mountain', 'cove', 'forest', 'shore'];
 
 // Runtime flag: the reward island (and its bridge) only physically exist once
 // the child has finished their first level. Rendering AND ground-collision both

--- a/components/game/BelusWorld/ui/GrowthMap.tsx
+++ b/components/game/BelusWorld/ui/GrowthMap.tsx
@@ -26,6 +26,7 @@ const SKILLS: Record<ActivityZone, string> = {
   mountain: 'Life Skills',
   cove: 'Calm & Senses',
   forest: 'Expressive Language',
+  shore: 'Sharing & Turns',
 };
 
 const GROWTH_EMOJI = ['🐣', '🐘', '🐘', '🐘']; // baby vs grown handled by scale below


### PR DESCRIPTION
## Summary
- New fifth learning island: **Sharing Shore 🏖️** — sharing, turn-taking, and waiting, with 5 embodied quest levels (whose turn → share the shells → waiting is okay → ask for a turn → build a sandcastle together) plus zone dialogue, host NPC (🦀), sticker, and Growth Map skill ("Sharing & Turns")
- Engagement data layer: visit-day streaks, achievements, growth rebalance with a floor, replay sparkles, and star quests

## Testing
- `tsc --noEmit` clean
- `vite build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)