### PR TITLE
Playtest fixes — true master mute, uniform controls, Block Craft HUD overlap, ▶️ My Movie

### DIFF
--- a/components/game/BelusWorld/index.tsx
+++ b/components/game/BelusWorld/index.tsx
@@ -205,6 +205,16 @@ export default function BelusWorldGame() {
     });
   }, []);
 
+  // one-tap master mute — flips the same settings.sound the settings panel
+  // uses, and cancels any speech already in flight so it doesn't keep talking
+  const toggleMute = useCallback(() => {
+    setSettings((s) => {
+      const next = !s.sound;
+      if (!next) stopSpeaking();
+      return { ...s, sound: next };
+    });
+  }, []);
+
   function start(name: string) {
     // did the garden grow while the child was away? (checked BEFORE the visit
     // stamp updates, so "away" means since the previous session)
@@ -447,6 +457,8 @@ export default function BelusWorldGame() {
         onPause={() => { sfx('tap'); setManualPause(true); }}
         onCycleSpeed={cycleSpeed}
         speedLabel={SPEED[settings.speed].label}
+        onToggleMute={toggleMute}
+        muted={!settings.sound}
       />
 
       <AnimatePresence>

--- a/components/game/BelusWorld/ui/HUD.tsx
+++ b/components/game/BelusWorld/ui/HUD.tsx
@@ -27,9 +27,11 @@ interface Props {
   onPause: () => void;
   onCycleSpeed: () => void;
   speedLabel: string;
+  onToggleMute: () => void;
+  muted: boolean;
 }
 
-export default function HUD({ beluLine, nearZone, starQuestZone, stickers, totalStars, isTouch, onOpenSettings, onOpenMap, onOpenWardrobe, onToggleFullscreen, onGoHome, onExit, onPause, onCycleSpeed, speedLabel }: Props) {
+export default function HUD({ beluLine, nearZone, starQuestZone, stickers, totalStars, isTouch, onOpenSettings, onOpenMap, onOpenWardrobe, onToggleFullscreen, onGoHome, onExit, onPause, onCycleSpeed, speedLabel, onToggleMute, muted }: Props) {
   const zoneMeta = nearZone && nearZone !== 'home' ? ISLANDS[nearZone] : null;
   const hasStarQuest = !!starQuestZone && starQuestZone === nearZone;
 
@@ -71,6 +73,14 @@ export default function HUD({ beluLine, nearZone, starQuestZone, stickers, total
             </span>
           )}
         </div>
+        <button
+          onClick={onToggleMute}
+          className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg shadow-lg backdrop-blur transition hover:bg-white"
+          aria-label={muted ? 'Unmute sound' : 'Mute sound'}
+          title={muted ? 'Unmute sound' : 'Mute sound'}
+        >
+          {muted ? '🔇' : '🔊'}
+        </button>
         <button
           onClick={onGoHome}
           className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg shadow-lg backdrop-blur transition hover:bg-white"

--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -124,15 +124,38 @@
   #lookHint { position:absolute; bottom:96px; left:50%; transform:translateX(-50%);
     background:rgba(255,255,255,.92); padding:10px 22px; border-radius:22px; font-size:19px; color:#246;
     box-shadow:0 4px 10px rgba(0,0,0,.2); }
-  /* side buttons: anchored under the top menu, wrapping inward — can never reach
-     the bottom action buttons no matter the screen height */
+  /* side buttons: anchored under the top menu, one flex column. On short
+     windows (see height-based media queries below) the buttons shrink and,
+     below ~600px, reflow into a compact grid so they can never collide with
+     the ⬆/⬇/🧱 action cluster on the same (right) edge. */
   #sideBtns { position:absolute; right:14px; top:64px; display:flex; flex-direction:column;
-    flex-wrap:wrap-reverse; gap:8px; pointer-events:auto;
-    max-height:calc(100vh - 320px); align-content:flex-start; }
+    flex-wrap:nowrap; gap:8px; pointer-events:auto; }
   .sideBtn { width:56px; height:56px; font-size:21px; display:flex; flex-direction:column;
-    align-items:center; justify-content:center; border-radius:14px; }
+    align-items:center; justify-content:center; border-radius:14px; flex-shrink:0; }
   .sideBtn small { font-size:10px; }
   .sideBtn.active { background:#ffe066; box-shadow:0 0 0 3px #fab005, 0 3px 8px rgba(0,0,0,.18); }
+
+  /* ---- short-viewport rescue: keep #sideBtns and #touchActs/#touchPad from
+     ever overlapping when the browser window isn't full height ---- */
+  @media (max-height: 850px) {
+    #sideBtns { top:56px; gap:6px; }
+    .sideBtn { width:46px; height:46px; font-size:17px; border-radius:11px; }
+    .sideBtn small { font-size:8px; }
+    #touchActs { right:14px; bottom:92px; gap:8px; }
+    #touchActs .tBtn { width:48px; height:48px; font-size:22px; }
+    #touchPad { bottom:92px; width:140px; height:140px; }
+  }
+  @media (max-height: 620px) {
+    /* not enough vertical room for a single column of 8 — reflow into a
+       compact 2-wide grid anchored under the top menu instead */
+    #sideBtns { top:52px; flex-direction:row; flex-wrap:wrap; justify-content:flex-end;
+      width:104px; gap:6px; }
+    .sideBtn { width:44px; height:44px; font-size:15px; }
+    .sideBtn small { display:none; }
+    #touchActs { bottom:78px; gap:6px; }
+    #touchActs .tBtn { width:44px; height:44px; font-size:19px; }
+    #touchPad { bottom:78px; width:124px; height:124px; }
+  }
 
   /* on-screen control pad — always visible, no Esc or mouse-lock needed */
   #touchPad, #touchActs { position:absolute; bottom:110px; pointer-events:auto; }
