### PR TITLE
First-class sharing + landing-page replay

### DIFF
--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -445,6 +445,8 @@
       <button class="bigBtn skin-selector" data-skin="classic" style="font-size:20px; padding:12px 28px;">🧱 Classic</button>
     </div>
     <button class="bigBtn" id="fsTitleBtn" style="font-size:20px; padding:12px 30px;">⛶ Full Screen</button>
+    <button class="bigBtn" id="titleMovieBtn" style="font-size:20px; padding:12px 30px; display:none;">▶️ My Movie — watch your world grow!</button>
+    <button class="bigBtn" id="titleVisitBtn" style="font-size:20px; padding:12px 30px;">📥 Visit a friend's world</button>
     <script>
       document.querySelectorAll('.skin-selector').forEach(btn => {
         btn.addEventListener('click', function() {
@@ -473,6 +475,7 @@
     <button class="menuBtn" id="muteBtn" title="Mute — tap to turn off sound" style="min-width:44px;min-height:44px;">🔊</button>
     <button class="menuBtn" id="pauseBtn" title="Take a break" style="min-width:44px;min-height:44px;">⏸️</button>
     <button class="menuBtn" id="movieBtn" title="Watch your last adventure!" style="min-width:44px;min-height:44px;">▶️</button>
+    <button class="menuBtn" id="shareBtn" title="Share your world with a friend" style="min-width:44px;min-height:44px;">📤</button>
     <button class="menuBtn deskOnly" id="buildMenuBtn">🏗️<span class="btnTxt"> Build</span></button>
     <button class="menuBtn deskOnly" id="slimeBtn">🌈<span class="btnTxt"> Slime Lab</span></button>
     <button class="menuBtn deskOnly" id="oreoBtn">🍪<span class="btnTxt"> Oreo Kitchen</span></button>

--- a/public/blockcraft/js/main.js
+++ b/public/blockcraft/js/main.js
@@ -1039,6 +1039,11 @@
     $('movieBtn').onclick = () => { ABC.startAdventureReplay && ABC.startAdventureReplay(); };
   }
 
+  /* ---------------- 📤 Share world — instant download straight from the HUD ---------------- */
+  if ($('shareBtn')) {
+    $('shareBtn').onclick = () => { ABC.ui.shareWorld && ABC.ui.shareWorld(); };
+  }
+
   /* full screen — works on Chrome/Edge/Firefox AND Safari (incl. iOS, which
      has no Fullscreen API, via a CSS faux-fullscreen fallback) */
   function nativeFsEl() { return document.fullscreenElement || document.webkitFullscreenElement; }
@@ -1125,6 +1130,19 @@
     }
   };
   $('howBtn').onclick = () => ABC.ui.showHelp();
+
+  /* ---------------- title-screen extras: ▶️ My Movie & 📥 Visit a friend's world ----------------
+     "My Movie" only appears for a returning builder — a saved world with at least
+     30 edits — so a brand-new player never sees an empty replay. Both buttons
+     start the game first (the normal playBtn flow), then open their feature. */
+  (function () {
+    const mv = $('titleMovieBtn'), vs = $('titleVisitBtn');
+    let edits = 0;
+    try { const s = ABC.world.serialize(); edits = s.d.length + s.r.length; } catch (e) { /* no world yet */ }
+    if (mv && hadSave && edits >= 30) mv.style.display = '';
+    if (mv) mv.onclick = () => { $('playBtn').click(); setTimeout(() => ABC.ui.startTimelapse && ABC.ui.startTimelapse(), 700); };
+    if (vs) vs.onclick = () => { $('playBtn').click(); setTimeout(() => ABC.ui.visitWorld && ABC.ui.visitWorld(), 700); };
+  })();
 
   /* ---------------- game speed (🐢 more time · 🐇 normal · 🚀 faster) ---------------- */
   ABC.refreshSpeedBtn = () => {
@@ -1325,6 +1343,7 @@
       'font-size:16px;font-weight:bold;cursor:pointer;padding:8px 14px;';
     rBar.innerHTML = '<span>🎬 My Adventure</span>' +
       `<button id="rpSpeed" style="${btnCss}background:linear-gradient(180deg,#a5d8ff,#74c0fc);color:#1864ab;">1x</button>` +
+      `<button id="rpShare" style="${btnCss}background:linear-gradient(180deg,#b2f2bb,#69db7c);color:#22400a;">📤 Share</button>` +
       `<button id="rpDone" style="${btnCss}background:linear-gradient(180deg,#ffe066,#ffd43b);color:#664d03;">⏹ Done</button>`;
     document.body.appendChild(rBar);
     rBar.querySelector('#rpSpeed').onclick = (e) => {
@@ -1332,6 +1351,7 @@
       e.target.textContent = rSpeed + 'x';
       ABC.audio.sfx.gentle();
     };
+    rBar.querySelector('#rpShare').onclick = () => { ABC.ui.shareWorld && ABC.ui.shareWorld(); };
     rBar.querySelector('#rpDone').onclick = () => endReplay();
     ABC.ui.toast('🎬 Watch where you went — here comes your adventure!', 3200, true);
   }

--- a/public/blockcraft/js/ui.js
+++ b/public/blockcraft/js/ui.js
@@ -200,7 +200,10 @@ ABC.ui = (function () {
       <div style="height:18px;background:#e9ecef;border-radius:10px;overflow:hidden;margin:14px 0;">
         <div id="tlFill" style="height:100%;width:0%;background:linear-gradient(90deg,#69db7c,#51cf66);transition:width .15s;"></div>
       </div>
-      <div class="dlgRow"><button class="bigBtn" id="tlStop" style="font-size:18px;padding:12px 30px;min-height:44px;">⏹ Stop</button></div>`);
+      <div class="dlgRow">
+        <button class="bigBtn" id="tlShare" style="font-size:18px;padding:12px 24px;min-height:44px;background:linear-gradient(180deg,#b2f2bb,#69db7c);color:#22400a;">📤 Share</button>
+        <button class="bigBtn" id="tlStop" style="font-size:18px;padding:12px 30px;min-height:44px;">⏹ Stop</button>
+      </div>`);
 
     let idx = 0, ticks = 0;
     const finish = () => {
@@ -209,6 +212,13 @@ ABC.ui = (function () {
       closeDialog();
       if (!ABC.audio.settings.calm) confetti(40);
       ABC.audio.say('Look how much you built!', { force: true });
+    };
+    $('tlShare').onclick = () => {
+      ABC.audio.sfx.pop();
+      if (tlTimer) { clearInterval(tlTimer); tlTimer = null; }
+      ABC.world.deserialize(snap);   // share the real, finished world — not a half-grown replay
+      closeDialog();
+      shareWorld();
     };
     $('tlStop').onclick = () => {
       ABC.audio.sfx.pop();
@@ -694,6 +704,9 @@ ABC.ui = (function () {
       { ico: '📔', label: 'Parks',      go: press('passportBtn') },
       { ico: '📸', label: 'Photo',      go: press('photoBtn') },
       { ico: '🖼️', label: 'Album',      go: press('albumBtn') },
+      { ico: '▶️', label: 'My Movie',   go: () => { closeDialog(); ABC.startAdventureReplay && ABC.startAdventureReplay(); } },
+      { ico: '📤', label: 'Share',      go: () => { closeDialog(); shareWorld(); } },
+      { ico: '📥', label: 'Visit',      go: () => { closeDialog(); visitWorld(); } },
       { ico: '👀', label: 'View',       go: press('viewBtn') },
       { ico: '🔍', label: 'Zoom +',     go: press('zoomInBtn') },
       { ico: '🔭', label: 'Zoom −',     go: press('zoomOutBtn') },

--- a/public/elly-tubbies/index.html
+++ b/public/elly-tubbies/index.html
@@ -216,6 +216,24 @@
   .rbtn:active{transform:translateY(3px);box-shadow:0 1px 0 #e0a92e;}
   .rbDone{background:linear-gradient(160deg,#ffd2de,#ff8fb1);box-shadow:0 4px 0 #d6547d;}
   .rbDone:active{box-shadow:0 1px 0 #d6547d;}
+  .rbtnLabeled{flex-direction:column;gap:1px;padding:6px 10px;}
+
+  /* ---------- share-this-adventure prompt (calm, skippable, after a solo replay ends) ---------- */
+  #sharePrompt{position:absolute;top:26%;left:50%;transform:translateX(-50%) scale(.7);z-index:16;
+    pointer-events:none;background:rgba(255,255,255,.97);border:3px solid #fff;border-radius:24px;
+    padding:16px 20px;box-shadow:0 10px 30px rgba(58,58,90,.3),0 4px 0 #d5ddf5;
+    font-weight:900;color:var(--ink);font-size:clamp(15px,4vw,18px);opacity:0;text-align:center;
+    display:flex;flex-direction:column;gap:10px;align-items:center;transition:opacity .25s ease;}
+  #sharePrompt.show{opacity:1;pointer-events:auto;animation:celebPop .4s cubic-bezier(.34,1.56,.64,1);}
+  body.rm #sharePrompt.show{animation:none;transform:translateX(-50%) scale(1);}
+  #sharePrompt .spRow{display:flex;gap:10px;}
+  #sharePrompt button{cursor:pointer;border:none;border-radius:16px;min-width:44px;min-height:44px;
+    font-weight:900;font-family:inherit;font-size:14px;padding:8px 14px;transition:.12s;}
+  #sharePrompt button:active{transform:translateY(3px);}
+  #sharePromptYes{background:linear-gradient(160deg,#fff6d5,#ffd97a);box-shadow:0 4px 0 #e0a92e;}
+  #sharePromptYes:active{box-shadow:0 1px 0 #e0a92e;}
+  #sharePromptNo{background:rgba(255,255,255,.92);box-shadow:0 4px 0 #cfd6ee;color:var(--ink);}
+  #sharePromptNo:active{box-shadow:0 1px 0 #cfd6ee;}
 
   /* ---------- overlays (intro / book / finale only) ---------- */
   .overlay{position:absolute;inset:0;z-index:20;display:none;align-items:center;justify-content:center;
@@ -268,6 +286,7 @@
       <button class="mbtn" id="soundBtn" title="Sound — tap to mute or unmute" aria-label="Sound on or off">🔊</button>
       <button class="mbtn" id="pauseBtn" title="Take a break" aria-label="Pause">⏸️</button>
       <button class="mbtn mbtnLabeled" id="replayBtn" title="Watch my adventure!" aria-label="Watch my adventure — My Movie">▶️<span class="mbtnLbl">My Movie</span></button>
+      <button class="mbtn mbtnLabeled" id="shareBtn" title="Share my adventure!" aria-label="Share my adventure">📤<span class="mbtnLbl">Share</span></button>
       <button class="mbtn" id="mapBtn" title="Map — fly to a friend!" aria-label="Map">🗺️</button>
       <button class="mbtn" id="bookBtn" title="Sticker garden" aria-label="Sticker garden">📖<span id="stkBadge" class="mbadge" style="display:none"></span></button>
       <button class="mbtn" id="speedBtn" title="Game speed — tap for more time 🐢 or faster 🚀" aria-label="Game speed">🐇</button>
@@ -287,7 +306,7 @@
   <div id="replayBar" class="hidden">
     <span class="rbLabel">▶️ My Movie</span>
     <button class="rbtn" id="replaySpeedBtn" title="Change speed" aria-label="Playback speed">1x</button>
-    <button class="rbtn" id="replayShareBtn" title="Share adventure" aria-label="Share adventure">📤</button>
+    <button class="rbtn rbtnLabeled" id="replayShareBtn" title="Share adventure" aria-label="Share adventure">📤<span class="mbtnLbl">Share</span></button>
     <button class="rbtn rbDone" id="replayDoneBtn" title="Done watching" aria-label="Done watching">⏹ Done</button>
   </div>
   <input type="file" id="importFile" accept="application/json,.json" class="hidden">
@@ -297,6 +316,14 @@
   <div id="celebToast" aria-live="polite"></div>
   <!-- gentle idle hint: nudges toward an activity that hasn't been discovered yet -->
   <div id="hintToast" aria-live="polite"></div>
+  <!-- calm, skippable nudge shown after a child's own adventure finishes playing -->
+  <div id="sharePrompt" aria-live="polite">
+    <div>Share this adventure? 📤</div>
+    <div class="spRow">
+      <button id="sharePromptYes">📤 Share</button>
+      <button id="sharePromptNo">Not now</button>
+    </div>
+  </div>
 
   <!-- World map: tap a place to FLY there (recharges every 5 minutes) -->
   <div class="overlay" id="wmap"><div class="panel" style="max-width:470px">
@@ -381,6 +408,11 @@
     <div style="display:flex;gap:14px;flex-wrap:wrap;justify-content:center;">
       <button class="bigBtn" id="titleHowBtn" style="font-size:20px;padding:12px 30px;">❓ How to Play</button>
       <button class="bigBtn" id="titleFsBtn" style="font-size:20px;padding:12px 30px;">⛶ Full Screen</button>
+    </div>
+    <!-- shown only when a saved adventure (≥20s) is waiting from last visit -->
+    <div id="titleMovieRow" style="display:none;gap:14px;flex-wrap:wrap;justify-content:center;">
+      <button class="bigBtn" id="titleMovieBtn" style="font-size:20px;padding:12px 30px;">▶️ My Movie</button>
+      <button class="bigBtn" id="titleImportBtn" style="font-size:20px;padding:12px 30px;">📥 Watch a friend's adventure</button>
     </div>
     <div id="orgFooter">A game from <b>Aaria's Blue Elephant</b> 🐘💙 · aariasblueelephant.org · Mountain House &amp; Tracy, CA</div>
     <a id="disclosureLink" href="/legal/disclosure.html" target="_blank" rel="noopener">General Disclosure</a>
@@ -1892,13 +1924,13 @@ function floatSprite(ch,pos,rise=3,dur=1.4,scale=1.3){
    ========================================================================== */
 const REC_SAMPLE_MS=250, REC_MAX_SAMPLES=1200, REC_MAX_EVENTS=500, REC_MIN_MS=20000;
 let REC={t0:0,acc:0,samples:[],events:[]};
-let replaying=false,replayData=null,replayIdx=0,replayElapsed=0,replaySpeed=1,replaySaved=null;
+let replaying=false,replayData=null,replayIdx=0,replayElapsed=0,replaySpeed=1,replaySaved=null,replayIsOwn=false;
 function recTick(dt,now){
   if(paused||replaying||mode==='intro'||mode==='finale')return;
   REC.acc+=dt*1000;
   if(REC.acc<REC_SAMPLE_MS)return;
   REC.acc=0;
-  if(!REC.t0)REC.t0=now;
+  if(!REC.t0)REC.t0=now-(REC.resumeAt||0);
   const p=player.group.position;
   REC.samples.push([Math.round(now-REC.t0),Math.round(p.x*100)/100,Math.round(p.z*100)/100,
     Math.round(player.group.rotation.y*1000)/1000]);
@@ -1911,11 +1943,38 @@ function recTick(dt,now){
 /* call from wherever a fun, recordable moment happens — cheap, no-op while paused/replaying */
 function recEvent(type,extra){
   if(paused||replaying||mode==='intro'||mode==='finale')return;
-  if(!REC.t0)REC.t0=performance.now();
+  if(!REC.t0)REC.t0=performance.now()-(REC.resumeAt||0);
   REC.events.push([Math.round(performance.now()-REC.t0),type,extra===undefined?0:extra]);
   if(REC.events.length>REC_MAX_EVENTS)REC.events.shift();
 }
 function recordedSpanMs(){const s=REC.samples;return s.length<2?0:s[s.length-1][0]-s[0][0];}
+/* ---------- 💾 keep the adventure across visits (so My Movie survives a reload) ---------- */
+const REC_STORE_KEY='ellyTubbies.replay.v1';
+function persistRec(){
+  try{
+    if(REC.samples.length<2)return;
+    localStorage.setItem(REC_STORE_KEY,JSON.stringify({v:1,samples:REC.samples,events:REC.events}));
+  }catch(e){}
+}
+function loadPersistedRec(){
+  try{
+    const raw=localStorage.getItem(REC_STORE_KEY);if(!raw)return;
+    const d=JSON.parse(raw);
+    if(!d||d.v!==1||!Array.isArray(d.samples)||d.samples.length<2)return;
+    const samples=d.samples.filter(s=>Array.isArray(s)&&s.length>=4&&s.every(Number.isFinite))
+      .slice(-REC_MAX_SAMPLES);
+    if(samples.length<2)return;
+    const events=(Array.isArray(d.events)?d.events:[])
+      .filter(e=>Array.isArray(e)&&e.length>=2&&Number.isFinite(+e[0]))
+      .slice(-REC_MAX_EVENTS);
+    REC.samples=samples;REC.events=events;
+    /* when recording resumes, continue the timeline just after the saved adventure */
+    REC.resumeAt=samples[samples.length-1][0]+1000;
+  }catch(e){}
+}
+loadPersistedRec();
+document.addEventListener('visibilitychange',()=>{if(document.visibilityState==='hidden')persistRec();});
+addEventListener('pagehide',persistRec);
 /* re-fire ONLY the visual/sound flourish for a recorded moment — never state! */
 function replayFireEvent(type,extra){
   const p=player.group.position;
@@ -1952,13 +2011,15 @@ function replayFireEvent(type,extra){
   }
 }
 function angLerp(a,b,k){const d=((b-a+Math.PI*3)%(Math.PI*2))-Math.PI;return a+d*k;}
-function startReplay(data){
+function startReplay(data,isOwn){
   if(replaying||!data||!data.samples||data.samples.length<2)return;
+  replayIsOwn=!!isOwn;
   replaySaved={x:player.group.position.x,y:player.group.position.y,z:player.group.position.z,
     ry:player.group.rotation.y,mode,trav,
     jumpCount,trumpetCount,lastTrumpetNear,lastTrampAt,mischiefT,sunActT,questPoll};
   replaying=true;replayData={samples:data.samples,events:data.events||[],_evIdx:0};
   replayIdx=0;replayElapsed=0;replaySpeed=1;
+  hideSharePrompt();
   clearNarr();freeCam();clearChoices();
   duck=false;jumping=false;jumpY=0;kd=null;
   player.group.rotation.x=0;player.anim.inner.rotation.x=0;player.anim.inner.rotation.z=0;
@@ -1970,9 +2031,10 @@ function startReplay(data){
   const rs=$('replaySpeedBtn');if(rs)rs.textContent='1x';
   const rb=$('replayBar');if(rb)rb.classList.remove('hidden');
 }
-function endReplay(){
+function endReplay(natural){
   if(!replaying)return;
   replaying=false;
+  const wasOwn=replayIsOwn;replayIsOwn=false;
   const sv=replaySaved;replaySaved=null;
   if(sv){
     player.group.position.set(sv.x,sv.y,sv.z);player.group.rotation.y=sv.ry;
@@ -1986,6 +2048,21 @@ function endReplay(){
     $('funRow').classList.remove('hidden');}
   updateActBtn();
   sfx.tap();celebToast('What an adventure! 🌟',2400);
+  /* natural finish of the child's OWN movie (not a friend's import, not ⏹ stop):
+     one calm, skippable nudge to share it */
+  if(natural&&wasOwn)setTimeout(showSharePrompt,600);
+}
+/* ---------- 📤 share-this-adventure prompt (auto-dismisses; never blocks play) ---------- */
+function showSharePrompt(){
+  const el=$('sharePrompt');if(!el||replaying)return;
+  el.classList.add('show');
+  clearTimeout(showSharePrompt._t);
+  showSharePrompt._t=setTimeout(hideSharePrompt,8000);
+}
+function hideSharePrompt(){
+  const el=$('sharePrompt');if(!el)return;
+  el.classList.remove('show');
+  clearTimeout(showSharePrompt._t);
 }
 function updateReplay(dt,time){
   const data=replayData;const samples=data.samples;
@@ -2007,12 +2084,12 @@ function updateReplay(dt,time){
     data._evIdx++;
   }
   const lastT=samples[samples.length-1][0]-t0;
-  if(replayElapsed>=lastT)endReplay();
+  if(replayElapsed>=lastT)endReplay(true);
 }
 function tryStartOwnReplay(){
   if(mode!=='roam'){sfx.soft();celebToast('Let\'s finish this first! 💛',2000);return;}
   if(recordedSpanMs()<REC_MIN_MS){sfx.soft();celebToast('Play a little first, then watch your adventure! 🎬',2800);return;}
-  startReplay({samples:REC.samples.map(s=>s.slice()),events:REC.events.map(e=>e.slice())});
+  startReplay({samples:REC.samples.map(s=>s.slice()),events:REC.events.map(e=>e.slice())},true);
 }
 function buildExportPayload(){
   const samples=replaying?replayData.samples:REC.samples;
@@ -3236,9 +3313,17 @@ addEventListener('resize',resize);resize();
 
 /* ================================ UI wire ================================ */
 /* title screen (uniform across ABE games) */
-$('titlePlayBtn').onclick=()=>{ac();sfx.pop();
-  $('title').classList.add('hiddenT');mode='roam';lastInputAt=performance.now();wakeRitual();};
+function dismissTitle(){
+  if($('title').classList.contains('hiddenT'))return;
+  $('title').classList.add('hiddenT');mode='roam';lastInputAt=performance.now();wakeRitual();}
+$('titlePlayBtn').onclick=()=>{ac();sfx.pop();dismissTitle();};
 $('titleHowBtn').onclick=()=>{sfx.tap();$('intro').classList.add('show');};
+/* 🎬 last visit's adventure survives a reload — offer it right on the title screen.
+   The friend-import button is always available; "My Movie" needs a recording. */
+{const r=$('titleMovieRow');if(r)r.style.display='flex';
+ if(recordedSpanMs()<REC_MIN_MS)$('titleMovieBtn').style.display='none';}
+$('titleMovieBtn').onclick=()=>{ac();sfx.pop();dismissTitle();tryStartOwnReplay();};
+$('titleImportBtn').onclick=()=>{ac();sfx.tap();dismissTitle();$('importFile').click();};
 $('titleFsBtn').onclick=()=>{
   if(document.fullscreenElement)document.exitFullscreen();
   else document.documentElement.requestFullscreen().catch(()=>{});};
@@ -3316,6 +3401,13 @@ $('pauseBtn').onclick=()=>{sfx.tap();setPaused(true);};
 $('resumeBtn').onclick=()=>{sfx.tap();setPaused(false);};
 /* 🎬 replay: watch a recording of recent play (own, or an imported friend's) */
 $('replayBtn').onclick=()=>{sfx.tap();tryStartOwnReplay();};
+/* 📤 share: save the adventure as a file to send to a friend */
+$('shareBtn').onclick=()=>{
+  if(recordedSpanMs()>=REC_MIN_MS){sfx.tap();shareAdventure();celebToast('Adventure saved! Send it to a friend! 📤',2800);}
+  else{sfx.soft();celebToast('Play a little first, then share your adventure! 📤',2800);}};
+$('sharePromptYes').onclick=()=>{sfx.tap();hideSharePrompt();shareAdventure();
+  celebToast('Adventure saved! Send it to a friend! 📤',2800);};
+$('sharePromptNo').onclick=()=>{sfx.soft();hideSharePrompt();};
 $('setReplay').onclick=()=>{sfx.tap();$('settings').classList.remove('show');tryStartOwnReplay();};
 $('setImportReplay').onclick=()=>{sfx.tap();$('importFile').click();};
 $('importFile').addEventListener('change',e=>{

--- a/public/magnetblocks/index.html
+++ b/public/magnetblocks/index.html
@@ -49,6 +49,11 @@
     box-shadow:0 6px 0 #e8920c, 0 10px 18px rgba(0,0,0,.18); transition:transform .12s; }
   .bigBtn:hover { transform:scale(1.06); }
   .bigBtn:active { transform:translateY(4px); box-shadow:0 2px 0 #e8920c; }
+  #titleExtras { display:flex; flex-wrap:wrap; gap:12px; justify-content:center; padding:0 16px; }
+  .bigBtn.small { font-size:18px; min-height:48px; padding:10px 26px; border-radius:24px;
+    background:linear-gradient(180deg,#d0ebff,#74c0fc); color:#1c3d6b;
+    box-shadow:0 5px 0 #4098d7, 0 8px 14px rgba(0,0,0,.16); }
+  .bigBtn.small:active { box-shadow:0 2px 0 #4098d7; }
 
   /* ---------- HUD ---------- */
   #hud { position:fixed; inset:0; z-index:10; pointer-events:none; display:none; }
@@ -61,6 +66,7 @@
   .menuBtn:hover { transform:scale(1.08); background:#fff; }
   .menuBtn.on { background:#d0ebff; box-shadow:0 3px 8px rgba(0,0,0,.18), inset 0 0 0 3px #4dabf7; }
   #replayBtn { min-height:48px; background:linear-gradient(180deg,#bac8ff,#748ffc); color:#1c2e6b; }
+  #shareBtn { min-height:48px; background:linear-gradient(180deg,#ffd8a8,#ffa94d); color:#5c3200; }
 
   /* big round action buttons */
   .fab { border:none; border-radius:26px; cursor:pointer; pointer-events:auto; font-family:inherit;
@@ -196,6 +202,10 @@
     <div class="titleEmojis">🧲 🧱 🏠 🦋 🚗 ⭐</div>
     <div class="subtitle">Welcome to the playroom! Take blocks off the shelves, feel them <b>click</b> together like magic magnets, and build anything you dream of. Snap a photo to keep your creation safe in your school bag! 🎒</div>
     <button class="bigBtn" id="startBtn">Let's Build! 🧲</button>
+    <div id="titleExtras">
+      <button class="bigBtn small" id="titleMovieBtn" style="display:none">▶️ My Movie — watch your last build!</button>
+      <button class="bigBtn small" id="titleImportBtn">📥 Bring a friend's build</button>
+    </div>
     <div id="orgFooter">Aaria's Blue Elephant 🐘💙 — play, learn &amp; grow</div>
     <a id="disclosureLink" href="/legal/disclosure.html" target="_blank" rel="noopener">General Disclosure</a>
   </div>
@@ -212,8 +222,9 @@
     <div id="topRight">
       <button class="menuBtn" id="soundBtn">🔊</button>
       <button class="menuBtn" id="replayBtn" style="display:none">▶️ My Movie</button>
-      <button class="menuBtn" id="tableBtn">🟩 Table</button>
+      <button class="menuBtn" id="shareBtn" style="display:none">📤 Share</button>
       <button class="menuBtn" id="calmBtn" title="Calm mode">😌</button>
+      <button class="menuBtn" id="tableBtn">🟩 Table</button>
       <button class="menuBtn" id="tidyNowBtn">🧹 Tidy</button>
       <button class="menuBtn" id="clearBtn">🆕 New</button>
       <button class="menuBtn" id="parentBtn" title="Parent panel">👨‍👩‍👧</button>

--- a/public/magnetblocks/js/bag.js
+++ b/public/magnetblocks/js/bag.js
@@ -79,15 +79,27 @@ window.MB = window.MB || {};
   Bag.remove = function(id){ Bag.items = Bag.items.filter(i => i.id !== id); save(); };
 
   // ---- share/export: a tiny, personal-data-free JSON file a friend can bring back in ----
-  Bag.exportItem = function(item){
-    const payload = { app:'magnetblocks', v:1, name: item.name, pieces: item.pieces };
+  function downloadBuild(name, pieces){
+    const payload = { app:'magnetblocks', v:1, name: name, pieces: pieces };
     const blob = new Blob([JSON.stringify(payload)], { type:'application/json' });
     const url = URL.createObjectURL(blob);
-    const slug = (item.name || 'creation').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'creation';
+    const slug = (name || 'creation').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'creation';
     const a = document.createElement('a');
     a.href = url; a.download = slug + '.magnetblocks.json';
     document.body.appendChild(a); a.click();
     setTimeout(() => { document.body.removeChild(a); URL.revokeObjectURL(url); }, 200);
+  }
+
+  Bag.exportItem = function(item){
+    downloadBuild(item.name, item.pieces);
+  };
+
+  // share the LIVE table (not a saved school-bag item) — used by the 📤 share HUD button
+  Bag.exportTable = function(){
+    const pieces = Bag.serializeTable();
+    if (!pieces.length) return false;
+    downloadBuild('My Magnet Build', pieces);
+    return true;
   };
 
   // defensive shape check — never trust a dropped-in file

--- a/public/magnetblocks/js/main.js
+++ b/public/magnetblocks/js/main.js
@@ -229,8 +229,11 @@ window.MB = window.MB || {};
     } else hidePalette();
     const count = MB.Builder.placedCount();
     $('pieceChip').textContent = '🧱 ' + count;
+    const readyToShow = (!MB.Builder.locked && MB.Bag.serializeTable().length >= 3) ? 'inline-block' : 'none';
     const rb = $('replayBtn');
-    if (rb) rb.style.display = (!MB.Builder.locked && MB.Bag.serializeTable().length >= 3) ? 'inline-block' : 'none';
+    if (rb) rb.style.display = readyToShow;
+    const sb = $('shareBtn');
+    if (sb) sb.style.display = readyToShow;
     if (count >= 10) ui.milestone('ten', '🎉 10 blocks! Wow, look at all you built!');
     if (count >= 20) ui.milestone('twenty', '🎉 20 blocks! You are building something amazing!');
     if (count >= 40) ui.milestone('forty', '🌟 40 blocks! You are a building superstar!');
@@ -384,7 +387,9 @@ window.MB = window.MB || {};
     window.addEventListener('keyup', ev => { MB.Animate.keys[ev.code] = false; });
 
     // HUD buttons
-    $('startBtn').addEventListener('click', () => {
+    // shared by all title-screen buttons: hide the title, wake audio, greet
+    function startGame(){
+      if (started) return;
       MB.Audio.init(); MB.Audio.bgm(true);
       $('titleScreen').style.display = 'none';
       $('hud').style.display = 'block';
@@ -399,6 +404,9 @@ window.MB = window.MB || {};
         const e = 1 - Math.pow(1-k, 3);
         orbit.theta = th0 - 2.2*e + 0.5*0; orbit.radius = r0 - (r0-17)*e;
       });
+    }
+    $('startBtn').addEventListener('click', () => {
+      startGame();
       // offer to restore the last unsaved table, if any
       const auto = MB.Bag.loadAutosave();
       if (auto.length){
@@ -407,6 +415,20 @@ window.MB = window.MB || {};
           () => { MB.Bag.clearAutosave(); },
           'Yes! 🧲', 'Fresh table');
       }
+    });
+    // ▶️ My Movie from the title screen: restore the autosaved table (no confirm), then replay it
+    if (MB.Bag.loadAutosave().length >= 3) $('titleMovieBtn').style.display = 'inline-block';
+    $('titleMovieBtn').addEventListener('click', () => {
+      startGame();
+      const auto = MB.Bag.loadAutosave();
+      if (auto.length < 3) return; // autosave vanished under us — just start normally
+      MB.Bag.rebuildPieces(auto, scene); updateSelBar(); MB.Undo && MB.Undo.push();
+      setTimeout(() => MB.Replay.playTable(scene), 600);
+    });
+    // 📥 Bring a friend's build from the title screen: start, then open the import picker
+    $('titleImportBtn').addEventListener('click', () => {
+      startGame();
+      $('importFile').click();
     });
     $('homeBtn').addEventListener('click', () => ui.confirm('Leave the playroom? 🏠', 'Your school bag creations stay saved!', () => location.href = '/'));
     $('soundBtn').addEventListener('click', () => {
@@ -436,6 +458,9 @@ window.MB = window.MB || {};
     $('bagBtn').addEventListener('click', openBag);
     $('bagClose').addEventListener('click', () => ui.hide('bagModal'));
     $('replayBtn').addEventListener('click', () => MB.Replay.playTable(scene));
+    $('shareBtn').addEventListener('click', () => {
+      if (MB.Bag.exportTable()){ MB.Audio.sparkle(); ui.toast('Saved! Send it to a friend! 📤', 2600); }
+    });
     $('replayStopBtn').addEventListener('click', () => MB.Replay.stop());
     $('importBtn').addEventListener('click', () => $('importFile').click());
     $('importFile').addEventListener('change', (ev) => {


### PR DESCRIPTION
- 📤 Share button on the HUD in Elly-Tubbies, Block Craft, Magnet Blocks (uniform slot after ▶️ My Movie) and on the replay/timelapse bars while playing — share without finishing the movie
- Title screens now offer ▶️ My Movie (last adventure/world/build) and 📥 load a friend's game before playing; Elly's adventure recording persists across reloads
- Verified control-standard order (🔊 → ⏸️ → ▶️ → 📤 → … → ⚙️) by direct markup inspection in all 7 games; fixed Elly's friend-import being gated on having your own recording

Verified: node --check on all game JS incl. inline scripts; full build + prerender + minify passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)