### PR TITLE
feat: Block Craft — hidden treasure + ⭐ hints + fur skins for animals

### DIFF
--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -457,7 +457,7 @@
    window.__ABC_SKIN so js/world.js derives ABC.SKIN/MODERN/SMOOTH from the
    exact same value. Modern is the new default. */
 (function () {
-  var V = 41;                                   // cache-bust for all game scripts
+  var V = 42;                                   // cache-bust for all game scripts
   var skin = null;
   try { skin = localStorage.getItem('abcSkin'); } catch (e) {}
   if (skin !== 'modern' && skin !== 'smooth' && skin !== 'classic') skin = 'modern';

--- a/public/blockcraft/js/animals.js
+++ b/public/blockcraft/js/animals.js
@@ -4,7 +4,59 @@ ABC.animals = (function () {
   let scene = null;
   let nameIdx = 0;
 
-  function mat(color) { return new THREE.MeshLambertMaterial({ color }); }
+  /* ---------- 🧸 modern fur ----------
+     Flat single-color parts are what make the animals read as plastic toys.
+     On modern, every animal color becomes a little painted FUR texture — a
+     tinted base with hundreds of short, mostly-downward strokes plus soft
+     dapples — so bodies read as felt/plush fur under the PBR sun. One texture
+     + material cached per color. Smooth/Classic keep plain Lambert colors. */
+  const _furTex = new Map(), _furMat = new Map();
+  function shadeHex(hex, k) {                    // '#rgb'/'#rrggbb' lightened (+k) / darkened (−k)
+    let h = hex.slice(1);
+    if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+    const n = parseInt(h, 16);
+    const c = (v) => Math.max(0, Math.min(255, Math.round(v * (1 + k))));
+    return `rgb(${c(n >> 16)},${c((n >> 8) & 255)},${c(n & 255)})`;
+  }
+  function furTexture(color) {
+    let tex = _furTex.get(color);
+    if (tex) return tex;
+    const S = 128, cv = document.createElement('canvas'); cv.width = cv.height = S;
+    const g = cv.getContext('2d');
+    g.fillStyle = color; g.fillRect(0, 0, S, S);
+    for (let i = 0; i < 12; i++) {               // soft tonal dapples
+      g.globalAlpha = 0.12;
+      g.fillStyle = shadeHex(color, (i % 2 ? 0.18 : -0.18));
+      g.beginPath(); g.arc(Math.random() * S, Math.random() * S, 16 + Math.random() * 28, 0, 7); g.fill();
+    }
+    for (let i = 0; i < 1100; i++) {             // the fur itself — bold enough to read in-game
+      const x = Math.random() * S, y = Math.random() * S, len = 5 + Math.random() * 10;
+      const a = Math.PI / 2 + (Math.random() - 0.5) * 0.9;   // mostly downward, like real coat lie
+      g.globalAlpha = 0.22 + Math.random() * 0.26;
+      g.strokeStyle = shadeHex(color, (Math.random() - 0.45) * 0.75);
+      g.lineWidth = 0.8 + Math.random() * 1.4;
+      g.lineCap = 'round';
+      g.beginPath(); g.moveTo(x, y);
+      g.quadraticCurveTo(x + Math.cos(a) * len * 0.5 + 1.5, y + Math.sin(a) * len * 0.5,
+                         x + Math.cos(a) * len, y + Math.sin(a) * len);   // gentle curl
+      g.stroke();
+    }
+    g.globalAlpha = 1;
+    tex = new THREE.CanvasTexture(cv);
+    tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+    tex.repeat.set(2, 2);                        // finer fur across big body parts
+    if (THREE.SRGBColorSpace) tex.colorSpace = THREE.SRGBColorSpace;
+    _furTex.set(color, tex);
+    return tex;
+  }
+  function mat(color) {
+    if (!ABC.MODERN || typeof color !== 'string' || color[0] !== '#') {
+      return new THREE.MeshLambertMaterial({ color });
+    }
+    let m = _furMat.get(color);                  // materials are never mutated per-animal → share
+    if (!m) { m = new THREE.MeshLambertMaterial({ map: furTexture(color) }); _furMat.set(color, m); }
+    return m;
+  }
   function sp(group, r, x, y, z, color, sy) {
     const m = new THREE.Mesh(new THREE.SphereGeometry(r, 18, 14), mat(color));
     m.position.set(x, y, z);
@@ -22,7 +74,7 @@ ABC.animals = (function () {
     if (!lib || !lib.RoundedBoxGeometry) return new THREE.BoxGeometry(w, h, d);
     const k = w + ',' + h + ',' + d;
     let g = _geoCache.get(k);
-    if (!g) { g = new lib.RoundedBoxGeometry(w, h, d, 4, Math.min(w, h, d) * 0.25); _geoCache.set(k, g); }
+    if (!g) { g = new lib.RoundedBoxGeometry(w, h, d, 4, Math.min(w, h, d) * 0.34); _geoCache.set(k, g); }
     return g;
   }
   function bx(group, w,h,d, x,y,z, color) {

--- a/public/blockcraft/js/dig.js
+++ b/public/blockcraft/js/dig.js
@@ -34,6 +34,60 @@ ABC.dig = (function () {
       `You dug up a sleepy little friend! ${a ? a.def.emoji : '🐾'} Tap them to say hello and help!`, 5200);
   }
 
+  /* ---------- ⭐ gentle treasure hints ----------
+     Treasures are truly buried now (invisible under the grass), so a child who
+     hasn't found one in a while gets a nudge: a floating, bobbing star appears
+     over ONE or TWO nearby buried treasures — never all of them, so the hunt
+     stays a hunt. Triggers after ~3 min without a find, or sooner if they've
+     been digging a lot with no luck. A hint vanishes when its treasure is dug. */
+  let lastFound = performance.now(), digsSinceFound = 0, hints = [], bobT = 0, retryAt = 0;
+  const TREASURE_IDS = ['silverGlint', 'goldGlint', 'eggTell', 'moundTell'];
+  function hintSprite() {
+    const cv = document.createElement('canvas'); cv.width = cv.height = 128;
+    const g = cv.getContext('2d');
+    const rg = g.createRadialGradient(64, 64, 8, 64, 64, 60);   // soft golden halo
+    rg.addColorStop(0, 'rgba(255,225,120,.9)'); rg.addColorStop(1, 'rgba(255,225,120,0)');
+    g.fillStyle = rg; g.beginPath(); g.arc(64, 64, 60, 0, 7); g.fill();
+    g.font = '72px serif'; g.textAlign = 'center'; g.textBaseline = 'middle';
+    g.fillText('⭐', 64, 66);
+    const tex = new THREE.CanvasTexture(cv);
+    if (THREE.SRGBColorSpace) tex.colorSpace = THREE.SRGBColorSpace;
+    const sp = new THREE.Sprite(new THREE.SpriteMaterial({ map: tex, transparent: true, depthWrite: false }));
+    sp.scale.set(1.5, 1.5, 1);
+    sp.userData.noAO = true;
+    return sp;
+  }
+  function noteDig() { digsSinceFound++; }
+  function update(dt, px, pz) {
+    const scene = ABC.world.getScene && ABC.world.getScene();
+    if (!scene) return;
+    bobT += dt;
+    for (const h of hints) {
+      h.sp.position.y = h.y + Math.sin(bobT * 2 + h.ph) * 0.28;
+      if (ABC.world.get(h.cx, h.cy, h.cz) !== h.t ||                 // dug (or gone) → hint done
+          Math.hypot(h.cx - px, h.cz - pz) > 80) {                   // wandered far away → drop it
+        scene.remove(h.sp); h.dead = true;
+      }
+    }
+    if (hints.length) { hints = hints.filter((h) => !h.dead); return; }
+    const now = performance.now();
+    const struggling = (now - lastFound > 180000) ||                          // ~3 min, no find
+                       (digsSinceFound >= 12 && now - lastFound > 45000);     // digging hard, no luck
+    if (!struggling || now < retryAt) return;
+    retryAt = now + 20000;                       // rescan at most every 20s
+    const near = ABC.world.findNear ? ABC.world.findNear(TREASURE_IDS, px, pz, 48, 2) : [];
+    for (const c of near) {
+      const sp = hintSprite();
+      const top = ABC.world.topBlock ? ABC.world.topBlock(c.x, c.z) : null;
+      const y = (top ? top.y + 1 : c.y + 2) + 1.6;
+      sp.position.set(c.x + 0.5, y, c.z + 0.5);
+      scene.add(sp);
+      hints.push({ sp, y, ph: Math.random() * 6, cx: c.x, cy: c.y, cz: c.z, t: c.t });
+    }
+    if (near.length) ABC.ui.bellaSays && ABC.ui.bellaSays(
+      'I can feel treasure sparkling under the ground! Walk to the floating star and dig down! ⭐', 5200);
+  }
+
   // route a dug marker to its reward (called from main.js act() after a successful dig)
   function reward(kind, cell) {
     const f = (ABC.DIG_FIND && ABC.DIG_FIND[kind]) || { emoji: '✨', word: 'a surprise' };
@@ -50,8 +104,10 @@ ABC.dig = (function () {
     } else if (kind === 'friend') {
       wakeFriend(cell);
     }
+    lastFound = performance.now();               // found one — the hint timer starts over
+    digsSinceFound = 0;
     ABC.saveSoon && ABC.saveSoon();
   }
 
-  return { kindForBlock, reward, hatchNextShape, wakeFriend };
+  return { kindForBlock, reward, hatchNextShape, wakeFriend, noteDig, update };
 })();

--- a/public/blockcraft/js/main.js
+++ b/public/blockcraft/js/main.js
@@ -534,6 +534,7 @@
           pulverize(info.cell.x, info.cell.y, info.cell.z, t);   // 💥 crumble!
           collapseCheck(info.cell);                              // 🌳 unsupported parts fall
           // 🪙 dig up buried treasure — the dug marker block IS the reward (no random roll)
+          ABC.dig && ABC.dig.noteDig && ABC.dig.noteDig();      // feeds the ⭐ hint timer
           const treasureKind = ABC.dig && ABC.dig.kindForBlock(t);
           if (treasureKind) ABC.dig.reward(treasureKind, info.cell);
         } else if (info.cell.y === ABC.world.MIN_Y) {
@@ -1193,6 +1194,7 @@
       ABC.shops.update(dt);
       ABC.signs.update(dt);
       ABC.animals.update(dt, now / 1000);
+      ABC.dig.update && ABC.dig.update(dt, feet.x, feet.z);   // ⭐ treasure hints
       ABC.pet.update(dt, feet);
       ABC.squishy.update(dt, camera);
       ABC.portal.update(dt);

--- a/public/blockcraft/js/world.js
+++ b/public/blockcraft/js/world.js
@@ -1344,16 +1344,17 @@ ABC.world = (function () {
     h = Math.imul(h ^ (h >>> 13), 1274126177);
     return ((h ^ (h >>> 16)) >>> 0) / 4294967296;
   }
-  /* Buried-treasure "tell": which VISIBLE marker (if any) sits on this cell.
-     Deterministic from hash2, so the same spot always holds the same thing — the
-     child SEES the glint/egg/mound and digs it (no random rolls). Made MUCH more
-     common so treasures are easy to find & engaging to hunt for! */
+  /* Buried treasure: which marker (if any) hides UNDER this cell. Deterministic
+     from hash2, so the same spot always holds the same thing (no random rolls).
+     Truly hidden at y=-1 — dig through the grass to discover it. Dense enough
+     that digging a small patch almost always finds something (~1 in 5 columns);
+     the floating-star hint system in dig.js helps a child who's struck out. */
   function treasureMarkerAt(x, z) {
     const h = hash2(x * 31 + 5, z * 31 + 7);
-    if (h < 0.010) return 'moundTell';     // sleepy animal friend (common!)
-    if (h < 0.035) return 'eggTell';       // shape egg (3× more common)
-    if (h < 0.12) return 'goldGlint';      // gold coin (+5) (17× more common!)
-    if (h < 0.30) return 'silverGlint';    // silver coin (+1) (the most common find!)
+    if (h < 0.006) return 'moundTell';     // rarest — a sleepy animal friend
+    if (h < 0.026) return 'eggTell';       // a shape egg
+    if (h < 0.09)  return 'goldGlint';     // gold coin (+5)
+    if (h < 0.20)  return 'silverGlint';   // silver coin (+1) — the common find
     return null;
   }
   function vnoise(x, z, s) {
@@ -1405,7 +1406,7 @@ ABC.world = (function () {
     const sp = Math.hypot(x, z), h = hash2(x * 3 + 1, z * 3 + 7);
     gset(keys, x, 0, z, sp > 14 ? groundAt(x, z) : 'grass');   // spawn pad stays tidy
     const tk = sp > 10 ? treasureMarkerAt(x, z) : null;   // off the spawn pad
-    if (tk) { gset(keys, x, 0, z, tk); return; }          // BURY IT: treasure replaces the grass block
+    if (tk) { gset(keys, x, -1, z, tk); return; }         // truly buried: hidden in the dirt UNDER the grass
     if (sp > 16 && treeCell(x, z, 13) && vnoise(x + 777, z - 777, 34) > 0.55) genTree(keys, x, z, 0);
     else if (h < 0.007) gset(keys, x, 1, z, 'flower');
   }
@@ -1417,7 +1418,7 @@ ABC.world = (function () {
     const hsh = hash2(x * 3 + 1, z * 3 + 7);
     if (hh === 0) {
       const tk = treasureMarkerAt(x, z);
-      if (tk) gset(keys, x, 0, z, tk);                    // BURY IT: treasure replaces the grass block
+      if (tk) gset(keys, x, -1, z, tk);                   // truly buried: hidden in the dirt UNDER the grass
       else if (treeCell(x, z, 14) && vnoise(x, z, 26) > 0.58) genTree(keys, x, z, 0);
       else if (hsh < 0.004) gset(keys, x, 1, z, 'flower');
     }
@@ -1709,8 +1710,24 @@ ABC.world = (function () {
     return root;
   }
 
+  /* nearest loaded blocks of the given types (uses the per-type instance
+     position lists that rebuild() maintains) — the treasure-hint radar */
+  function findNear(types, px, pz, r, limit) {
+    const out = [];
+    for (const t of types) {
+      const m = meshes[t];
+      if (!m || !m.userData.positions) continue;
+      for (const p of m.userData.positions) {
+        const d = Math.hypot(p[0] - px, p[2] - pz);
+        if (d < r) out.push({ x: p[0], y: p[1], z: p[2], t, d });
+      }
+    }
+    out.sort((a, b) => a.d - b.d);
+    return out.slice(0, limit || 2);
+  }
+
   return { SIZE, MAX_Y, MIN_Y, initScene, generate: infiniteInit, get, set, remove, flush, key,
            blockMeshes, serialize: serializeEdits, deserialize: deserializeEdits, materials,
            ensureChunks, setTheme, gradeFrame, updateSky, updateSun, getRot, topBlock,
-           entityShadows, setSkyPipeline, footstep, getScene: () => scene };
+           entityShadows, setSkyPipeline, footstep, findNear, getScene: () => scene };
 })();


### PR DESCRIPTION
Owner feedback: treasure cubes were visible sitting in holes (should be discovered by digging), and animals still looked plastic.

**Treasure — truly hidden**
- Markers now generate at y=-1, inside the dirt under the grass. Nothing visible on the surface; dig the grass to reveal the glowing treasure below.
- ~1 in 5 columns hides something, so digging a small patch almost always pays off.

**⭐ Hint system**
- No find for ~3 minutes (or lots of fruitless digging) → a soft golden star bobs above one or two nearby buried treasures + Nilu says to walk there and dig down.
- Never marks all treasures — the hunt stays a hunt. Star vanishes once dug.

**Fur skins (Modern only)**
- Every animal color becomes a painted fur texture (directional strokes, tonal dapples) — soft fur instead of smooth plastic; bodies rounder (radius 34%).

Verified headless: clean surface, dig-to-reveal works, exactly 2 hint stars appear after forced struggle, fur visible. Zero page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)