@@ -313,12 +336,22 @@
   /* spacious edge placement — replaces the cramped defaults */
   body.skin-smooth #scoreBar { top:var(--hud-pad); left:var(--hud-pad); gap:12px; }
   body.skin-smooth #menuBar  { top:var(--hud-pad); right:var(--hud-pad); gap:10px; }
-  body.skin-smooth #sideBtns { right:var(--hud-pad); top:86px; gap:13px;
-    max-height:calc(100vh - 340px); }
+  body.skin-smooth #sideBtns { right:var(--hud-pad); top:86px; gap:13px; }
   body.skin-smooth .sideBtn  { width:60px; height:60px; border-radius:17px; font-size:22px; }
   body.skin-smooth .sideBtn small { font-size:10px; opacity:.8; }
   body.skin-smooth .sideBtn.active { background:rgba(31,182,166,.3);
     box-shadow:0 0 0 3px var(--accent), 0 8px 18px -8px rgba(18,38,56,.5); }
+  /* short-viewport rescue applies to the Smooth skin too */
+  @media (max-height: 850px) {
+    body.skin-smooth #sideBtns { top:70px; gap:8px; }
+    body.skin-smooth .sideBtn { width:48px; height:48px; font-size:18px; }
+  }
+  @media (max-height: 620px) {
+    body.skin-smooth #sideBtns { top:64px; flex-direction:row; flex-wrap:wrap;
+      justify-content:flex-end; width:114px; gap:8px; }
+    body.skin-smooth .sideBtn { width:46px; height:46px; font-size:16px; }
+    body.skin-smooth .sideBtn small { display:none; }
+  }
 
   /* the bag — calm: no pulsing glow, no strobing sparkle */
   body.skin-smooth #bagBtn {
@@ -352,6 +385,18 @@
   body.skin-smooth #touchActs .tBtn { width:66px; height:66px; font-size:28px; }
   body.skin-smooth #tMode { box-shadow:0 0 0 3px #2fb36a, 0 8px 18px -8px rgba(18,38,56,.5); }
   body.skin-smooth #tMode.digMode { box-shadow:0 0 0 3px #ff922b, 0 8px 18px -8px rgba(18,38,56,.5); }
