### PR TITLE
Minify deployed games + LICENSE and copyright banners

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright © 2026 Aaria's Blue Elephant (aariasblueelephant.org)
+All rights reserved.
+
+The games, artwork, characters (including "Nilu"), game code under public/
+(blockcraft, doughlab, elly-tubbies, helpinghands, magnetblocks, roadsafety,
+craft3d) and the Belu's World / Nilu's World game code under components/game/
+are original works created for Aaria's Blue Elephant, a nonprofit supporting
+children with autism and their families.
+
+You may NOT copy, redistribute, modify, or reuse the games or their code,
+in whole or in part, for any purpose — commercial or non-commercial —
+without prior written permission.
+
+We're a small nonprofit and we usually say yes to good causes.
+Want to use something? Just ask: buddy@aariasblueelephant.org
+
+Website framework code (build scripts, site pages) may reference third-party
+open-source libraries (React, three.js, etc.) which remain under their own
+licenses.

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,9 +32,11 @@
         "@vitejs/plugin-react": "^5.0.0",
         "autoprefixer": "^10.4.27",
         "express": "^5.2.1",
+        "html-minifier-terser": "^7.2.0",
         "postcss": "^8.5.16",
         "puppeteer": "^24.38.0",
         "tailwindcss": "^4.2.2",
+        "terser": "^5.49.0",
         "tsx": "^4.23.0",
         "typescript": "~5.8.2",
         "vite": "^6.4.3"
@@ -816,6 +818,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -1936,6 +1949,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2297,6 +2323,13 @@
         "node": "*"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -2348,6 +2381,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/camera-controls": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.2.tgz",
@@ -2396,6 +2440,19 @@
         "devtools-protocol": "*"
       }
     },
+    "node_modules/clean-css": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "~0.6.0"
+      },
+      "engines": {
+        "node": ">= 10.0"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -2430,6 +2487,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -2635,6 +2702,17 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/draco3d": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
@@ -2709,6 +2787,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -3271,6 +3362,28 @@
       "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
       "license": "Apache-2.0"
     },
+    "node_modules/html-minifier-terser": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
+      "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "clean-css": "~5.3.2",
+        "commander": "^10.0.0",
+        "entities": "^4.4.0",
+        "param-case": "^3.0.4",
+        "relateurl": "^0.2.7",
+        "terser": "^5.15.1"
+      },
+      "bin": {
+        "html-minifier-terser": "cli.js"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -3817,6 +3930,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4009,6 +4132,17 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/node-appwrite": {
       "version": "23.1.0",
       "resolved": "https://registry.npmjs.org/node-appwrite/-/node-appwrite-23.1.0.tgz",
@@ -4102,6 +4236,17 @@
         "node": ">= 14"
       }
     },
+    "node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4142,6 +4287,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/path-key": {
@@ -4513,6 +4669,16 @@
         }
       }
     },
