### PR TITLE
chore: wire analytics (GTM GTM-WD789BVB)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,20 @@
 <html lang="en" class="dark">
 
 <head>
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
+    </script>
+    <!-- End Google Tag Manager -->
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-66RGGXFPWC"></script>
   <script>
@@ -143,6 +157,7 @@
 </head>
 
 <body>
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
   <a href="#main-content"
     class="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:p-4 focus:bg-white focus:text-sky-700 focus:font-bold focus:rounded-br-lg focus:shadow-md">Skip
     to content</a>

--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -1,6 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
+    </script>
+    <!-- End Google Tag Manager -->
 <meta charset="UTF-8">
 <title>Aaria's Block Craft 3D 🌈</title>
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
@@ -348,6 +362,7 @@
 </style>
 </head>
 <body>
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
 <canvas id="gameCanvas"></canvas>
 
 <div id="titleScreen">

--- a/public/craft3d/index.html
+++ b/public/craft3d/index.html
@@ -1,5 +1,20 @@
-<!DOCTYPE html><html><head><meta charset="UTF-8">
+<!DOCTYPE html><html><head>
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
+    </script>
+    <!-- End Google Tag Manager --><meta charset="UTF-8">
 <title>Aaria's Block Craft 3D</title>
 <meta http-equiv="refresh" content="0; url=/blockcraft/index.html">
 <link rel="canonical" href="https://aariasblueelephant.org/blockcraft/index.html">
-</head><body><p>Taking you to <a href="/blockcraft/index.html">Aaria's Block Craft 3D</a>… 🐘💙</p></body></html>
+</head><body>
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) --><p>Taking you to <a href="/blockcraft/index.html">Aaria's Block Craft 3D</a>… 🐘💙</p></body></html>

--- a/public/doughlab/index.html
+++ b/public/doughlab/index.html
@@ -1,6 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
+    </script>
+    <!-- End Google Tag Manager -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <title>Dough Lab 3D — playdough & slime simulator</title>
@@ -154,6 +168,7 @@
 </style>
 </head>
 <body>
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
 
 <div id="titleScreen">
   <img id="logoImg" src="logo.png" alt="Aaria's Blue Elephant" onerror="this.style.display='none'">
@@ -167,6 +182,20 @@
 </div>
 
 <header>
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
+    </script>
+    <!-- End Google Tag Manager -->
   <h1>🧁 Dough Lab<small>squish it · slice it · sculpt it — in real 3D 🌈</small></h1>
   <div class="seg" id="modeSeg">
     <button data-mode="dough" class="on">🫓 Playdough</button>

--- a/public/elly-tubbies/index.html
+++ b/public/elly-tubbies/index.html
@@ -1,6 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
+    </script>
+    <!-- End Google Tag Manager -->
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
 <title>Elly-Tubbies 🐘 — Aaria's Blue Elephant</title>
@@ -203,6 +217,7 @@
 </style>
 </head>
 <body>
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
   <canvas id="cv" role="application" aria-label="Trunkland — a 3D world you explore as Nilu the elephant"></canvas>
   <div id="loading"><div class="ele">🐘</div><div class="lbl">Waking up Trunkland…</div></div>
 

--- a/public/helpinghands/index.html
+++ b/public/helpinghands/index.html
@@ -1,6 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
+    </script>
+    <!-- End Google Tag Manager -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <title>Nilu's Helping Hands</title>
@@ -547,6 +561,7 @@
 </style>
 </head>
 <body>
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
 
 <div id="bgShapes"><i></i><i></i><i></i></div>
 
@@ -579,6 +594,20 @@
 <!-- 3. HOME MENU -->
 <div id="menuScreen" class="screen" hidden>
   <header class="chrome-header">
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
+    </script>
+    <!-- End Google Tag Manager -->
     <div class="sticker-counter">🌟 <span class="stickerCount">0</span></div>
     <button class="mute-btn" title="Mute sounds">🔊</button>
   </header>
@@ -622,6 +651,20 @@
 <!-- 5. MY HELPING HAND -->
 <div id="handScreen" class="screen" hidden>
   <header class="chrome-header">
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
+    </script>
+    <!-- End Google Tag Manager -->
     <button class="btn-back" data-target="menu">◀ Menu</button>
     <div style="display:flex;align-items:center;gap:8px;">
       <div class="sticker-counter">🌟 <span class="stickerCount">0</span></div>
@@ -634,6 +677,20 @@
 <!-- 6. PRACTICE BEING BRAVE -->
 <div id="practiceScreen" class="screen" hidden>
   <header class="chrome-header">
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
+    </script>
+    <!-- End Google Tag Manager -->
     <button class="btn-back" data-target="menu">◀ Menu</button>
     <div style="display:flex;align-items:center;gap:8px;">
       <div class="sticker-counter">🌟 <span class="stickerCount">0</span></div>
@@ -646,6 +703,20 @@
 <!-- 7. GROWN-UPS CORNER -->
 <div id="grownupsScreen" class="screen" hidden>
   <header class="chrome-header">
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
+    </script>
+    <!-- End Google Tag Manager -->
     <button class="btn-back" id="guBackBtn">◀ Back</button>
   </header>
   <div id="guGateWrap" class="gu-gate-wrap">

--- a/public/legal/disclosure.html
+++ b/public/legal/disclosure.html
@@ -1,6 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
+    </script>
+    <!-- End Google Tag Manager -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>General Disclosure — Aaria's Blue Elephant Games</title>
@@ -27,8 +41,23 @@
 </style>
 </head>
 <body>
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
 <div class="wrap">
 <header>
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
+    </script>
+    <!-- End Google Tag Manager -->
   <div class="label">Aaria's Blue Elephant · aariasblueelephant.org</div>
   <h1>General Disclosure for Our Games</h1>
   <p class="updated">Last updated July 5, 2026 · Applies to all games and interactive activities on this site</p>

--- a/public/magnetblocks/index.html
+++ b/public/magnetblocks/index.html
@@ -1,6 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
+    </script>
+    <!-- End Google Tag Manager -->
 <meta charset="UTF-8">
 <title>Aaria's Magnet Blocks 🧲🧱</title>
 <link rel="icon" href="../favicon.png">
@@ -156,6 +170,7 @@
 </style>
 </head>
 <body>
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
   <div id="titleScreen">
     <img id="logoImg" src="logo.png" alt="Aaria's Blue Elephant" onerror="this.style.display='none'">
     <h1>Aaria's Magnet Blocks</h1>

--- a/public/roadsafety/index.html
+++ b/public/roadsafety/index.html
@@ -1,12 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google Tag Manager -->
+    <script>
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
+    </script>
+    <!-- End Google Tag Manager -->
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 <title>Mountain House Road Safety Heroes — Aaria's Blue Elephant</title>
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
 <canvas id="gl" aria-hidden="true"></canvas>
 <div id="wrap">
   <canvas id="game" width="520" height="760" role="application" aria-label="Road Safety Heroes — drive the real streets of Mountain House"></canvas>


### PR DESCRIPTION
Wires analytics ids into this site (public client-side ids, not secrets).

- GTM container: `GTM-WD789BVB` (FFC-owned, via workflow 503)
- GA4 measurement id: `G-L9BXF9E8VK` (via workflow 505; GA4 fires inside the GTM container)

Generated by FFC workflow **704. Website - Analytics Wire**. Part of the fleet analytics
rollout (FreeForCharity/FFC-Cloudflare-Automation#629).