+  /* short-viewport rescue: shrink the Smooth skin's roomy pad/action cluster
+     so it can't push into the (also-shrinking) side buttons above it */
+  @media (max-height: 850px) {
+    body.skin-smooth #touchPad  { bottom:92px; width:150px; height:150px; }
+    body.skin-smooth #touchActs { bottom:92px; gap:10px; }
+    body.skin-smooth #touchActs .tBtn { width:50px; height:50px; font-size:22px; }
+  }
+  @media (max-height: 620px) {
+    body.skin-smooth #touchPad  { bottom:78px; width:130px; height:130px; }
+    body.skin-smooth #touchActs { bottom:78px; gap:8px; }
+    body.skin-smooth #touchActs .tBtn { width:44px; height:44px; font-size:19px; }
+  }
   body.skin-smooth #lookHint { bottom:104px; border-radius:22px; padding:11px 22px; color:var(--ink); }
   body.skin-smooth #crosshair { text-shadow:0 0 8px rgba(0,0,0,.45); opacity:.7; }
   body.skin-smooth #projectPanel { border-radius:20px; }
@@ -425,14 +470,15 @@
     <div class="scoreChip" id="flowerChip" title="Days of adventures">🌻 0</div>
   </div>
   <div id="menuBar">
+    <button class="menuBtn" id="muteBtn" title="Mute — tap to turn off sound" style="min-width:44px;min-height:44px;">🔊</button>
+    <button class="menuBtn" id="pauseBtn" title="Take a break" style="min-width:44px;min-height:44px;">⏸️</button>
+    <button class="menuBtn" id="movieBtn" title="Watch your last adventure!" style="min-width:44px;min-height:44px;">▶️</button>
     <button class="menuBtn deskOnly" id="buildMenuBtn">🏗️<span class="btnTxt"> Build</span></button>
     <button class="menuBtn deskOnly" id="slimeBtn">🌈<span class="btnTxt"> Slime Lab</span></button>
     <button class="menuBtn deskOnly" id="oreoBtn">🍪<span class="btnTxt"> Oreo Kitchen</span></button>
     <button class="menuBtn deskOnly" id="kindBtn">💌<span class="btnTxt"> Kind Words</span></button>
     <button class="menuBtn deskOnly" id="stickersBtn" title="My Treasures">🏅</button>
     <button class="menuBtn deskOnly" id="friendsBtn" title="Friend Book">📖</button>
-    <button class="menuBtn" id="muteBtn" title="Mute — tap to turn off sound" style="min-width:44px;min-height:44px;">🔊</button>
-    <button class="menuBtn" id="pauseBtn" title="Take a break" style="min-width:44px;min-height:44px;">⏸️</button>
     <button class="menuBtn" id="speedBtn" title="Game speed — tap for more time 🐢 or faster 🚀">🎛️</button>
     <button class="menuBtn" id="skinToggleBtn" title="Switch Modern / Smooth / Classic look">🎨</button>
     <button class="menuBtn deskOnly" id="fsBtn" title="Full screen">⛶</button>

