### PR TITLE
Smart Play — resume last game + first-visit sampler

### DIFF
--- a/components/game/BelusWorld/index.tsx
+++ b/components/game/BelusWorld/index.tsx
@@ -197,6 +197,19 @@ export default function BelusWorldGame() {
     try { localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings)); } catch { /* ignore */ }
   }, [settings]);
 
+  // stamp "last game played" so the Home page's smart Play button can offer
+  // to resume Nilu's World alongside the other static games
+  useEffect(() => {
+    try {
+      localStorage.setItem('abe_last_game', JSON.stringify({
+        url: '/nelus-world',
+        name: "Nilu's World",
+        emoji: '🌈',
+        at: Date.now(),
+      }));
+    } catch { /* ignore */ }
+  }, []);
+
   const cycleSpeed = useCallback(() => {
     setSettings((s) => {
       const next = SPEED_ORDER[(SPEED_ORDER.indexOf(s.speed) + 1) % SPEED_ORDER.length];

--- a/pages/Home.tsx
+++ b/pages/Home.tsx
@@ -57,6 +57,24 @@ const imagesToPreload = [
 // Track initial app load to allow random initialization on refresh but skip on internal navigation
 let isAppInitialLoad = true;
 
+// The games kids can play — used to power the smart "Play" button on Home.
+// Nilu's Helping Hands is excluded from the random "surprise me" pool since
+// it's password-gated safety-ed content, not open-ended free play.
+type PlayGame = { url: string; name: string; emoji: string; isReactRoute?: boolean; sampler?: boolean };
+const RANDOM_GAMES: PlayGame[] = [
+    { url: '/elly-tubbies/index.html', name: 'Elly-Tubbies', emoji: '🐘', sampler: true },
+    { url: '/blockcraft/index.html', name: 'Block Craft 3D', emoji: '🧱', sampler: true },
+    { url: '/roadsafety/index.html', name: 'Road Safety Heroes', emoji: '🚴', sampler: true },
+    { url: '/doughlab/index.html', name: 'Dough Lab', emoji: '🌈', sampler: true },
+    { url: '/magnetblocks/index.html', name: 'Magnet Blocks', emoji: '🧲', sampler: true },
+];
+
+type LastGame = { url: string; name: string; emoji: string; at: number };
+
+function pickRandomGame(): PlayGame {
+    return RANDOM_GAMES[Math.floor(Math.random() * RANDOM_GAMES.length)];
+}
+
 const Home: React.FC = () => {
     // Animations play on full refresh (isAppInitialLoad is true)
     // but skip on internal navigation (isAppInitialLoad becomes false after first mount)
@@ -122,6 +140,24 @@ const Home: React.FC = () => {
     const a = (cls: string) => shouldAnimate ? cls : '';
 
     const [isHydrated, setIsHydrated] = useState(false);
+    const [lastGame, setLastGame] = useState<LastGame | null>(null);
+
+    // Read the "last game played" stamp (written by each game on mount) so
+    // we can offer a one-tap "keep playing" button on first paint.
+    useEffect(() => {
+        try {
+            const raw = localStorage.getItem('abe_last_game');
+            if (raw) setLastGame(JSON.parse(raw));
+        } catch { /* ignore */ }
+    }, []);
+
+    // "Surprise me" — picks a random static game and appends ?sampler=1 so
+    // it can show a lightweight taste of the game to a first-time visitor.
+    const goToRandomGame = () => {
+        const game = pickRandomGame();
+        const dest = game.sampler ? `${game.url}?sampler=1` : game.url;
+        window.location.href = dest;
+    };
 
     useEffect(() => {
         setIsHydrated(true);
@@ -390,11 +426,66 @@ const Home: React.FC = () => {
                 </div>
             </section>
 
-            {/* Play Nilu's World — free, kid-facing 3D game built for Aaria & friends.
+            {/* Play — free, kid-facing games built for Aaria & friends.
                 Kept simple/warm rather than matching the marketing sections above,
-                since this card is for kids and parents to click through and play. */}
+                since this card is for kids and parents to click through and play.
+                Smart: offers to resume the last game played, or picks a random
+                one for first-time visitors. */}
             <section className="pb-20 bg-white dark:bg-slate-900 transition-colors">
-                <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+                <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 space-y-6">
+                    <div
+                        className="group relative flex flex-col items-center gap-4 overflow-hidden rounded-3xl border border-sky-100 dark:border-sky-900 p-10 text-center shadow-sm transition-all sm:flex-row sm:text-left"
+                        style={{ background: 'linear-gradient(120deg,#eaf6ff,#fef6e4)' }}
+                    >
+                        <div className="text-6xl transition-transform group-hover:scale-110">
+                            {lastGame ? lastGame.emoji : '🎲'}
+                        </div>
+                        <div className="flex-1">
+                            <h3 className="text-2xl font-black text-sky-700">
+                                {lastGame ? `Keep playing ${lastGame.name}` : 'Play — surprise me!'}
+                            </h3>
+                            <p className="mt-1 text-slate-600 dark:text-slate-500">
+                                {lastGame
+                                    ? `Jump back into ${lastGame.name} right where you left off.`
+                                    : 'Free, no-fail games built for Aaria and her friends — pick a game at random and see what you get. No login needed.'}
+                            </p>
+                        </div>
+                        <div className="flex flex-none flex-col items-center gap-3 sm:items-end">
+                            {lastGame ? (
+                                lastGame.url === '/nelus-world' ? (
+                                    <Link
+                                        to="/nelus-world"
+                                        className="rounded-full bg-sky-500 px-8 py-3 text-lg font-bold text-white shadow-lg transition hover:bg-sky-400"
+                                    >
+                                        ▶️ Keep playing {lastGame.name} {lastGame.emoji}
+                                    </Link>
+                                ) : (
+                                    <a
+                                        href={lastGame.url}
+                                        className="rounded-full bg-sky-500 px-8 py-3 text-lg font-bold text-white shadow-lg transition hover:bg-sky-400"
+                                    >
+                                        ▶️ Keep playing {lastGame.name} {lastGame.emoji}
+                                    </a>
+                                )
+                            ) : (
+                                <button
+                                    type="button"
+                                    onClick={goToRandomGame}
+                                    className="rounded-full bg-sky-500 px-8 py-3 text-lg font-bold text-white shadow-lg transition hover:bg-sky-400"
+                                >
+                                    ▶️ Play — surprise me!
+                                </button>
+                            )}
+                            <button
+                                type="button"
+                                onClick={goToRandomGame}
+                                className="rounded-full bg-white/80 dark:bg-slate-800/80 border border-sky-200 dark:border-sky-800 px-5 py-2 text-sm font-bold text-sky-600 dark:text-sky-300 shadow transition hover:bg-white"
+                            >
+                                🎲 Surprise me!
+                            </button>
+                        </div>
+                    </div>
+
                     <Link
                         to="/nelus-world"
                         className="group relative flex flex-col items-center gap-4 overflow-hidden rounded-3xl border border-sky-100 dark:border-sky-900 p-10 text-center shadow-sm transition-all hover:-translate-y-1 hover:shadow-xl sm:flex-row sm:text-left"

--- a/prerender.js
+++ b/prerender.js
@@ -53,7 +53,13 @@ async function prerender() {
                 const url = `http://localhost:${PORT}${route}`;
                 console.log(`Prerendering ${url}...`);
 
-                await page.goto(url, { waitUntil: 'networkidle0' });
+                // networkidle0 can hang on analytics keep-alives — retry with a looser wait
+                try {
+                    await page.goto(url, { waitUntil: 'networkidle0', timeout: 30000 });
+                } catch (e) {
+                    console.warn(`  networkidle0 timed out for ${route}, retrying with networkidle2…`);
+                    await page.goto(url, { waitUntil: 'networkidle2', timeout: 45000 });
+                }
 
                 // Ensure animations/hydration complete
                 await new Promise(r => setTimeout(r, 1500));

--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -420,6 +420,40 @@
 </head>
 <body>
     <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
+<script>
+(function(){
+try{localStorage.setItem('abe_last_game',JSON.stringify({url:'/blockcraft/index.html',name:'Block Craft 3D',emoji:'🧱',at:Date.now()}))}catch(e){}
+try{
+  var qs=location.search||'';
+  if(/(^|[?&])sampler=1(&|$)/.test(qs)){
+    setTimeout(function(){
+      if(document.getElementById('abeSamplerOverlay'))return;
+      var ov=document.createElement('div');
+      ov.id='abeSamplerOverlay';
+      ov.style.cssText='position:fixed;inset:0;z-index:999999;background:rgba(0,0,0,0.55);display:flex;align-items:center;justify-content:center;pointer-events:none;';
+      var card=document.createElement('div');
+      card.style.cssText='pointer-events:auto;background:#fff;border-radius:24px;padding:28px 24px;max-width:340px;width:88%;text-align:center;box-shadow:0 12px 40px rgba(0,0,0,0.3);font-family:system-ui,-apple-system,sans-serif;';
+      var msg=document.createElement('div');
+      msg.textContent='That was fun! Want to try another game? 🎮';
+      msg.style.cssText='font-size:20px;font-weight:700;color:#222;margin-bottom:20px;line-height:1.3;';
+      card.appendChild(msg);
+      var moreBtn=document.createElement('button');
+      moreBtn.textContent='🎮 More games';
+      moreBtn.style.cssText='display:block;width:100%;min-height:48px;font-size:17px;font-weight:700;border:none;border-radius:14px;background:#3b82f6;color:#fff;margin-bottom:12px;cursor:pointer;padding:12px;';
+      moreBtn.onclick=function(){location.href='/';};
+      card.appendChild(moreBtn);
+      var keepBtn=document.createElement('button');
+      keepBtn.textContent='Keep playing 💙';
+      keepBtn.style.cssText='display:block;width:100%;min-height:48px;font-size:17px;font-weight:700;border:none;border-radius:14px;background:#e2e8f0;color:#333;cursor:pointer;padding:12px;';
+      keepBtn.onclick=function(){ov.remove();};
+      card.appendChild(keepBtn);
+      ov.appendChild(card);
+      document.body.appendChild(ov);
+    },180000);
+  }
+}catch(e){}
+})();
+</script>
 <div id="loadingOverlay">
   <img src="logo.png" alt="">
   <div class="loadSpin"></div>

--- a/public/doughlab/index.html
+++ b/public/doughlab/index.html
@@ -218,6 +218,40 @@
 </head>
 <body>
     <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
+<script>
+(function(){
+try{localStorage.setItem('abe_last_game',JSON.stringify({url:'/doughlab/index.html',name:'Dough Lab',emoji:'🌈',at:Date.now()}))}catch(e){}
+try{
+  var qs=location.search||'';
+  if(/(^|[?&])sampler=1(&|$)/.test(qs)){
+    setTimeout(function(){
+      if(document.getElementById('abeSamplerOverlay'))return;
+      var ov=document.createElement('div');
+      ov.id='abeSamplerOverlay';
+      ov.style.cssText='position:fixed;inset:0;z-index:999999;background:rgba(0,0,0,0.55);display:flex;align-items:center;justify-content:center;pointer-events:none;';
+      var card=document.createElement('div');
+      card.style.cssText='pointer-events:auto;background:#fff;border-radius:24px;padding:28px 24px;max-width:340px;width:88%;text-align:center;box-shadow:0 12px 40px rgba(0,0,0,0.3);font-family:system-ui,-apple-system,sans-serif;';
+      var msg=document.createElement('div');
+      msg.textContent='That was fun! Want to try another game? 🎮';
+      msg.style.cssText='font-size:20px;font-weight:700;color:#222;margin-bottom:20px;line-height:1.3;';
+      card.appendChild(msg);
+      var moreBtn=document.createElement('button');
+      moreBtn.textContent='🎮 More games';
+      moreBtn.style.cssText='display:block;width:100%;min-height:48px;font-size:17px;font-weight:700;border:none;border-radius:14px;background:#3b82f6;color:#fff;margin-bottom:12px;cursor:pointer;padding:12px;';
+      moreBtn.onclick=function(){location.href='/';};
+      card.appendChild(moreBtn);
+      var keepBtn=document.createElement('button');
+      keepBtn.textContent='Keep playing 💙';
+      keepBtn.style.cssText='display:block;width:100%;min-height:48px;font-size:17px;font-weight:700;border:none;border-radius:14px;background:#e2e8f0;color:#333;cursor:pointer;padding:12px;';
+      keepBtn.onclick=function(){ov.remove();};
+      card.appendChild(keepBtn);
+      ov.appendChild(card);
+      document.body.appendChild(ov);
+    },180000);
+  }
+}catch(e){}
+})();
+</script>
 
 <div id="titleScreen">
   <img id="logoImg" src="logo.png" alt="Aaria's Blue Elephant" onerror="this.style.display='none'">

--- a/public/elly-tubbies/index.html
+++ b/public/elly-tubbies/index.html
@@ -270,6 +270,40 @@
 </head>
 <body>
     <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
+<script>
+(function(){
+try{localStorage.setItem('abe_last_game',JSON.stringify({url:'/elly-tubbies/index.html',name:'Elly-Tubbies',emoji:'🐘',at:Date.now()}))}catch(e){}
+try{
+  var qs=location.search||'';
+  if(/(^|[?&])sampler=1(&|$)/.test(qs)){
+    setTimeout(function(){
+      if(document.getElementById('abeSamplerOverlay'))return;
+      var ov=document.createElement('div');
+      ov.id='abeSamplerOverlay';
+      ov.style.cssText='position:fixed;inset:0;z-index:999999;background:rgba(0,0,0,0.55);display:flex;align-items:center;justify-content:center;pointer-events:none;';
+      var card=document.createElement('div');
+      card.style.cssText='pointer-events:auto;background:#fff;border-radius:24px;padding:28px 24px;max-width:340px;width:88%;text-align:center;box-shadow:0 12px 40px rgba(0,0,0,0.3);font-family:system-ui,-apple-system,sans-serif;';
+      var msg=document.createElement('div');
+      msg.textContent='That was fun! Want to try another game? 🎮';
+      msg.style.cssText='font-size:20px;font-weight:700;color:#222;margin-bottom:20px;line-height:1.3;';
+      card.appendChild(msg);
+      var moreBtn=document.createElement('button');
+      moreBtn.textContent='🎮 More games';
+      moreBtn.style.cssText='display:block;width:100%;min-height:48px;font-size:17px;font-weight:700;border:none;border-radius:14px;background:#3b82f6;color:#fff;margin-bottom:12px;cursor:pointer;padding:12px;';
+      moreBtn.onclick=function(){location.href='/';};
+      card.appendChild(moreBtn);
+      var keepBtn=document.createElement('button');
+      keepBtn.textContent='Keep playing 💙';
+      keepBtn.style.cssText='display:block;width:100%;min-height:48px;font-size:17px;font-weight:700;border:none;border-radius:14px;background:#e2e8f0;color:#333;cursor:pointer;padding:12px;';
+      keepBtn.onclick=function(){ov.remove();};
+      card.appendChild(keepBtn);
+      ov.appendChild(card);
+      document.body.appendChild(ov);
+    },180000);
+  }
+}catch(e){}
+})();
+</script>
   <canvas id="cv" role="application" aria-label="Trunkland — a 3D world you explore as Nilu the elephant"></canvas>
   <div id="loading"><div class="ele">🐘</div><div class="lbl">Waking up Trunkland…</div></div>
 

--- a/public/helpinghands/index.html
+++ b/public/helpinghands/index.html
@@ -596,6 +596,40 @@
 </head>
 <body>
     <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
+<script>
+(function(){
+try{localStorage.setItem('abe_last_game',JSON.stringify({url:'/helpinghands/index.html',name:'Nilu\'s Helping Hands',emoji:'🖐️',at:Date.now()}))}catch(e){}
+try{
+  var qs=location.search||'';
+  if(/(^|[?&])sampler=1(&|$)/.test(qs)){
+    setTimeout(function(){
+      if(document.getElementById('abeSamplerOverlay'))return;
+      var ov=document.createElement('div');
+      ov.id='abeSamplerOverlay';
+      ov.style.cssText='position:fixed;inset:0;z-index:999999;background:rgba(0,0,0,0.55);display:flex;align-items:center;justify-content:center;pointer-events:none;';
+      var card=document.createElement('div');
+      card.style.cssText='pointer-events:auto;background:#fff;border-radius:24px;padding:28px 24px;max-width:340px;width:88%;text-align:center;box-shadow:0 12px 40px rgba(0,0,0,0.3);font-family:system-ui,-apple-system,sans-serif;';
+      var msg=document.createElement('div');
+      msg.textContent='That was fun! Want to try another game? 🎮';
+      msg.style.cssText='font-size:20px;font-weight:700;color:#222;margin-bottom:20px;line-height:1.3;';
+      card.appendChild(msg);
+      var moreBtn=document.createElement('button');
+      moreBtn.textContent='🎮 More games';
+      moreBtn.style.cssText='display:block;width:100%;min-height:48px;font-size:17px;font-weight:700;border:none;border-radius:14px;background:#3b82f6;color:#fff;margin-bottom:12px;cursor:pointer;padding:12px;';
+      moreBtn.onclick=function(){location.href='/';};
+      card.appendChild(moreBtn);
+      var keepBtn=document.createElement('button');
+      keepBtn.textContent='Keep playing 💙';
+      keepBtn.style.cssText='display:block;width:100%;min-height:48px;font-size:17px;font-weight:700;border:none;border-radius:14px;background:#e2e8f0;color:#333;cursor:pointer;padding:12px;';
+      keepBtn.onclick=function(){ov.remove();};
+      card.appendChild(keepBtn);
+      ov.appendChild(card);
+      document.body.appendChild(ov);
+    },180000);
+  }
+}catch(e){}
+})();
+</script>
 
 <div id="bgShapes"><i></i><i></i><i></i></div>
 

--- a/public/magnetblocks/index.html
+++ b/public/magnetblocks/index.html
@@ -195,6 +195,40 @@
 </head>
 <body>
     <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
+<script>
+(function(){
+try{localStorage.setItem('abe_last_game',JSON.stringify({url:'/magnetblocks/index.html',name:'Magnet Blocks',emoji:'🧲',at:Date.now()}))}catch(e){}
+try{
+  var qs=location.search||'';
+  if(/(^|[?&])sampler=1(&|$)/.test(qs)){
+    setTimeout(function(){
+      if(document.getElementById('abeSamplerOverlay'))return;
+      var ov=document.createElement('div');
+      ov.id='abeSamplerOverlay';
+      ov.style.cssText='position:fixed;inset:0;z-index:999999;background:rgba(0,0,0,0.55);display:flex;align-items:center;justify-content:center;pointer-events:none;';
+      var card=document.createElement('div');
+      card.style.cssText='pointer-events:auto;background:#fff;border-radius:24px;padding:28px 24px;max-width:340px;width:88%;text-align:center;box-shadow:0 12px 40px rgba(0,0,0,0.3);font-family:system-ui,-apple-system,sans-serif;';
+      var msg=document.createElement('div');
+      msg.textContent='That was fun! Want to try another game? 🎮';
+      msg.style.cssText='font-size:20px;font-weight:700;color:#222;margin-bottom:20px;line-height:1.3;';
+      card.appendChild(msg);
+      var moreBtn=document.createElement('button');
+      moreBtn.textContent='🎮 More games';
+      moreBtn.style.cssText='display:block;width:100%;min-height:48px;font-size:17px;font-weight:700;border:none;border-radius:14px;background:#3b82f6;color:#fff;margin-bottom:12px;cursor:pointer;padding:12px;';
+      moreBtn.onclick=function(){location.href='/';};
+      card.appendChild(moreBtn);
+      var keepBtn=document.createElement('button');
+      keepBtn.textContent='Keep playing 💙';
+      keepBtn.style.cssText='display:block;width:100%;min-height:48px;font-size:17px;font-weight:700;border:none;border-radius:14px;background:#e2e8f0;color:#333;cursor:pointer;padding:12px;';
+      keepBtn.onclick=function(){ov.remove();};
+      card.appendChild(keepBtn);
+      ov.appendChild(card);
+      document.body.appendChild(ov);
+    },180000);
+  }
+}catch(e){}
+})();
+</script>
   <div id="titleScreen">
     <img id="logoImg" src="logo.png" alt="Aaria's Blue Elephant" onerror="this.style.display='none'">
     <h1>Aaria's Magnet Blocks</h1>

--- a/public/roadsafety/index.html
+++ b/public/roadsafety/index.html
@@ -22,6 +22,40 @@
 </head>
 <body>
     <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
+<script>
+(function(){
+try{localStorage.setItem('abe_last_game',JSON.stringify({url:'/roadsafety/index.html',name:'Road Safety Heroes',emoji:'🚴',at:Date.now()}))}catch(e){}
+try{
+  var qs=location.search||'';
+  if(/(^|[?&])sampler=1(&|$)/.test(qs)){
+    setTimeout(function(){
+      if(document.getElementById('abeSamplerOverlay'))return;
+      var ov=document.createElement('div');
+      ov.id='abeSamplerOverlay';
+      ov.style.cssText='position:fixed;inset:0;z-index:999999;background:rgba(0,0,0,0.55);display:flex;align-items:center;justify-content:center;pointer-events:none;';
+      var card=document.createElement('div');
+      card.style.cssText='pointer-events:auto;background:#fff;border-radius:24px;padding:28px 24px;max-width:340px;width:88%;text-align:center;box-shadow:0 12px 40px rgba(0,0,0,0.3);font-family:system-ui,-apple-system,sans-serif;';
+      var msg=document.createElement('div');
+      msg.textContent='That was fun! Want to try another game? 🎮';
+      msg.style.cssText='font-size:20px;font-weight:700;color:#222;margin-bottom:20px;line-height:1.3;';
+      card.appendChild(msg);
+      var moreBtn=document.createElement('button');
+      moreBtn.textContent='🎮 More games';
+      moreBtn.style.cssText='display:block;width:100%;min-height:48px;font-size:17px;font-weight:700;border:none;border-radius:14px;background:#3b82f6;color:#fff;margin-bottom:12px;cursor:pointer;padding:12px;';
+      moreBtn.onclick=function(){location.href='/';};
+      card.appendChild(moreBtn);
+      var keepBtn=document.createElement('button');
+      keepBtn.textContent='Keep playing 💙';
+      keepBtn.style.cssText='display:block;width:100%;min-height:48px;font-size:17px;font-weight:700;border:none;border-radius:14px;background:#e2e8f0;color:#333;cursor:pointer;padding:12px;';
+      keepBtn.onclick=function(){ov.remove();};
+      card.appendChild(keepBtn);
+      ov.appendChild(card);
+      document.body.appendChild(ov);
+    },180000);
+  }
+}catch(e){}
+})();
+</script>
 <canvas id="gl" aria-hidden="true"></canvas>
 <div id="loadingOverlay">
   <div id="loadingSpinner" aria-hidden="true"></div>


### PR DESCRIPTION
- All 7 games stamp `abe_last_game` in localStorage on launch
- Home's play section is now smart: **▶️ Keep playing {last game}** when the kid has played before; first-ever visit gets **▶️ Play — surprise me!** → a random game in sampler mode; **🎲 Surprise me!** always available (Helping Hands excluded from random — gated safety content)
- Sampler mode (`?sampler=1`): after 3 minutes the game shows a gentle card — **🎮 More games** (back to the site) or **Keep playing 💙**. Deliberately not a forced exit: yanking a child out mid-play is the unpredictable transition our games avoid.
- Games already auto-save state everywhere, so 'keep playing' resumes seamlessly.
- Also fixes flaky prerender builds (networkidle2 retry when analytics keep-alives hang networkidle0).

Verified: inline scripts node --check clean, tsc clean, full build + prerender + minify passes, smart-play markup present in dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)