### PR TITLE
Nilu's World: forward-chained islands, move-the-blocks activities, daily shuffle

### DIFF
--- a/components/game/BelusWorld/index.tsx
+++ b/components/game/BelusWorld/index.tsx
@@ -1072,7 +1072,7 @@ function IslandFormedToast({ info, reduceMotion, onClose }: { info: { zone: Acti
         <div className="text-6xl">{info.emoji}</div>
         <h2 className="mt-2 text-xl font-black text-slate-800">A new island appeared!</h2>
         <p className="mt-1 text-base font-bold text-sky-600">{info.label} just formed in the sky ✨</p>
-        <p className="mt-1 text-xs font-semibold text-slate-400">Follow the new rainbow bridge from Home!</p>
+        <p className="mt-1 text-xs font-semibold text-slate-400">Follow the new rainbow bridge to explore!</p>
         <button
           onClick={onClose}
           className="mt-4 rounded-full bg-sky-500 px-7 py-2.5 text-base font-bold text-white shadow-lg transition active:scale-95"

--- a/components/game/BelusWorld/three/GameCanvas.tsx
+++ b/components/game/BelusWorld/three/GameCanvas.tsx
@@ -246,6 +246,7 @@ export default function GameCanvas({
           level={islandNextLevel.mountain}
           paused={paused}
           reduceMotion={reduceMotion}
+          dateKey={dateKey}
           speak={speak}
           setEmotion={setEmotion}
           playSound={playSound}

--- a/components/game/BelusWorld/three/quest/CarryItem.tsx
+++ b/components/game/BelusWorld/three/quest/CarryItem.tsx
@@ -1,0 +1,71 @@
+// ---------------------------------------------------------------------------
+// A carryable thing — floats on its pedestal until Nilu walks into it, then
+// hovers just over her head (gently bobbing) while she carries it to the
+// right numbered pad / table. Walking into a slot/table hands it off; the
+// QuestLayer clears `carrying` and the item either disappears (placed) or
+// this component simply resumes floating on its own pedestal (returned).
+// ---------------------------------------------------------------------------
+
+import { useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { makeLabelTexture } from './emojiTexture';
+import { beluPos } from '../playerState';
+
+interface Props {
+  pedestalPosition: [number, number, number];
+  emoji: string;
+  caption?: string;
+  color: string;
+  carrying: boolean;
+  reduceMotion: boolean;
+  bobSeed?: number;
+}
+
+const HEAD_HEIGHT = 2.15;
+
+export default function CarryItem({
+  pedestalPosition, emoji, caption, color, carrying, reduceMotion, bobSeed = 0,
+}: Props) {
+  const grp = useRef<THREE.Group>(null);
+  const t = useRef(bobSeed);
+  const tex = useMemo(() => makeLabelTexture(emoji, caption), [emoji, caption]);
+
+  useFrame((_, dt) => {
+    t.current += dt;
+    const g = grp.current;
+    if (!g) return;
+    if (carrying) {
+      const bob = reduceMotion ? 0 : Math.sin(t.current * 3) * 0.1;
+      g.position.set(beluPos.x, beluPos.y + HEAD_HEIGHT + bob, beluPos.z);
+    } else {
+      const bob = reduceMotion ? 0 : Math.sin(t.current * 2) * 0.14;
+      g.position.set(pedestalPosition[0], pedestalPosition[1] + bob, pedestalPosition[2]);
+    }
+  });
+
+  return (
+    <group ref={grp} position={pedestalPosition}>
+      <mesh>
+        <sphereGeometry args={[0.42, 20, 16]} />
+        <meshStandardMaterial
+          color={color}
+          emissive={color}
+          emissiveIntensity={carrying ? 1.5 : 0.9}
+          roughness={0.3}
+          transparent
+          opacity={0.8}
+        />
+      </mesh>
+      <sprite position={[0, 0.1, 0]} scale={[1.5, 1.5, 1]} renderOrder={10}>
+        <spriteMaterial map={tex} transparent depthWrite={false} depthTest={false} />
+      </sprite>
+      {!carrying && (
+        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.5, 0]}>
+          <ringGeometry args={[0.4, 0.56, 24]} />
+          <meshBasicMaterial color={color} transparent opacity={0.5} side={THREE.DoubleSide} />
+        </mesh>
+      )}
+    </group>
+  );
+}

--- a/components/game/BelusWorld/three/quest/CarrySlot.tsx
+++ b/components/game/BelusWorld/three/quest/CarrySlot.tsx
@@ -1,0 +1,122 @@
+// ---------------------------------------------------------------------------
+// A glowing pad in the world Nilu walks onto to deliver (or step through) a
+// round. Two faces, same component:
+//   • numbered mode  — a big numeral (1/2/3…) for carry-in-order slots and
+//                       stepping-stone paths.
+//   • sign mode      — a big emoji + caption card for sort-round tables/bins.
+// Reuses makeLabelTexture from emojiTexture.ts for sign mode; numeral mode
+// paints its own tiny canvas texture locally (no shared-file edits needed).
+// ---------------------------------------------------------------------------
+
+import { useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { makeLabelTexture } from './emojiTexture';
+
+export type SlotStatus = 'idle' | 'next' | 'filled' | 'wrong';
+
+interface Props {
+  position: [number, number, number];
+  status: SlotStatus;
+  color: string;
+  reduceMotion: boolean;
+  /** numbered mode */
+  number?: number;
+  /** numbered mode: override the plain numeral with a short caption */
+  label?: string;
+  /** sign mode: a table/bin shows an emoji + caption instead of a number */
+  emoji?: string;
+  caption?: string;
+}
+
+const numberTexCache = new Map<string, THREE.CanvasTexture>();
+
+/** A big bold numeral (or short word) painted on its own canvas — local to
+ *  this file so we never need to touch the shared emojiTexture.ts. */
+function makeNumberTexture(text: string): THREE.CanvasTexture {
+  const hit = numberTexCache.get(text);
+  if (hit) return hit;
+  const W = 256;
+  const H = 256;
+  const canvas = document.createElement('canvas');
+  canvas.width = W;
+  canvas.height = H;
+  const ctx = canvas.getContext('2d')!;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.lineJoin = 'round';
+  const big = text.length <= 2;
+  ctx.font = `900 ${big ? 150 : 56}px Inter, system-ui, sans-serif`;
+  ctx.lineWidth = 16;
+  ctx.strokeStyle = 'rgba(20,20,32,0.85)';
+  ctx.strokeText(text, W / 2, H / 2);
+  ctx.fillStyle = '#ffffff';
+  ctx.fillText(text, W / 2, H / 2);
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  tex.anisotropy = 4;
+  tex.needsUpdate = true;
+  numberTexCache.set(text, tex);
+  return tex;
+}
+
+export default function CarrySlot({
+  position, status, color, reduceMotion, number, label, emoji, caption,
+}: Props) {
+  const grp = useRef<THREE.Group>(null);
+  const t = useRef((number ?? 0) * 0.6);
+  const isSign = !!emoji;
+  const numTex = useMemo(() => makeNumberTexture(label ?? String(number ?? '')), [label, number]);
+  const signTex = useMemo(
+    () => (isSign ? makeLabelTexture(emoji!, caption, true, color) : null),
+    [isSign, emoji, caption, color],
+  );
+
+  useFrame((_, dt) => {
+    t.current += dt;
+    const g = grp.current;
+    if (!g) return;
+    let x = position[0];
+    let scale = 1;
+    if (status === 'wrong') {
+      if (!reduceMotion) x += Math.sin(t.current * 40) * 0.12;
+      scale = 0.98;
+    } else if (status === 'next') {
+      scale = reduceMotion ? 1.06 : 1 + Math.sin(t.current * 2.2) * 0.07;
+    } else if (status === 'filled') {
+      scale = 1.05;
+    }
+    g.position.x = x;
+    g.scale.setScalar(scale);
+  });
+
+  const glow =
+    status === 'filled' ? '#ffe066' : status === 'wrong' ? '#ff8a80' : status === 'next' ? color : color;
+  const padOpacity = status === 'idle' ? 0.55 : 0.9;
+  const emissive = status === 'idle' ? 0.4 : status === 'wrong' ? 1.3 : 1.1;
+
+  return (
+    <group ref={grp} position={position}>
+      <mesh rotation={[-Math.PI / 2, 0, 0]}>
+        <cylinderGeometry args={[isSign ? 0.85 : 0.62, isSign ? 0.95 : 0.7, 0.14, 24]} />
+        <meshStandardMaterial
+          color={glow}
+          emissive={glow}
+          emissiveIntensity={emissive}
+          roughness={0.35}
+          transparent
+          opacity={padOpacity}
+        />
+      </mesh>
+      <sprite position={[0, isSign ? 1.0 : 0.5, 0]} scale={isSign ? [1.7, 1.7, 1] : [1.1, 1.1, 1]} renderOrder={9}>
+        <spriteMaterial map={isSign ? signTex! : numTex} transparent depthWrite={false} depthTest={false} />
+      </sprite>
+      {status === 'filled' && (
+        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.1, 0]}>
+          <ringGeometry args={[isSign ? 1.0 : 0.72, isSign ? 1.15 : 0.86, 28]} />
+          <meshBasicMaterial color="#ffe066" transparent opacity={0.55} side={THREE.DoubleSide} />
+        </mesh>
+      )}
+    </group>
+  );
+}

--- a/components/game/BelusWorld/three/quest/MountainLayer.tsx
+++ b/components/game/BelusWorld/three/quest/MountainLayer.tsx
@@ -12,15 +12,16 @@
 // Mirrors StoryLayer's frame-ref + arm/disarm/finish structure exactly.
 // ---------------------------------------------------------------------------
 
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Sparkles } from '@react-three/drei';
 import * as THREE from 'three';
 import { ISLANDS } from '../worldConfig';
 import { beluPos, dynamicSolids } from '../playerState';
+import { makeRng } from '../Scenery';
 import type { BeluEmotion } from '../../BeluCharacter';
 import { makeLabelTexture } from './emojiTexture';
-import { MOUNTAIN_ROUTINE, NIMBUS_LINES, type Station } from './mountainContent';
+import { MOUNTAIN_ROUTINE, NIMBUS_LINES, RING, SAFE_SPOTS, TWIN_DX, type Station } from './mountainContent';
 import { MorningSun, Nimbus, StepStone, StarSpark } from './mountainExtras';
 import StartSign from './StartSign';
 import type { QuestStatus } from './QuestLayer';
@@ -62,6 +63,10 @@ interface Props {
   level: number;
   paused: boolean;
   reduceMotion: boolean;
+  /** today's date key (e.g. "2026-07-09") — reshuffles station PLACEMENT once
+   *  per real day. The routine's authored order never changes, only which
+   *  pedestal spot each step lands on. */
+  dateKey: string;
   speak: (line: string) => void;
   setEmotion: (e: BeluEmotion) => void;
   playSound: (kind: 'tap' | 'correct' | 'star' | 'levelup' | 'growup') => void;
@@ -71,6 +76,48 @@ interface Props {
 
 function clampLevel(level: number) {
   return Math.max(0, Math.min(MOUNTAIN_ROUTINE.length - 1, level - 1));
+}
+
+// ---- daily station shuffle -------------------------------------------------
+// Same tiny string→seed hash used by HomeLife's dailySparkleSpots, feeding the
+// shared makeRng LCG. Deterministic per dateKey: stable all day, fresh tomorrow.
+function seedFromKey(key: string): number {
+  let h = 7;
+  for (let i = 0; i < key.length; i++) h = (h * 31 + key.charCodeAt(i)) % 2147483647;
+  return h || 1;
+}
+
+/** Fisher-Yates shuffle of [0..n-1], seeded so it's stable for a given day. */
+function seededPermutation(n: number, seed: number): number[] {
+  const rng = makeRng(seed);
+  const arr = Array.from({ length: n }, (_, i) => i);
+  for (let i = n - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+/** Builds today's slot-remap: which physical RING/SAFE_SPOTS slot each
+ *  authored slot now lands on. Stations still reference the SAME set of
+ *  well-spaced spots — just reassigned — so arc/spacing math is untouched. */
+function dailyStationShuffle(dateKey: string) {
+  const ringPerm = seededPermutation(RING.length, seedFromKey(`${dateKey}:mountain:ring`));
+  const safePerm = seededPermutation(SAFE_SPOTS.length, seedFromKey(`${dateKey}:mountain:safe`));
+  const ringIndexOf = (pos: [number, number]) =>
+    RING.findIndex(([x, z]) => x === pos[0] && z === pos[1]);
+  /** the SHUFFLED local [x,z] a given authored station should render/interact at today */
+  return function shuffledPos(s: Station): [number, number] {
+    if (s.kind === 'safe' || s.kind === 'unsafe') {
+      const pair = s.pair ?? 0;
+      const slot = SAFE_SPOTS[safePerm[pair] ?? pair];
+      return s.kind === 'unsafe' ? [slot[0] + TWIN_DX, slot[1]] : [slot[0], slot[1]];
+    }
+    const idx = ringIndexOf(s.pos);
+    if (idx < 0) return s.pos; // shouldn't happen — fall back to authored spot
+    const slot = RING[ringPerm[idx]];
+    return [slot[0], slot[1]];
+  };
 }
 
 /** stations that actually need visiting to finish (the un-safe twins don't). */
@@ -91,7 +138,13 @@ export default function MountainLayer(props: Props) {
   const frame = useRef<(dt: number) => void>(() => {});
   const isl = ISLANDS[ZONE];
 
-  const stationWorld = (s: Station): [number, number] => [isl.cx + s.pos[0], isl.cz + s.pos[1]];
+  // today's pedestal-placement shuffle — stable all day, fresh tomorrow
+  const shuffledPos = useMemo(() => dailyStationShuffle(props.dateKey), [props.dateKey]);
+
+  const stationWorld = (s: Station): [number, number] => {
+    const [lx, lz] = shuffledPos(s);
+    return [isl.cx + lx, isl.cz + lz];
+  };
   const starWorld = (p: [number, number]): [number, number] => [isl.cx + p[0], isl.cz + p[1]];
 
   // how far along the morning we are (0..1) — drives the rising sun + Nimbus

--- a/components/game/BelusWorld/three/quest/QuestLayer.tsx
+++ b/components/game/BelusWorld/three/quest/QuestLayer.tsx
@@ -16,10 +16,12 @@ import { ISLANDS } from '../worldConfig';
 import { beluPos, dynamicSolids } from '../playerState';
 import type { ActivityZone } from '../../belu/progress';
 import type { BeluEmotion } from '../../BeluCharacter';
-import { getQuest, starsFromSlips, type Quest, type QuestRound } from './quests';
+import { getQuest, starsFromSlips, type Quest, type QuestRound, type RoundKind } from './quests';
 import AnswerOrb, { type OrbStatus } from './AnswerOrb';
 import QuestNPC, { type Mood } from './QuestNPC';
 import BreatheOrb from './BreatheOrb';
+import CarryItem from './CarryItem';
+import CarrySlot, { type SlotStatus } from './CarrySlot';
 
 const ALL_ZONES: ActivityZone[] = [
   'meadow', 'mountain', 'cove', 'forest', 'shore',
@@ -43,6 +45,17 @@ const PICK_RADIUS = 2.4; // how close Nilu must walk to choose an orb (generous 
 const ORB_DIST = 3.0; // orb arc distance out in front of the friend
 const ORB_H = 1.0; // orb float height above the island top (near Nilu's body)
 
+// carry/sort: items sit further out on their own pedestals; the delivery pads
+// (numbered slots or labeled tables) sit a bit closer to the friend, so the
+// child's walk naturally reads as "pick up, then bring it in".
+const CARRY_ITEM_DIST = ORB_DIST + 2.6;
+const CARRY_SLOT_DIST = ORB_DIST;
+// steps: a little path of stones receding from the friend, each a touch
+// higher than the last — a gentle rising staircase to walk in order.
+const STEP_DIST = ORB_DIST + 0.4;
+const STEP_SPACING = 1.9;
+const STEP_RISE = 0.28;
+
 interface Layout {
   positions: [number, number, number][];
 }
@@ -54,14 +67,16 @@ function orbCount(round: QuestRound): number {
   return 0;
 }
 
-/** Lay the orbs out in an arc in front of the friend, facing Nilu's approach. */
-function layoutOrbs(zone: ActivityZone, n: number): Layout {
+/** Lay `n` things out in an arc at `dist` in front of the friend, facing
+ *  Nilu's approach (the same fan used for answer orbs, carry items/slots,
+ *  and sort tables — only the distance differs). */
+function layoutArc(zone: ActivityZone, n: number, dist: number): Layout {
   const isl = ISLANDS[zone];
   // approach direction = from the island centre toward home (0,0)
   const len = Math.hypot(isl.cx, isl.cz) || 1;
   const ax = -isl.cx / len;
   const az = -isl.cz / len;
-  // perpendicular (for spreading orbs left/right)
+  // perpendicular (for spreading things left/right)
   const px = -az;
   const pz = ax;
   // wider fan = easier to reach from any approach angle; pick radius (2.4) is
@@ -71,11 +86,56 @@ function layoutOrbs(zone: ActivityZone, n: number): Layout {
   for (let i = 0; i < n; i++) {
     const frac = n === 1 ? 0 : i / (n - 1) - 0.5;
     const off = frac * (n - 1) * spacing;
-    const x = isl.cx + ax * ORB_DIST + px * off;
-    const z = isl.cz + az * ORB_DIST + pz * off;
+    const x = isl.cx + ax * dist + px * off;
+    const z = isl.cz + az * dist + pz * off;
     positions.push([x, isl.top + ORB_H, z]);
   }
   return { positions };
+}
+
+/** Lay the answer orbs out in an arc in front of the friend. */
+function layoutOrbs(zone: ActivityZone, n: number): Layout {
+  return layoutArc(zone, n, ORB_DIST);
+}
+
+/** A little path of stepping stones receding from the friend, rising as it
+ *  goes — purely a visual staircase feel (proximity-triggered, like orbs). */
+function layoutSteps(zone: ActivityZone, n: number): Layout {
+  const isl = ISLANDS[zone];
+  const len = Math.hypot(isl.cx, isl.cz) || 1;
+  const ax = -isl.cx / len;
+  const az = -isl.cz / len;
+  const positions: [number, number, number][] = [];
+  for (let i = 0; i < n; i++) {
+    const dist = STEP_DIST + i * STEP_SPACING;
+    positions.push([isl.cx + ax * dist, isl.top + ORB_H * 0.6 + i * STEP_RISE, isl.cz + az * dist]);
+  }
+  return { positions };
+}
+
+/** Deterministic shuffle (no Math.random at render/module time — like the
+ *  rest of the world). Same round always lays its pedestals out the same
+ *  way, so it's stable across re-renders but still varies per round/level. */
+function seededShuffle<T>(arr: T[], seed: number): T[] {
+  return arr
+    .map((v, i) => ({ v, k: Math.sin((seed + 1) * 12.9898 + i * 78.233) }))
+    .sort((a, b) => a.k - b.k)
+    .map((o) => o.v);
+}
+
+/** A short on-screen hint per round kind (choice/sequence/multiPick already
+ *  read clearly from their instruction line alone). */
+function hintFor(kind: RoundKind): string | undefined {
+  switch (kind) {
+    case 'carry':
+      return 'Walk into a thing to pick it up, then carry it to the right number!';
+    case 'sort':
+      return 'Walk into a thing to pick it up, then carry it to the table it belongs on!';
+    case 'steps':
+      return 'Walk onto each stone in order — 1, 2, 3…';
+    default:
+      return undefined;
+  }
 }
 
 function npcPosition(zone: ActivityZone): [number, number, number] {
@@ -99,6 +159,15 @@ interface State {
   disarmed: ActivityZone | null;
   pendingSay: string | null;
   sayAt: number;
+  /** carry/sort: index into round.items currently hovering over Nilu's head, or null */
+  carrying: number | null;
+  /** steps: how many stones have been walked in order so far */
+  stepIdx: number;
+  /** steps: consecutive out-of-order taps (a slip only counts after 2 in a row) */
+  stepWrongStreak: number;
+  /** carry/sort/steps: which slot/table/stone is wobbling right now, or -1 */
+  wrongSlot: number;
+  wrongSlotUntil: number;
 }
 
 export interface QuestStatus {
@@ -139,6 +208,7 @@ export default function QuestLayer(props: Props) {
     seqDone: [], picked: new Set(), solved: false, advanceAt: 0,
     lockUntil: 0, wrongIdx: -1, wrongUntil: 0, disarmed: null,
     pendingSay: null, sayAt: 0,
+    carrying: null, stepIdx: 0, stepWrongStreak: 0, wrongSlot: -1, wrongSlotUntil: 0,
   });
 
   // The frame logic is re-bound every render so it never closes over stale
@@ -153,6 +223,11 @@ export default function QuestLayer(props: Props) {
     S.current.picked = new Set();
     S.current.solved = false;
     S.current.wrongIdx = -1;
+    S.current.carrying = null;
+    S.current.stepIdx = 0;
+    S.current.stepWrongStreak = 0;
+    S.current.wrongSlot = -1;
+    S.current.wrongSlotUntil = 0;
   }
 
   // tell the DOM HUD what the player should be doing right now (persistent card)
@@ -164,10 +239,11 @@ export default function QuestLayer(props: Props) {
     }
     const q = getQuest(z, S.current.level);
     const isl = ISLANDS[z];
+    const round = q.rounds[S.current.roundIdx];
     props.onStatus({
       zone: z, title: isl.label, emoji: isl.emoji, accent: isl.accent,
       level: S.current.level, instruction, step: S.current.roundIdx,
-      total: q.rounds.length, phase,
+      total: q.rounds.length, phase, hint: hintFor(round.kind),
     });
   }
 
@@ -251,6 +327,204 @@ export default function QuestLayer(props: Props) {
     bump();
   }
 
+  // carry/sort's version of `slip` — the wobble targets a pad/table (not an
+  // orb index), and the coaching line is passed in so it can name the thing.
+  function carrySlip(slotIdx: number, message: string) {
+    const st = S.current;
+    st.slips += 1;
+    st.wrongSlot = slotIdx;
+    st.wrongSlotUntil = st.clock + 0.5;
+    st.lockUntil = st.clock + 0.45;
+    props.playSound('tap');
+    props.setEmotion('curious');
+    props.speak(message);
+    bump();
+  }
+
+  /** carry: walk into items to pick them up (one at a time — walking into a
+   *  new one politely swaps), then walk into pad 1, 2, 3… in that exact
+   *  order. The array order of `round.items` IS the correct delivery order. */
+  function carryFrame(st: State, round: QuestRound) {
+    const items = round.items!;
+    const n = items.length;
+    const seed = st.roundIdx * 7 + st.level * 3 + (st.zone?.length ?? 0);
+    const perm = seededShuffle(items.map((_, i) => i), seed);
+    const itemPositions = layoutArc(st.zone!, n, CARRY_ITEM_DIST).positions;
+    const slotPositions = layoutArc(st.zone!, n, CARRY_SLOT_DIST).positions;
+
+    if (st.carrying == null) {
+      for (let p = 0; p < n; p++) {
+        const idx = perm[p];
+        if (st.seqDone.includes(items[idx].caption ?? String(idx))) continue;
+        const pos = itemPositions[p];
+        const d = Math.hypot(beluPos.x - pos[0], beluPos.z - pos[2]);
+        if (d < PICK_RADIUS) {
+          st.carrying = idx;
+          props.playSound('tap');
+          st.lockUntil = st.clock + 0.3;
+          bump();
+          return;
+        }
+      }
+      return;
+    }
+
+    // already carrying something — walking into a different, unplaced item
+    // swaps politely (no penalty, it's still just one thing at a time)
+    for (let p = 0; p < n; p++) {
+      const idx = perm[p];
+      if (idx === st.carrying || st.seqDone.includes(items[idx].caption ?? String(idx))) continue;
+      const pos = itemPositions[p];
+      const d = Math.hypot(beluPos.x - pos[0], beluPos.z - pos[2]);
+      if (d < PICK_RADIUS) {
+        st.carrying = idx;
+        props.playSound('tap');
+        st.lockUntil = st.clock + 0.3;
+        bump();
+        return;
+      }
+    }
+
+    // walking onto a numbered pad — right item + right pad (the next one in
+    // order) delivers it; anything else is a gentle "not yet, try again"
+    for (let s = 0; s < n; s++) {
+      const pos = slotPositions[s];
+      const d = Math.hypot(beluPos.x - pos[0], beluPos.z - pos[2]);
+      if (d < PICK_RADIUS) {
+        const expected = st.seqDone.length;
+        if (s === expected && st.carrying === expected) {
+          st.seqDone.push(items[expected].caption ?? String(expected));
+          st.carrying = null;
+          props.playSound('correct');
+          if (st.seqDone.length >= n) {
+            solveRound(round.doneLine ?? 'Perfect! Everything is in its place!');
+          } else {
+            st.lockUntil = st.clock + 0.3;
+            props.setEmotion('happy');
+            bump();
+          }
+        } else {
+          st.carrying = null; // returns to its pedestal
+          carrySlip(s, 'Hmm — what comes first?');
+        }
+        return;
+      }
+    }
+  }
+
+  /** sort: like carry, but delivery is by which table the item belongs on —
+   *  any order is fine, there's no sequence to keep. */
+  function sortFrame(st: State, round: QuestRound) {
+    const items = round.items!;
+    const tables = round.tables!;
+    const n = items.length;
+    const seed = st.roundIdx * 11 + st.level * 5 + (st.zone?.length ?? 0);
+    const perm = seededShuffle(items.map((_, i) => i), seed);
+    const itemPositions = layoutArc(st.zone!, n, CARRY_ITEM_DIST).positions;
+    const tablePositions = layoutArc(st.zone!, tables.length, CARRY_SLOT_DIST).positions;
+
+    if (st.carrying == null) {
+      for (let p = 0; p < n; p++) {
+        const idx = perm[p];
+        if (st.seqDone.includes(items[idx].caption ?? String(idx))) continue;
+        const pos = itemPositions[p];
+        const d = Math.hypot(beluPos.x - pos[0], beluPos.z - pos[2]);
+        if (d < PICK_RADIUS) {
+          st.carrying = idx;
+          props.playSound('tap');
+          st.lockUntil = st.clock + 0.3;
+          bump();
+          return;
+        }
+      }
+      return;
+    }
+
+    for (let p = 0; p < n; p++) {
+      const idx = perm[p];
+      if (idx === st.carrying || st.seqDone.includes(items[idx].caption ?? String(idx))) continue;
+      const pos = itemPositions[p];
+      const d = Math.hypot(beluPos.x - pos[0], beluPos.z - pos[2]);
+      if (d < PICK_RADIUS) {
+        st.carrying = idx;
+        props.playSound('tap');
+        st.lockUntil = st.clock + 0.3;
+        bump();
+        return;
+      }
+    }
+
+    for (let t = 0; t < tables.length; t++) {
+      const pos = tablePositions[t];
+      const d = Math.hypot(beluPos.x - pos[0], beluPos.z - pos[2]);
+      if (d < PICK_RADIUS) {
+        const carried = items[st.carrying];
+        if (carried.table === t) {
+          st.seqDone.push(carried.caption ?? String(st.carrying));
+          st.carrying = null;
+          props.playSound('correct');
+          if (st.seqDone.length >= n) {
+            solveRound(round.doneLine ?? 'Everything sorted!');
+          } else {
+            st.lockUntil = st.clock + 0.3;
+            props.setEmotion('happy');
+            bump();
+          }
+        } else {
+          st.carrying = null;
+          carrySlip(t, `Hmm — where does the ${carried.caption ?? 'thing'} go?`);
+        }
+        return;
+      }
+    }
+  }
+
+  /** steps: just walk the stones 1→2→3… — no carrying. Stepping ahead out of
+   *  order gets a gentle wobble + coaching line every time, but only counts
+   *  as a real slip after two wrong steps in a row (adjacent-number mixups
+   *  are expected and shouldn't cost stars). Stepping on an already-done
+   *  stone is simply ignored. */
+  function stepsFrame(st: State, round: QuestRound) {
+    const n = round.count ?? 4;
+    const positions = layoutSteps(st.zone!, n).positions;
+    const expected = st.stepIdx;
+    for (let i = 0; i < n; i++) {
+      const pos = positions[i];
+      const d = Math.hypot(beluPos.x - pos[0], beluPos.z - pos[2]);
+      if (d < PICK_RADIUS) {
+        if (i === expected) {
+          st.stepIdx += 1;
+          st.stepWrongStreak = 0;
+          const label = round.labels?.[i] ?? String(i + 1);
+          props.playSound(st.stepIdx >= n ? 'star' : 'correct');
+          if (st.stepIdx >= n) {
+            solveRound(round.doneLine ?? 'You did every step!');
+          } else {
+            props.speak(`${label}!`);
+            st.lockUntil = st.clock + 0.35;
+            props.setEmotion('happy');
+            bump();
+          }
+        } else if (i > expected) {
+          st.stepWrongStreak += 1;
+          st.wrongSlot = i;
+          st.wrongSlotUntil = st.clock + 0.5;
+          st.lockUntil = st.clock + 0.4;
+          if (st.stepWrongStreak >= 2) {
+            st.slips += 1;
+            st.stepWrongStreak = 0;
+          }
+          props.playSound('tap');
+          props.setEmotion('curious');
+          props.speak('Which number comes next?');
+          bump();
+        }
+        // stepping on an already-done stone (i < expected): no reaction
+        return;
+      }
+    }
+  }
+
   function pick(i: number) {
     const st = S.current;
     if (!curRound || st.solved || st.clock < st.lockUntil) return;
@@ -319,6 +593,10 @@ export default function QuestLayer(props: Props) {
       st.wrongIdx = -1;
       bump();
     }
+    if (st.wrongSlot >= 0 && st.clock > st.wrongSlotUntil) {
+      st.wrongSlot = -1;
+      bump();
+    }
 
     // a solved round animates, then advances
     if (st.solved && st.clock >= st.advanceAt) {
@@ -364,6 +642,18 @@ export default function QuestLayer(props: Props) {
     // orb pick detection (walk-in). Breathe rounds handle themselves.
     const round = getQuest(st.zone, st.level).rounds[st.roundIdx];
     if (round.kind === 'breathe' || st.solved || st.clock < st.lockUntil) return;
+    if (round.kind === 'carry') {
+      carryFrame(st, round);
+      return;
+    }
+    if (round.kind === 'sort') {
+      sortFrame(st, round);
+      return;
+    }
+    if (round.kind === 'steps') {
+      stepsFrame(st, round);
+      return;
+    }
     const n = orbCount(round);
     if (!n) return;
     const { positions } = layoutOrbs(st.zone, n);
@@ -461,6 +751,120 @@ export default function QuestLayer(props: Props) {
               onPhase={(label) => props.speak(label)}
               onDone={() => solveRound()}
             />
+          ) : curRound.kind === 'carry' ? (
+            (() => {
+              const st = S.current;
+              const zone = S.current.zone!;
+              const items = curRound.items!;
+              const n = items.length;
+              const seed = st.roundIdx * 7 + st.level * 3 + zone.length;
+              const perm = seededShuffle(items.map((_, i) => i), seed);
+              const itemPositions = layoutArc(zone, n, CARRY_ITEM_DIST).positions;
+              const slotPositions = layoutArc(zone, n, CARRY_SLOT_DIST).positions;
+              return (
+                <group>
+                  {perm.map((idx, p) => {
+                    if (st.seqDone.includes(items[idx].caption ?? String(idx))) return null;
+                    return (
+                      <CarryItem
+                        key={`carry-item-${idx}`}
+                        pedestalPosition={itemPositions[p]}
+                        emoji={items[idx].emoji}
+                        caption={items[idx].caption}
+                        color={accent[zone]}
+                        carrying={st.carrying === idx}
+                        reduceMotion={props.reduceMotion}
+                        bobSeed={p * 0.6}
+                      />
+                    );
+                  })}
+                  {slotPositions.map((pos, s) => {
+                    const filled = s < st.seqDone.length;
+                    const next = s === st.seqDone.length;
+                    const status: SlotStatus = filled ? 'filled' : st.wrongSlot === s ? 'wrong' : next ? 'next' : 'idle';
+                    return (
+                      <CarrySlot
+                        key={`carry-slot-${s}`}
+                        position={pos}
+                        number={s + 1}
+                        status={status}
+                        color={accent[zone]}
+                        reduceMotion={props.reduceMotion}
+                      />
+                    );
+                  })}
+                </group>
+              );
+            })()
+          ) : curRound.kind === 'sort' ? (
+            (() => {
+              const st = S.current;
+              const zone = S.current.zone!;
+              const items = curRound.items!;
+              const tables = curRound.tables!;
+              const n = items.length;
+              const seed = st.roundIdx * 11 + st.level * 5 + zone.length;
+              const perm = seededShuffle(items.map((_, i) => i), seed);
+              const itemPositions = layoutArc(zone, n, CARRY_ITEM_DIST).positions;
+              const tablePositions = layoutArc(zone, tables.length, CARRY_SLOT_DIST).positions;
+              return (
+                <group>
+                  {perm.map((idx, p) => {
+                    if (st.seqDone.includes(items[idx].caption ?? String(idx))) return null;
+                    return (
+                      <CarryItem
+                        key={`sort-item-${idx}`}
+                        pedestalPosition={itemPositions[p]}
+                        emoji={items[idx].emoji}
+                        caption={items[idx].caption}
+                        color={accent[zone]}
+                        carrying={st.carrying === idx}
+                        reduceMotion={props.reduceMotion}
+                        bobSeed={p * 0.6}
+                      />
+                    );
+                  })}
+                  {tables.map((tb, t) => (
+                    <CarrySlot
+                      key={`sort-table-${t}`}
+                      position={tablePositions[t]}
+                      status={st.wrongSlot === t ? 'wrong' : 'idle'}
+                      color={accent[zone]}
+                      reduceMotion={props.reduceMotion}
+                      emoji={tb.emoji}
+                      caption={tb.caption}
+                    />
+                  ))}
+                </group>
+              );
+            })()
+          ) : curRound.kind === 'steps' ? (
+            (() => {
+              const st = S.current;
+              const zone = S.current.zone!;
+              const n = curRound.count ?? 4;
+              const positions = layoutSteps(zone, n).positions;
+              return (
+                <group>
+                  {positions.map((pos, i) => {
+                    const done = i < st.stepIdx;
+                    const next = i === st.stepIdx;
+                    const status: SlotStatus = done ? 'filled' : st.wrongSlot === i ? 'wrong' : next ? 'next' : 'idle';
+                    return (
+                      <CarrySlot
+                        key={`step-${i}`}
+                        position={pos}
+                        number={i + 1}
+                        label={curRound.labels?.[i]}
+                        status={status}
+                        color={accent[zone]}
+                        reduceMotion={props.reduceMotion}
+                      />
+                    );
+                  })}
+                </group>
+              );
+            })()
           ) : (
             (() => {
               const n = orbCount(curRound);

--- a/components/game/BelusWorld/three/quest/mountainContent.ts
+++ b/components/game/BelusWorld/three/quest/mountainContent.ts
@@ -78,7 +78,10 @@ function st(
 
 // A ring of station spots around the island centre, so the routine is a little
 // walking loop. Index = the visit order for ordered levels.
-const RING: [number, number][] = [
+// Exported so MountainLayer can reshuffle WHICH physical slot each step lands
+// on each real day — the routine's authored ORDER never changes, only the
+// pedestal placement does (see MountainLayer's daily station shuffle).
+export const RING: [number, number][] = [
   [0, -5], // top
   [4.5, -2.5], // upper-right
   [4.5, 2.5], // lower-right
@@ -89,8 +92,8 @@ const RING: [number, number][] = [
 
 // L4 safety pairs sit side by side (safe on the left, twin on the right) at a
 // few spots around the ring, so Nilu chooses by walking to the safe one.
-const SAFE_SPOTS: [number, number][] = [[-2.6, -4], [2.6, -4], [-2.6, 4], [2.6, 4]];
-const TWIN_DX = 2.4;
+export const SAFE_SPOTS: [number, number][] = [[-2.6, -4], [2.6, -4], [-2.6, 4], [2.6, 4]];
+export const TWIN_DX = 2.4;
 
 export const MOUNTAIN_ROUTINE: MountainLevel[] = [
   {

--- a/components/game/BelusWorld/three/quest/quests.ts
+++ b/components/game/BelusWorld/three/quest/quests.ts
@@ -17,7 +17,7 @@ export interface Orb {
   correct?: boolean;
 }
 
-export type RoundKind = 'choice' | 'sequence' | 'multiPick' | 'breathe';
+export type RoundKind = 'choice' | 'sequence' | 'multiPick' | 'breathe' | 'carry' | 'sort' | 'steps';
 
 export interface QuestRound {
   kind: RoundKind;
@@ -34,6 +34,17 @@ export interface QuestRound {
   picks?: number;
   /** breathe: how many calm breath cycles */
   cycles?: number;
+  /** carry: things to carry to numbered pads, in the CORRECT order — the
+   *  array order itself is the correct delivery order (slot 0 = pad 1, etc).
+   *  sort: things to carry to a table — `table` says which table (index into
+   *  `tables`) each one belongs on; any delivery order is fine. */
+  items?: (Orb & { table?: number })[];
+  /** sort: the labeled tables/bins the child sorts `items` onto */
+  tables?: Orb[];
+  /** steps: how many stepping stones to walk, in order, 1..count */
+  count?: number;
+  /** steps: optional short captions spoken instead of plain numbers */
+  labels?: string[];
   /** optional success line when the round is solved */
   doneLine?: string;
 }
@@ -687,14 +698,14 @@ const SCHOOL: Quest[] = [
     outro: 'You know just how to get ready to learn. Great job!',
     moment: 'got ready to learn on School Island',
     rounds: [
-      { kind: 'sequence', say: "Let's get ready to learn! Walk into the steps in order.",
-        npc: { face: '🦉', mood: MOOD('happy'), thought: { emoji: '🎒' } },
-        pool: [
-          step('👋', 'Say bye to my grown-up'), step('🎒', 'Put my backpack away'),
-          step('🪑', 'Sit at my spot'),
+      { kind: 'carry', say: "Let's pack the backpack! Pick up the book and carry it to spot 1!",
+        npc: { face: '🎒', mood: MOOD('happy') },
+        items: [
+          { emoji: '📚', caption: 'book' },
+          { emoji: '🥪', caption: 'lunchbox' },
+          { emoji: '💧', caption: 'water bottle' },
         ],
-        order: ['Put my backpack away', 'Say bye to my grown-up', 'Sit at my spot'],
-        doneLine: 'Backpack away, bye said, spot found — ready to learn!' },
+        doneLine: 'Packed and ready — book, lunchbox, water bottle!' },
       { kind: 'choice', say: 'The teacher is talking to the class. What do I do?',
         npc: { face: '🦉', mood: MOOD('happy') },
         options: [
@@ -752,11 +763,18 @@ const SCHOOL: Quest[] = [
         options: [
           step('🙏', 'Ask first', true), step('🤚', 'Take it without asking'), step('😋', 'Grab some'),
         ], doneLine: "Asking first is kind. Then it's Bear's choice to share." },
-      { kind: 'multiPick', say: "Let's find what's in YOUR lunch area. Walk into each one.", picks: 3,
+      { kind: 'sort', say: "Let's sort lunch things! Carry each one to whose it is.",
         npc: { face: '🦉', mood: MOOD('happy') },
-        options: [
-          step('🍱', 'My lunchbox'), step('💧', 'My water bottle'), step('🧻', 'My napkin'),
-        ], doneLine: "Those are all yours! Bear's cookie belongs to Bear." },
+        tables: [
+          { emoji: '🎒', caption: 'My things' },
+          { emoji: '🐻', caption: "Bear's things" },
+        ],
+        items: [
+          { emoji: '🍱', caption: 'My lunchbox', table: 0 },
+          { emoji: '💧', caption: 'My water bottle', table: 0 },
+          { emoji: '🍪', caption: "Bear's cookie", table: 1 },
+        ],
+        doneLine: "Yours stay with you, Bear's stay with Bear!" },
     ],
   },
   {
@@ -814,11 +832,19 @@ const AFTERNOON: Quest[] = [
     outro: 'That was the nicest snack time ever.',
     moment: 'shared snack time at the Fun Corner',
     rounds: [
-      { kind: 'choice', say: "It's snack time! Which is a healthy pick?",
+      { kind: 'sort', say: "Let's sort snacks! Carry each one to the right plate.",
         npc: { face: '🐕', mood: MOOD('happy'), thought: { emoji: '🍎' } },
-        options: [
-          step('🍎', 'An apple', true), step('🍬', 'Candy'), step('🍟', 'Chips'),
-        ], doneLine: 'Yes! An apple is a healthy pick.' },
+        tables: [
+          { emoji: '🍎', caption: 'Every day' },
+          { emoji: '🎉', caption: 'Sometimes' },
+        ],
+        items: [
+          { emoji: '🍎', caption: 'apple', table: 0 },
+          { emoji: '🥕', caption: 'carrot', table: 0 },
+          { emoji: '🍬', caption: 'candy', table: 1 },
+          { emoji: '🍟', caption: 'chips', table: 1 },
+        ],
+        doneLine: 'Every-day foods and sometimes-treats — both are okay, just not the same amount!' },
       { kind: 'choice', say: 'You want a snack from the kitchen. What do you do?',
         npc: { face: '🐕', mood: MOOD('happy') },
         options: [
@@ -837,13 +863,11 @@ const AFTERNOON: Quest[] = [
         options: [
           step('🧸', 'Play', true), step('📚', 'More homework'),
         ], doneLine: 'First homework, then play — that is the plan!' },
-      { kind: 'sequence', say: "Let's say the First-Then plan in order. Walk into the steps.",
+      { kind: 'steps', say: "Let's walk the plan: First, Then, Next!",
         npc: { face: '🐕', mood: MOOD('happy') },
-        pool: [
-          step('📝', 'First: homework'), step('🧸', 'Then: play'), step('🍎', 'Then: snack'),
-        ],
-        order: ['First: homework', 'Then: play'],
-        doneLine: '"First homework, then play." You did it!' },
+        count: 3,
+        labels: ['First: homework 📖', 'Then: puzzle 🧩', 'Next: play ⚽'],
+        doneLine: 'First homework, then puzzle, next play — you followed the whole plan!' },
     ],
   },
   {
@@ -875,14 +899,14 @@ const AFTERNOON: Quest[] = [
     outro: 'Everything back in its place — the Fun Corner sparkles!',
     moment: 'tidied up at the Fun Corner',
     rounds: [
-      { kind: 'sequence', say: 'Time to tidy up! Walk into the steps in order.',
+      { kind: 'carry', say: 'Time to tidy up! Pick up the toys and carry them to spot 1!',
         npc: { face: '🐕', mood: MOOD('happy'), thought: { emoji: '🧸' } },
-        pool: [
-          step('🧸', 'Toys in the bin'), step('📚', 'Books on the shelf'),
-          step('👕', 'Clothes in the basket'),
+        items: [
+          { emoji: '🧸', caption: 'toys' },
+          { emoji: '📚', caption: 'books' },
+          { emoji: '👕', caption: 'clothes' },
         ],
-        order: ['Toys in the bin', 'Books on the shelf', 'Clothes in the basket'],
-        doneLine: 'Tidy and cozy — great job!' },
+        doneLine: 'Toys in the bin, books on the shelf, clothes in the basket — tidy!' },
       { kind: 'choice', say: 'One lost sock is on the floor. Where does it go?',
         npc: { face: '🐕', mood: MOOD('happy') },
         options: [
@@ -945,11 +969,10 @@ const NIGHT: Quest[] = [
         pool: [step('🪥', 'Get my brush'), step('🧴', 'Add toothpaste'), step('😁', 'Brush!')],
         order: ['Get my brush', 'Add toothpaste', 'Brush!'],
         doneLine: 'Brush brush brush — sparkly!' },
-      { kind: 'choice', say: 'How long do we brush?',
-        npc: { face: '🐑', mood: MOOD('calm'), thought: { emoji: '🎵' } },
-        options: [
-          step('🎵', 'Until the song ends', true), step('⏱️', 'Just one second'),
-        ], doneLine: 'Brushing until the song ends gets every tooth clean.' },
+      { kind: 'steps', say: 'Brush time! Count with me as you walk each number.',
+        npc: { face: '🐑', mood: MOOD('calm'), thought: { emoji: '🪥' } },
+        count: 4,
+        doneLine: 'One, two, three, four — every tooth is sparkly clean!' },
     ],
   },
   {
@@ -958,11 +981,14 @@ const NIGHT: Quest[] = [
     outro: 'Your bed is all ready for a cozy night!',
     moment: 'got my bed ready on Sleepy Island',
     rounds: [
-      { kind: 'multiPick', say: 'Walk into each thing your bed needs.', picks: 4,
+      { kind: 'carry', say: 'Pick up the pillow and carry it to spot 1 on the bed!',
         npc: { face: '🐑', mood: MOOD('calm') },
-        options: [
-          step('🛏️', 'My pillow'), step('🧣', 'My blanket'), step('🧸', 'My teddy'), step('🥤', 'My water cup'),
-        ], doneLine: 'Pillow, blanket, teddy, water cup — all ready!' },
+        items: [
+          { emoji: '🛏️', caption: 'pillow' },
+          { emoji: '🧸', caption: 'teddy' },
+          { emoji: '💧', caption: 'water cup' },
+        ],
+        doneLine: 'Pillow, teddy, water cup — your bed is all ready!' },
     ],
   },
   {

--- a/components/game/BelusWorld/three/worldConfig.ts
+++ b/components/game/BelusWorld/three/worldConfig.ts
@@ -146,12 +146,14 @@ export const ISLANDS: Record<ZoneId, IslandDef> = {
     label: 'School Island',
     emoji: '🏫',
   },
-  // 🏡 Fun Corner — after-school play + home routines. North-west, between the
-  // Rainbow Playground and Feelings Meadow.
+  // 🏡 Fun Corner — after-school play + home routines. Continues the day's
+  // sweep south-east of School Island (chained FROM school, not home — the
+  // day arc reads as one continuous path: mountain → school → afternoon →
+  // night, so finishing a stage always leads onward, never back to base).
   afternoon: {
     id: 'afternoon',
-    cx: -27,
-    cz: -33,
+    cx: 44,
+    cz: -48,
     radius: 8.5,
     top: 2,
     grass: '#ffc9a3',
@@ -160,12 +162,13 @@ export const ISLANDS: Record<ZoneId, IslandDef> = {
     label: 'Fun Corner',
     emoji: '🏡',
   },
-  // 🌙 Sleepy Island — winding down for the night. Due east, between Morning
-  // Mountain and Friendship Forest.
+  // 🌙 Sleepy Island — winding down for the night. Final stop of the day's
+  // sweep, chained FROM Fun Corner, curving back east toward Morning
+  // Mountain's side of the map so the day arc closes into a loop shape.
   night: {
     id: 'night',
-    cx: 46,
-    cz: 8,
+    cx: 62,
+    cz: -28,
     radius: 8.5,
     top: 1.5,
     grass: '#9aa4d8',
@@ -188,10 +191,13 @@ export const BRIDGES: BridgeDef[] = [
   { from: 'home', to: 'shore', halfWidth: 2.2, colors: RAINBOW_STRIPES },
   // bridge to the reward island — only walkable once it's unlocked
   { from: 'home', to: 'rainbow', halfWidth: 2.4, colors: RAINBOW_STRIPES },
-  // Day Arc islands — bridges only form when their island does
-  { from: 'home', to: 'school', halfWidth: 2.2, colors: RAINBOW_STRIPES },
-  { from: 'home', to: 'afternoon', halfWidth: 2.2, colors: RAINBOW_STRIPES },
-  { from: 'home', to: 'night', halfWidth: 2.2, colors: RAINBOW_STRIPES },
+  // Day Arc islands — bridges only form when their island does. The day
+  // chains forward from wherever Nilu just was (not back to Home) so each
+  // new stage genuinely feels like leveling up: Home → Mountain is the day's
+  // one entrance, then Mountain → School → Afternoon → Night sweeps onward.
+  { from: 'mountain', to: 'school', halfWidth: 2.2, colors: RAINBOW_STRIPES },
+  { from: 'school', to: 'afternoon', halfWidth: 2.2, colors: RAINBOW_STRIPES },
+  { from: 'afternoon', to: 'night', halfWidth: 2.2, colors: RAINBOW_STRIPES },
 ];
 
 // The zone islands that host a learning activity (everything except home + the

--- a/components/game/BelusWorld/ui/HUD.tsx
+++ b/components/game/BelusWorld/ui/HUD.tsx
@@ -81,13 +81,15 @@ export default function HUD({ beluLine, nearZone, starQuestZone, stickers, total
         >
           {muted ? '🔇' : '🔊'}
         </button>
+        {/* labeled + emerald so a child hunting for "how do I get back?" spots it
+            among the icon-only buttons — it teleports Nilu straight to home base */}
         <button
           onClick={onGoHome}
-          className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg shadow-lg backdrop-blur transition hover:bg-white"
-          aria-label="Go to home island"
-          title="Home base"
+          className="pointer-events-auto flex h-11 items-center gap-1.5 rounded-full bg-emerald-500/95 px-3 text-lg shadow-lg backdrop-blur transition hover:bg-emerald-400"
+          aria-label="Go back to home base"
+          title="Go back to home base"
         >
-          🏡
+          🏡<span className="text-sm font-bold text-white">Home</span>
         </button>
         <button
           onClick={onOpenWardrobe}


### PR DESCRIPTION
Playtest feedback round 3:

- **Leveling up walks forward**: new islands bridge from the island you're on (mountain→school→afternoon→night), not from home. Distances/geometry verified (no overlaps or crossing bridges); each bridge appears the moment its island forms.
- **Move-the-blocks variety** (walk-based, joystick-friendly, no dragging): **carry & place** (pick items up by walking into them, deliver to numbered pads — backpack packing, tidy-up, bed prep), **sorting tables** (my lunch vs friend's lunch, everyday foods vs treats), **stepping stones** (walk stones in order counting aloud; First-Then-Next homework→puzzle→play). Gentle coaching on mistakes, no fail states, reduced-motion aware.
- **Morning stations shuffle daily** (date-seeded, stable within a day) — the routine order stays fixed (that's the lesson), but placement is fresh each day so it's not muscle-memory.
- **🏡 Home button** upgraded to a labeled emerald pill — the obvious way back to base to visit the skill islands (kid's choice).

Verified: tsc clean, full build + prerender + minify passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)