--- a/public/blockcraft/js/audio.js
+++ b/public/blockcraft/js/audio.js
@@ -1,7 +1,8 @@
 /* Aaria's Block Craft 3D — audio: WebAudio synth SFX, gentle music, and text-to-speech */
 ABC.audio = (function () {
   let ctx = null, musicGain = null, musicTimer = null;
-  const S = { sound:true, music:false, readAloud:true, voiceMode:false, speed:'normal', calm:false };
+  const S = { sound:true, music:false, readAloud:true, voiceMode:false, speed:'normal', calm:false,
+              muted:false };   // 🔇 master mute (HUD one-tap) — silences sfx, music AND speech
 
   /* Game pace 🐢🐇🚀 — kids who need more time stay Relaxed; kids who want it
      snappier go Fast. Scales how long messages linger AND the read-aloud rate.
@@ -31,7 +32,7 @@ ABC.audio = (function () {
   /* polite audio: cap how many beeps can stack, and duck under Bella's voice */
   const _toneLog = [];
   function tone(freq, dur, type, vol, when, slideTo) {
-    if (!S.sound) return;
+    if (!S.sound || S.muted) return;
     const nowMs = performance.now();
     while (_toneLog.length && nowMs - _toneLog[0] > 350) _toneLog.shift();
     if (_toneLog.length >= 6) return;
@@ -123,7 +124,7 @@ ABC.audio = (function () {
   /* Soft generative music: slow pentatonic bells */
   const SCALE = [523.25, 587.33, 659.25, 783.99, 880.0, 1046.5];
   function musicTick() {
-    if (!S.music || !ctx) return;
+    if (!S.music || S.muted || !ctx) return;
     const n = SCALE[Math.floor(Math.random()*SCALE.length)];
     const t = ctx.currentTime;
     const o = ctx.createOscillator(), g = ctx.createGain();
@@ -171,6 +172,7 @@ ABC.audio = (function () {
   }
   function say(text, opts) {
     if (!window.speechSynthesis) return;
+    if (S.muted) return;   // master mute wins over everything, even forced reads
     if (!S.readAloud && !(opts && opts.force)) return;
     const clean = String(text).replace(/<[^>]*>/g, '').replace(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}✨⭐]/gu, '');
     if (!clean.trim()) return;

--- a/public/blockcraft/js/main.js
+++ b/public/blockcraft/js/main.js
@@ -902,7 +902,8 @@
         metrics: ABC.state.metrics,
         tutorialDone: ABC.state.tutorialDone,
         settings: { sound: s.sound, music: s.music, readAloud: s.readAloud, voiceMode: s.voiceMode,
-                    theme: s.theme, voiceName: s.voiceName, speed: s.speed, weather: s.weather, calm: s.calm },
+                    theme: s.theme, voiceName: s.voiceName, speed: s.speed, weather: s.weather, calm: s.calm,
+                    muted: s.muted },
       }));
     } catch (e) { /* storage blocked — keep playing */ }
   }
@@ -983,7 +984,7 @@
   /* ---------------- 🔊 one-tap mute ---------------- */
   function refreshMuteBtn() {
     const b = $('muteBtn'); if (!b) return;
-    const muted = !ABC.audio.settings.sound;
+    const muted = !!ABC.audio.settings.muted;
     b.textContent = muted ? '🔇' : '🔊';
     b.title = muted ? 'Unmute — tap to hear sound again' : 'Mute — tap to turn off sound';
   }
@@ -991,12 +992,12 @@
   if ($('muteBtn')) {
     $('muteBtn').onclick = () => {
       const s = ABC.audio.settings;
-      const turningOn = !s.sound;
-      s.sound = turningOn; s.music = turningOn;
+      s.muted = !s.muted;             // master mute: sfx + music + Bella's voice
+      if (s.muted) ABC.audio.stopSay();  // silence any line already being spoken
       refreshMuteBtn();
       saveSoon();
-      if (turningOn) ABC.audio.sfx.pop();
-      ABC.ui.toast(turningOn ? '🔊 Sound is back on!' : '🔇 Sound is off — tap 🔇 to hear again!', 2000);
+      if (!s.muted) ABC.audio.sfx.pop();
+      ABC.ui.toast(s.muted ? '🔇 Sound is off — tap 🔇 to hear again!' : '🔊 Sound is back on!', 2000);
     };
     refreshMuteBtn();
   }
@@ -1032,6 +1033,11 @@
     $('restPlayAgain').onclick = () => { ov.remove(); started = true; };
   }
   if ($('pauseBtn')) $('pauseBtn').onclick = showPauseDialog;
+
+  /* ---------------- ▶️ My Movie — the replay button, promoted out of Settings ---------------- */
+  if ($('movieBtn')) {
+    $('movieBtn').onclick = () => { ABC.startAdventureReplay && ABC.startAdventureReplay(); };
+  }
 
   /* full screen — works on Chrome/Edge/Firefox AND Safari (incl. iOS, which
      has no Fullscreen API, via a CSS faux-fullscreen fallback) */