+    "node_modules/relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4831,7 +4997,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4844,6 +5009,17 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/stats-gl": {
@@ -4983,6 +5159,32 @@
       "dependencies": {
         "streamx": "^2.12.5"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/text-decoder": {
       "version": "1.2.7",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "fetch-data": "tsx scripts/fetch-resilience-data.ts",
-    "build": "npm run fetch-data && tsc && vite build && node prerender.js",
+    "build": "npm run fetch-data && tsc && vite build && node prerender.js && node scripts/minify-games.mjs",
     "preview": "vite preview",
     "lint": "tsc --noEmit"
   },
@@ -35,9 +35,11 @@
     "@vitejs/plugin-react": "^5.0.0",
     "autoprefixer": "^10.4.27",
     "express": "^5.2.1",
+    "html-minifier-terser": "^7.2.0",
     "postcss": "^8.5.16",
     "puppeteer": "^24.38.0",
     "tailwindcss": "^4.2.2",
+    "terser": "^5.49.0",
     "tsx": "^4.23.0",
     "typescript": "~5.8.2",
     "vite": "^6.4.3"

--- a/scripts/minify-games.mjs
+++ b/scripts/minify-games.mjs
@@ -1,0 +1,60 @@
+// Post-build: minify the games in dist/ and stamp a copyright banner.
+// Runs AFTER vite build + prerender, touches ONLY dist/ — source stays readable.
+// Mangling is function-local only (toplevel:false): the games share globals
+// (ABC.*, MB.*, HH.*) across <script> files, so top-level names must survive.
+import { readFile, writeFile, readdir } from 'node:fs/promises';
+import { join, extname } from 'node:path';
+import { minify as terser } from 'terser';
+import { minify as htmlMinify } from 'html-minifier-terser';
+
+const DIST = new URL('../dist/', import.meta.url).pathname;
+const GAME_DIRS = ['blockcraft', 'doughlab', 'elly-tubbies', 'helpinghands',
+  'magnetblocks', 'roadsafety', 'craft3d'];
+
+const BANNER = `/*! © ${new Date().getFullYear()} Aaria's Blue Elephant · aariasblueelephant.org · All rights reserved.
+ * Built by Aaria and her Friends 💙 — please don't copy; ask us instead: buddy@aariasblueelephant.org */`;
+
+const TERSER_OPTS = {
+  compress: { defaults: true, passes: 2 },
+  mangle: { toplevel: false }, // keep cross-file globals intact
+  format: { comments: false, preamble: BANNER },
+};
+
+async function* walk(dir) {
+  for (const e of await readdir(dir, { withFileTypes: true })) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) yield* walk(p);
+    else yield p;
+  }
+}
+
+let jsN = 0, htmlN = 0, saved = 0;
+for (const g of GAME_DIRS) {
+  const root = join(DIST, g);
+  for await (const file of walk(root)) {
+    const ext = extname(file);
+    // skip vendored libs that are already minified
+    if (/\.min\.js$/.test(file) || file.includes('/lib/')) continue;
+    if (ext === '.js') {
+      const src = await readFile(file, 'utf8');
+      const out = await terser(src, TERSER_OPTS);
+      if (!out.code) throw new Error(`terser produced no output for ${file}`);
+      saved += src.length - out.code.length;
+      await writeFile(file, out.code);
+      jsN++;
+    } else if (ext === '.html') {
+      const src = await readFile(file, 'utf8');
+      const out = await htmlMinify(src, {
+        collapseWhitespace: true,
+        removeComments: true,
+        minifyCSS: true,
+        minifyJS: TERSER_OPTS, // inline <script> games (doughlab, elly-tubbies)
+      });
+      const stamped = out.replace(/<head>/i, `<head><!-- ${BANNER.replace(/\/\*!|\*\//g, '').trim()} -->`);
+      saved += src.length - stamped.length;
+      await writeFile(file, stamped);
+      htmlN++;
+    }
+  }
+}
+console.log(`minify-games: ${jsN} js + ${htmlN} html minified, ${(saved / 1024).toFixed(0)}KB saved`);


### PR DESCRIPTION
Practical code-protection layer (repo stays public):

- **Post-build minifier** (`scripts/minify-games.mjs`, wired into `npm run build`): all 7 games' JS + HTML in `dist/` are minified and stamped with a copyright banner before deploy. Source in the repo stays readable for development; the live site serves compact, comment-stripped code (~489KB lighter as a bonus).
- Safe for the games' architecture: terser mangles function-local names only, so cross-file globals (`ABC.*`, `MB.*`, `HH.*`) keep working; already-minified `lib/*.min.js` vendored files are skipped.
- **LICENSE**: explicit all-rights-reserved for the games, characters and artwork, with a friendly "just ask us" contact for good causes.

Verified: full build passes; every minified JS file (and extracted inline scripts from doughlab/elly-tubbies) passes `node --check`; banner present in output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)