--- a/public/blockcraft/js/ui.js
+++ b/public/blockcraft/js/ui.js
@@ -731,8 +731,8 @@ ABC.ui = (function () {
       <button class="choiceBtn" id="setCalm">${chk(s.calm)} 😌 Calm mode — softer sounds &amp; less bouncy camera</button>
       <button class="choiceBtn" id="setShare">📤 Share world — save a file of your build to send a friend</button>
       <button class="choiceBtn" id="setVisit">📥 Visit a friend's world — open a world file they shared</button>
-      <button class="choiceBtn" id="setTimelapse">🎬 My world grew! — watch your build come together again</button>
-      <button class="choiceBtn" id="setAdventure">🎬 Watch my adventure — replay your last walk around!</button>
+      <button class="choiceBtn" id="setTimelapse">🏗️ My world grew! — watch it build</button>
+      <button class="choiceBtn" id="setAdventure">▶️ My Movie — watch your adventure!</button>
       <button class="choiceBtn" id="setParent">👨‍👩‍👧 For grown-ups — progress dashboard</button>
       <button class="choiceBtn" id="setReset" style="border-color:#ffa8a8;">🧹 Start a brand-new world (erases this one)</button>
       <div class="scene" style="font-size:15px; color:#557;">Made with 💙 by <b>${ABC.BRAND.org}</b> — ${ABC.BRAND.tagline}<br>${ABC.BRAND.url.replace('https://','')}</div>

--- a/public/doughlab/index.html
+++ b/public/doughlab/index.html
@@ -257,12 +257,12 @@
   <canvas id="ui"></canvas>
   <div id="chip">🍪 Shapes made: <span id="chipCount">0</span></div>
   <div id="hudBtns">
+    <button id="muteBtn" class="hudBtn" title="Mute sound">🔊</button>
     <button id="calmBtn" class="hudBtn" title="Calm mode — locks the camera and calms things down">😌</button>
     <button id="viewBtn" class="hudBtn" title="Reset the camera view">🔄</button>
     <button id="photoBtn" class="hudBtn" title="Save a photo of your dough">📸</button>
     <button id="exportBtn" class="hudBtn" title="Share your dough — save a file">📤</button>
     <button id="importBtn" class="hudBtn" title="Load a friend's dough file">📥</button>
-    <button id="muteBtn" class="hudBtn" title="Mute sound">🔊</button>
     <button id="parentBtn" class="hudBtn" title="Parent stats">👨‍👩‍👧</button>
   </div>
   <input type="file" id="importFile" accept=".json,application/json" style="display:none">

--- a/public/elly-tubbies/index.html
+++ b/public/elly-tubbies/index.html
@@ -89,14 +89,17 @@
   @keyframes questPop{0%{transform:translateX(-50%) scale(.85)}
     55%{transform:translateX(-50%) scale(1.12)}100%{transform:translateX(-50%) scale(1)}}
   body.rm .chip.quest.donePulse{animation:none;}
-  #menu{display:flex;gap:7px;pointer-events:auto;}
+  #menu{display:flex;flex-wrap:wrap;justify-content:flex-end;gap:7px;pointer-events:auto;max-width:100%;}
   .mbtn{position:relative;pointer-events:auto;cursor:pointer;border:2px solid rgba(255,255,255,.92);
-    background:rgba(255,255,255,.66);
+    background:rgba(255,255,255,.66);min-width:48px;min-height:48px;
     backdrop-filter:blur(10px) saturate(1.5);-webkit-backdrop-filter:blur(10px) saturate(1.5);
     border-radius:16px;padding:9px 12px;font-size:clamp(15px,4vw,20px);font-weight:800;
+    display:inline-flex;align-items:center;justify-content:center;
     color:var(--ink);box-shadow:0 4px 0 rgba(213,221,245,.8),0 8px 16px rgba(58,58,90,.15),inset 0 1px 0 rgba(255,255,255,.9);line-height:1;transition:.12s;}
   .mbtn:active{transform:translateY(3px);box-shadow:0 1px 0 #d5ddf5;}
   .mbtn.off{opacity:.45;}
+  .mbtn.mbtnLabeled{flex-direction:column;gap:1px;padding:6px 10px;}
+  .mbtnLbl{font-size:9.5px;font-weight:900;line-height:1;white-space:nowrap;letter-spacing:.2px;}
   .mbadge{position:absolute;top:-6px;right:-6px;background:#ff6b9d;color:#fff;border-radius:999px;
     min-width:19px;height:19px;padding:0 4px;font-size:11px;font-weight:900;
     align-items:center;justify-content:center;box-shadow:0 2px 5px rgba(58,58,90,.35);border:2px solid #fff;}
@@ -262,11 +265,12 @@
       <div class="chip" id="sched" style="pointer-events:auto;gap:4px" title="Today's plan"></div>
     </div>
     <div id="menu">
+      <button class="mbtn" id="soundBtn" title="Sound — tap to mute or unmute" aria-label="Sound on or off">🔊</button>
+      <button class="mbtn" id="pauseBtn" title="Take a break" aria-label="Pause">⏸️</button>
+      <button class="mbtn mbtnLabeled" id="replayBtn" title="Watch my adventure!" aria-label="Watch my adventure — My Movie">▶️<span class="mbtnLbl">My Movie</span></button>
       <button class="mbtn" id="mapBtn" title="Map — fly to a friend!" aria-label="Map">🗺️</button>
       <button class="mbtn" id="bookBtn" title="Sticker garden" aria-label="Sticker garden">📖<span id="stkBadge" class="mbadge" style="display:none"></span></button>
-      <button class="mbtn" id="speedBtn" title="Game speed — tap for more time 🐢 or faster 🚀" aria-label="Game speed">🎛️</button>
-      <button class="mbtn" id="pauseBtn" title="Take a break" aria-label="Pause">⏸️</button>
-      <button class="mbtn" id="replayBtn" title="Watch my adventure!" aria-label="Watch my adventure">🎬</button>
+      <button class="mbtn" id="speedBtn" title="Game speed — tap for more time 🐢 or faster 🚀" aria-label="Game speed">🐇</button>
       <button class="mbtn" id="settingsBtn" title="Settings" aria-label="Settings">⚙️</button>
       <button class="mbtn" id="helpBtn" title="How to play" aria-label="How to play">❔</button>
     </div>
@@ -279,9 +283,9 @@
   <!-- Sun Baby's never-ending quest — tap for a sparkle trail -->
   <div class="chip quest" id="questChip" style="display:none" title="Sun Baby's quest — tap for a sparkle trail!"></div>
 
-  <!-- 🎬 Replay bar — shown only while watching a recorded adventure -->
+  <!-- ▶️ Replay bar — shown only while watching a recorded adventure -->
   <div id="replayBar" class="hidden">
-    <span class="rbLabel">🎬 Nilu's Adventure</span>
+    <span class="rbLabel">▶️ My Movie</span>
     <button class="rbtn" id="replaySpeedBtn" title="Change speed" aria-label="Playback speed">1x</button>
     <button class="rbtn" id="replayShareBtn" title="Share adventure" aria-label="Share adventure">📤</button>
     <button class="rbtn rbDone" id="replayDoneBtn" title="Done watching" aria-label="Done watching">⏹ Done</button>
@@ -311,7 +315,7 @@
       <button class="big" id="setVoice" style="font-size:17px"></button>
       <button class="big" id="setCalm" style="font-size:17px"></button>
       <button class="big" id="setFs" style="font-size:17px">⛶ Full screen</button>
-      <button class="big" id="setReplay" style="font-size:17px">🎬 Watch my adventure</button>
+      <button class="big" id="setReplay" style="font-size:17px">▶️ My Movie — watch your adventure!</button>
       <button class="big" id="setImportReplay" style="font-size:17px">📥 Watch a friend's adventure</button>
       <button class="big" id="setParent" style="font-size:17px">👨‍👩‍👧 For grown-ups</button>
     </div>
@@ -3248,20 +3252,32 @@ addEventListener('wheel',e=>{if(mode==='roam')setCamZoom(e.deltaY>0?0.1:-0.1);},
 $('helpBtn').onclick=()=>{$('intro').classList.add('show');};
 /* ---- ⚙️ settings + 🎛️ speed (uniform across ABE games; Block Craft canon) ---- */
 const SPEED_META={relaxed:{ico:'🐢',label:'More time'},normal:{ico:'🐇',label:'Just right'},fast:{ico:'🚀',label:'Faster'}};
+function updateSpeedBtn(){const b=$('speedBtn');if(!b)return;
+  b.textContent=SPEED_META[S.speed].ico;
+  b.setAttribute('aria-label',`Game speed: ${SPEED_META[S.speed].label}`);}
 function cycleSpeed(){const order=['relaxed','normal','fast'];
   S.speed=order[(order.indexOf(S.speed)+1)%3];save();sfx.tap();
-  renderSettings();
-  say('☀️',`${SPEED_META[S.speed].ico} Game speed: ${SPEED_META[S.speed].label}!`);}
+  renderSettings();updateSpeedBtn();
+  celebToast(`${SPEED_META[S.speed].ico} ${SPEED_META[S.speed].label}!`,1800);}
 function renderSettings(){
   $('setSpeed').innerHTML=`🎛️ Game speed: <b>${SPEED_META[S.speed].ico} ${SPEED_META[S.speed].label}</b>`;
   $('setSound').textContent=S.muted?'🔇 Sound: off — tap to turn on':'🔊 Sound: on';
   $('setVoice').textContent=S.voice?'🗣️ Read aloud: on':'🤫 Read aloud: off — tap to turn on';
   $('setCalm').textContent=S.calm?'😌 Calm mode: on — extra gentle':'😌 Calm mode: off — tap for extra gentle';}
+/* 🔊 one-tap HUD mute — mirrors + stays in sync with the settings sound toggle */
+function updateSoundBtn(){const b=$('soundBtn');if(!b)return;
+  b.textContent=S.muted?'🔇':'🔊';b.classList.toggle('off',!!S.muted);
+  b.setAttribute('aria-label',S.muted?'Sound off — tap to turn on':'Sound on — tap to mute');}
+function toggleMute(){S.muted=!S.muted;save();
+  if(S.muted&&voiceOK)try{speechSynthesis.cancel();}catch(e){}
+  updateSoundBtn();renderSettings();if(!S.muted)sfx.tap();}
+$('soundBtn').onclick=toggleMute;
+updateSoundBtn();updateSpeedBtn();
 $('speedBtn').onclick=cycleSpeed;
 $('settingsBtn').onclick=()=>{sfx.tap();renderSettings();$('settings').classList.add('show');};
 $('setClose').onclick=()=>{sfx.tap();$('settings').classList.remove('show');};
 $('setSpeed').onclick=cycleSpeed;
-$('setSound').onclick=()=>{S.muted=!S.muted;save();renderSettings();if(!S.muted)sfx.tap();};
+$('setSound').onclick=toggleMute;
 $('setVoice').onclick=()=>{S.voice=!S.voice;save();renderSettings();
   if(S.voice)speak('Hello! I will read for you!');else if(voiceOK)speechSynthesis.cancel();sfx.tap();};
 $('setCalm').onclick=()=>{S.calm=!S.calm;save();renderSettings();sfx.tap();

--- a/public/magnetblocks/index.html
+++ b/public/magnetblocks/index.html
@@ -210,13 +210,13 @@
       <div class="chip" id="bestChip" title="Your biggest build ever!">🏆 0</div>
     </div>
     <div id="topRight">
+      <button class="menuBtn" id="soundBtn">🔊</button>
+      <button class="menuBtn" id="replayBtn" style="display:none">▶️ My Movie</button>
       <button class="menuBtn" id="tableBtn">🟩 Table</button>
       <button class="menuBtn" id="calmBtn" title="Calm mode">😌</button>
-      <button class="menuBtn" id="soundBtn">🔊</button>
       <button class="menuBtn" id="tidyNowBtn">🧹 Tidy</button>
       <button class="menuBtn" id="clearBtn">🆕 New</button>
       <button class="menuBtn" id="parentBtn" title="Parent panel">👨‍👩‍👧</button>
-      <button class="menuBtn" id="replayBtn" style="display:none">🎬 Watch my build</button>
     </div>
 
     <div id="viewStack">

--- a/public/magnetblocks/js/bag.js
+++ b/public/magnetblocks/js/bag.js
@@ -169,7 +169,7 @@ window.MB = window.MB || {};
       const el = document.createElement('div'); el.className = 'bagItem';
       el.innerHTML = '<img src="' + item.thumb + '" alt=""><div class="nm" title="✏️ Tap to rename">' + item.name + ' · ' + item.date + '</div>' +
                      '<div class="bagActions">' +
-                       '<button class="bagAct" title="Watch my build">🎬</button>' +
+                       '<button class="bagAct" title="My Movie — watch my build">▶️</button>' +
                        '<button class="bagAct" title="Share this build">📤</button>' +
                      '</div>' +
                      '<button class="del">✕</button>';

--- a/public/roadsafety/game.js
+++ b/public/roadsafety/game.js
@@ -357,7 +357,7 @@ function speak(txt){
 document.getElementById("muteBtn").addEventListener("click", () => {
   muted = !muted;
   document.getElementById("muteBtn").textContent = muted ? "🔇" : "🔊";
-  if (muted) sirenStop();
+  if (muted){ sirenStop(); if (window.speechSynthesis) speechSynthesis.cancel(); }
 });
 function toggleView(){
   S.view = S.view === "top" ? "fp" : "top";

--- a/public/roadsafety/index.html
+++ b/public/roadsafety/index.html
@@ -30,11 +30,11 @@
 <div id="wrap">
   <canvas id="game" width="520" height="760" role="application" aria-label="Road Safety Heroes — drive the real streets of Mountain House"></canvas>
   <div id="topbtns">
+    <button id="muteBtn" title="Sound on/off" aria-label="Sound">🔊</button>
     <button id="viewBtn" title="Toggle first-person view (V)" aria-label="Toggle view">👁</button>
     <button id="mapBtn" title="Toggle minimap (M)" aria-label="Minimap">🗺</button>
     <button id="speedBtn" title="Game speed — tap for more time 🐢 or faster 🚀" aria-label="Game speed">🎛️</button>
     <button id="settingsBtn" title="Settings" aria-label="Settings">⚙️</button>
-    <button id="muteBtn" title="Sound on/off" aria-label="Sound">🔊</button>
   </div>
   <button id="pauseBtn" class="hidden" title="Pause (tap to freeze the game)" aria-label="Pause game">⏸️</button>
   <div id="pauseOverlay" class="hidden">


### PR DESCRIPTION
Fixes from real-device playtesting (Safari + Chrome):

- **Block Craft sound-off actually works now** — the mute button only gated the synth beeps; Bella's voice and music kept playing. New master mute silences sfx + music + speech, persisted.
- **Block Craft side-toolbar overlap** (non-fullscreen windows) — root cause was `flex-wrap:wrap-reverse` + a fixed max-height; now height-aware (850px/620px breakpoints) reflowing into a compact grid that can never reach the bottom controls.
- **Replay discoverable**: ▶️ "My Movie" button on the HUD in Block Craft & Elly-Tubbies (was buried in Settings / unclear 🎬 icon).
- **Uniform controls across all 7 games**: 🔊/🔇 one-tap mute first on every HUD (muting cancels TTS mid-sentence), then ⏸️, then ▶️ My Movie, settings last; speed controls show live 🐢/🐇/🚀.

Verified: node --check on all game JS (incl. extracted inline scripts), tsc clean, full build + prerender passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)