### PR TITLE
Nilu's World: stuck-help, advanced islands for every domain, clearer world

### DIFF
--- a/components/game/BelusWorld/belu/dialogue.ts
+++ b/components/game/BelusWorld/belu/dialogue.ts
@@ -287,6 +287,82 @@ const DB: Record<string, Partial<Record<0 | 1 | 2 | 3, Line[]>>> = {
     3: [ctx => `${name(ctx)}, that was genuinely incredible. I am SO proud of us.`, "Achievement unlocked! And you made it look easy."],
   },
 
+  zone_garden: {
+    0: [
+      "This is the Feelings Garden... feelings here can be tricky. Sometimes two at once!",
+      "The Feelings Garden grew once you mastered the meadow. There's more to learn about feelings here.",
+    ],
+    1: [
+      "The Feelings Garden! Did you know you can feel two things at the same time? I'm still getting used to that.",
+      "This garden is for the BIG feelings questions. Ready to look closer?",
+    ],
+    2: [
+      "The Feelings Garden — I've learned that a smile doesn't always mean happy. Noticing that takes practice.",
+      "I love helping friends here now. Empathy gets easier the more you practice it.",
+    ],
+    3: [
+      "FEELINGS GARDEN! My advanced feelings headquarters. Ask me anything.",
+      "The butterfly taught me that feelings pass like clouds. I think about that all the time now.",
+    ],
+  },
+
+  zone_deepforest: {
+    0: [
+      "This is the Deep Forest... it's further in than the Friendship Forest. Bigger friendship things happen here.",
+      "Sometimes friends say no, or we lose a game. We can practice that here, gently.",
+    ],
+    1: [
+      "The Deep Forest! Joining a game already in progress used to feel scary. It gets easier.",
+      "Deer and Bear taught me how to lose a game with a smile. Want to try?",
+    ],
+    2: [
+      "The Deep Forest — I know how to disagree kindly now, even about the red block.",
+      "Giving compliments used to feel weird. Now I love telling my friends how great they are.",
+    ],
+    3: [
+      "DEEP FOREST! Where I mastered the graceful 'good game!' Ask Deer, she'll confirm.",
+      "I once said 'not now' to a friend and it was totally fine. 'Not now' isn't 'never' — huge lesson.",
+    ],
+  },
+
+  zone_lagoon: {
+    0: [
+      "This is the Quiet Lagoon... it formed once the Calm Cove felt easy for you. Even calmer things live here.",
+      "Sometimes our body tells us a big feeling is coming before we even notice. We can practice noticing early.",
+    ],
+    1: [
+      "The Quiet Lagoon! Noticing tight hands or a fast heart EARLY — that's the trick I learned here.",
+      "Five calm breaths, five calm stones. Want to climb them with me?",
+    ],
+    2: [
+      "The Quiet Lagoon — I have a real plan for loud places now. Cover ears, ask for quiet, breathe.",
+      "Waiting used to feel impossible. Counting slowly and squeezing my hands really helps now.",
+    ],
+    3: [
+      "QUIET LAGOON! My most peaceful island. Even when plans change, I find a new idea here.",
+      "The dolphin and I have a whole breathing routine now. It's basically a superpower.",
+    ],
+  },
+
+  zone_bay: {
+    0: [
+      "This is Treasure Bay... it formed once Sharing Shore felt easy for you. Bigger sharing things happen here.",
+      "Borrowing, trading, building together — there's a lot to practice at the bay.",
+    ],
+    1: [
+      "Treasure Bay! I learned to borrow AND give things back here. Parrot trusts me with the shovel now.",
+      "Trading shells with Turtle taught me compromise. Want to see?",
+    ],
+    2: [
+      "Treasure Bay — we built a whole sandcastle together here, turn by turn. Even better than building alone.",
+      "When there's only one boat, a timer or riding together both work. I learned that at the bay.",
+    ],
+    3: [
+      "TREASURE BAY! Where I learned to cheer for a friend's win like it was my own.",
+      "Turtle won the swimming race and I clapped so loud. Being happy for a friend feels amazing.",
+    ],
+  },
+
   overwhelmed_response: {
     0: ["Oh... is it too much? It's okay. We can go slow."],
     1: ["Hey, it's okay if this feels like a lot. We can take a break at the Calm Cove."],
@@ -317,6 +393,10 @@ export function getZoneDialogue(zone: string, ctx: DialogueContext): string {
     school: 'zone_school',
     afternoon: 'zone_afternoon',
     night: 'zone_night',
+    garden: 'zone_garden',
+    deepforest: 'zone_deepforest',
+    lagoon: 'zone_lagoon',
+    bay: 'zone_bay',
   };
   return getDialogue(keyMap[zone] ?? 'zone_meadow', ctx);
 }

--- a/components/game/BelusWorld/belu/progress.ts
+++ b/components/game/BelusWorld/belu/progress.ts
@@ -8,22 +8,37 @@
 // No timers, no losing, no farming the same level past 3 stars.
 // ---------------------------------------------------------------------------
 
+import { ADVANCED_STICKERS } from '../three/quest/advancedQuests';
+
 export type ActivityZone =
   | 'meadow' | 'mountain' | 'cove' | 'forest' | 'shore'
-  | 'school' | 'afternoon' | 'night';
+  | 'school' | 'afternoon' | 'night'
+  | 'garden' | 'deepforest' | 'lagoon' | 'bay';
 
 export const ZONES: ActivityZone[] = [
   'meadow', 'mountain', 'cove', 'forest', 'shore',
   'school', 'afternoon', 'night',
+  'garden', 'deepforest', 'lagoon', 'bay',
 ];
 
 /** Nilu's Day — the story arc through one day of Nilu's life. Each stage's
  *  island only FORMS once the previous stage's island is fully completed. */
 export const DAY_ARC: ActivityZone[] = ['mountain', 'school', 'afternoon', 'night'];
+
+/** Advanced sister islands (see three/quest/advancedQuests.ts): each FORMS once
+ *  its PARENT skill island reaches 5/5 completed levels. Plain gating — no
+ *  dayArc/fresh choice involved, unlike the Nilu's Day arc above. */
+export const ADVANCED_PARENT: Record<'garden' | 'deepforest' | 'lagoon' | 'bay', ActivityZone> = {
+  garden: 'meadow',
+  deepforest: 'forest',
+  lagoon: 'cove',
+  bay: 'shore',
+};
+
 export const MAX_LEVEL = 5;
 export const MAX_STARS_PER_LEVEL = 3;
 export const MAX_STARS_PER_ISLAND = MAX_LEVEL * MAX_STARS_PER_LEVEL; // 15
-export const MAX_TOTAL_STARS = MAX_STARS_PER_ISLAND * ZONES.length; // 75
+export const MAX_TOTAL_STARS = MAX_STARS_PER_ISLAND * ZONES.length; // 180
 
 export interface IslandProgress {
   /** best stars earned on each level (index 0..MAX_LEVEL-1); 0 = not completed */
@@ -65,14 +80,26 @@ export const COSMETICS: Cosmetic[] = [
   { id: 'moonpin', name: 'Moon Pin', icon: '🌙', slot: 'face' },
   { id: 'kite', name: 'Play Kite', icon: '🪁', slot: 'back' },
   { id: 'snackpin', name: 'Snack Pin', icon: '🍎', slot: 'face' },
+  // ---- Advanced sister island items — earned across Feelings Garden / Deep
+  // Forest / Quiet Lagoon / Treasure Bay levels. ----
+  { id: 'gardencrown', name: 'Garden Crown', icon: '🌸', slot: 'head' },
+  { id: 'explorerhat', name: 'Explorer Hat', icon: '🧭', slot: 'head' },
+  { id: 'pearl', name: 'Lagoon Pearl', icon: '🫧', slot: 'face' },
+  { id: 'captainhat', name: "Captain's Hat", icon: '⛵', slot: 'head' },
+  { id: 'butterflywings', name: 'Butterfly Wings', icon: '🦋', slot: 'back' },
+  { id: 'antlers', name: 'Gentle Antlers', icon: '🦌', slot: 'head' },
+  { id: 'lilypin', name: 'Lily Pin', icon: '🪷', slot: 'face' },
+  { id: 'treasuremap', name: 'Treasure Map', icon: '🗺️', slot: 'back' },
 ];
 /** the order items unlock as the child completes levels — slots interleaved so
  *  every few levels the reward feels different (a hat, then something for the
- *  back, then the face…). 24 items across 40 total levels. */
+ *  back, then the face…). 32 items across 60 total levels (the remaining
+ *  levels still award stars/stickers, just no new cosmetic). */
 export const UNLOCK_ORDER = [
   'cap', 'bow', 'glasses', 'scarf', 'party', 'flowercrown', 'cape', 'sunhat',
   'goggles', 'crown', 'backpack', 'beanie', 'hearts', 'wings', 'balloon', 'wizard',
   'schoolcap', 'snackpin', 'schoolbag', 'kite', 'starbadge', 'teddy', 'moonpin', 'pajamahat',
+  'gardencrown', 'explorerhat', 'pearl', 'captainhat', 'butterflywings', 'antlers', 'lilypin', 'treasuremap',
 ];
 
 export interface EquippedCosmetics {
@@ -198,6 +225,9 @@ export const DAY_BOOK_STICKERS: Record<string, { emoji: string; label: string }>
   'night-3': { emoji: '📚', label: 'Story time!' },
   'night-4': { emoji: '🧸', label: 'Cuddled Teddy!' },
   'night-5': { emoji: '🌙', label: 'Slept tight!' },
+
+  // ---- Advanced sister islands (garden/deepforest/lagoon/bay) ----
+  ...ADVANCED_STICKERS,
 };
 
 const KEY = 'belus_world_progress_v1';
@@ -216,6 +246,10 @@ function emptyPracticeStats(): Record<ActivityZone, { slips: number; rounds: num
     school: { slips: 0, rounds: 0 },
     afternoon: { slips: 0, rounds: 0 },
     night: { slips: 0, rounds: 0 },
+    garden: { slips: 0, rounds: 0 },
+    deepforest: { slips: 0, rounds: 0 },
+    lagoon: { slips: 0, rounds: 0 },
+    bay: { slips: 0, rounds: 0 },
   };
 }
 
@@ -230,6 +264,10 @@ function defaults(): GameProgress {
       school: emptyIsland(),
       afternoon: emptyIsland(),
       night: emptyIsland(),
+      garden: emptyIsland(),
+      deepforest: emptyIsland(),
+      lagoon: emptyIsland(),
+      bay: emptyIsland(),
     },
     unlocked: [],
     equipped: {},
@@ -398,10 +436,24 @@ export function setDayChoice(p: GameProgress, choice: 'fresh' | 'continue'): Gam
   return { ...p, dayArc: { ...p.dayArc, choice } };
 }
 
-/** Mark a day-arc island's "it formed!" celebration as played (fires once). */
+/** Mark a day-arc island's "it formed!" celebration as played (fires once).
+ *  Also reused (tolerantly) for the advanced sister islands below — the
+ *  `celebrated` list is just a flat array of zone ids, not restricted to
+ *  DAY_ARC members. */
 export function markDayCelebrated(p: GameProgress, zone: ActivityZone): GameProgress {
   if (p.dayArc.celebrated.includes(zone)) return p;
   return { ...p, dayArc: { ...p.dayArc, celebrated: [...p.dayArc.celebrated, zone] } };
+}
+
+// ---- Advanced sister islands (🌷 garden / 🌲 deepforest / 🪷 lagoon / ⛵ bay) --
+// Plain gating: no dayArc/fresh choice involved. Each simply forms once its
+// PARENT skill island reaches 5/5 completed levels.
+
+/** Has this advanced sister island formed yet? */
+export function isAdvancedZoneUnlocked(p: GameProgress, zone: ActivityZone): boolean {
+  const parent = (ADVANCED_PARENT as Partial<Record<ActivityZone, ActivityZone>>)[zone];
+  if (!parent) return true; // not an advanced zone — always considered unlocked
+  return completedLevels(p, parent) >= MAX_LEVEL;
 }
 
 // ---- totals ----
@@ -430,12 +482,12 @@ export interface GrowthInfo {
   scale: number;
 }
 
-// Star thresholds for each growth stage. Retuned for the Nilu's Day update
-// (8 islands × 15 stars = 120 max) so the FINAL stage lands near the end of
-// the whole journey instead of leaving the day-arc islands with no growth
-// payoff. Existing players are protected by `growthFloor` — a stage once
-// reached is never lost.
-const GROWTH_THRESHOLDS = [0, 18, 45, 84];
+// Star thresholds for each growth stage. Retuned for the advanced sister
+// islands update (12 islands × 15 stars = 180 max) so the FINAL stage lands
+// near the end of the whole journey instead of leaving the newest islands
+// with no growth payoff. Existing players are protected by `growthFloor` — a
+// stage once reached is never lost.
+const GROWTH_THRESHOLDS = [0, 22, 60, 110];
 const GROWTH_LABELS = ['Baby Nilu', 'Little Nilu', 'Big Nilu', 'Grown-Up Nilu'];
 const GROWTH_SCALES = [0.7, 0.85, 1.0, 1.15];
 

--- a/components/game/BelusWorld/index.tsx
+++ b/components/game/BelusWorld/index.tsx
@@ -112,6 +112,18 @@ function loadSettings(): Settings {
   }
 }
 
+// Skill islands (as opposed to the Day-arc islands, which already get an
+// "a new island formed!" celebration) bloom silently via World.tsx's decor —
+// no other cue marks a finished level as progress. This gives each one a
+// zone-appropriate "the island is growing!" moment instead.
+const SKILL_ZONES: ActivityZone[] = ['meadow', 'forest', 'cove', 'shore'];
+const GROWTH_WORDING: Record<'meadow' | 'forest' | 'cove' | 'shore', { emoji: string; grew: string }> = {
+  meadow: { emoji: '🌼', grew: 'New flowers bloomed!' },
+  forest: { emoji: '🌳', grew: 'New trees appeared!' },
+  cove: { emoji: '💧', grew: 'The pool shimmers brighter!' },
+  shore: { emoji: '🐚', grew: 'More shells washed up!' },
+};
+
 const STICKER_KEYS: Record<ActivityZone, string> = {
   meadow: '💛',
   mountain: '⛰️',
@@ -167,6 +179,9 @@ export default function BelusWorldGame() {
 
   const rootRef = useRef<HTMLDivElement>(null);
   const lineTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // the on-screen "🤝 Help me" button calls whichever quest layer currently
+  // owns the status card (QuestLayer or MountainLayer claim this while active)
+  const helpRequestRef = useRef<() => void>(() => {});
   const settingsRef = useRef(settings);
   settingsRef.current = settings;
   const isTouch = useRef(typeof window !== 'undefined' && ('ontouchstart' in window || navigator.maxTouchPoints > 0));
@@ -232,6 +247,12 @@ export default function BelusWorldGame() {
   // island-forming celebration — fires once per day-arc island, the moment its
   // unlock condition flips true (and any reward toast is out of the way)
   const [islandFormed, setIslandFormed] = useState<{ zone: ActivityZone; label: string; emoji: string } | null>(null);
+
+  // skill-island "it's growing!" celebration — queued by handleQuestComplete,
+  // fired once the RewardToast for that same play closes (see RewardToast's
+  // onClose below), so it never competes with the stars/level-up moment.
+  const pendingGrowthRef = useRef<{ zone: ActivityZone; mastered: boolean } | null>(null);
+  const [growthToast, setGrowthToast] = useState<{ zone: ActivityZone; label: string; emoji: string; text: string; mastered: boolean } | null>(null);
 
   // ---- Home life: daily sparkles, garden, jar, remembered friends ----
   const dateKey = todayKey();
@@ -468,6 +489,15 @@ export default function BelusWorldGame() {
       setMemory(m);
 
       const mastered = completedLevels(nextProgress, zone) >= 5;
+
+      // a skill island (meadow/forest/cove/shore) blooms silently in the 3D
+      // world on every newly-finished level — queue a small toast for it so
+      // finishing a level actually feels like visible progress, not just
+      // stars. Never fires on a replay of an already-finished level.
+      if (SKILL_ZONES.includes(zone) && res.newLevel) {
+        pendingGrowthRef.current = { zone, mastered };
+      }
+
       setEmotion('excited');
       playSound(res.grewUp ? 'growup' : res.newLevel ? 'levelup' : 'star', settingsRef.current.sound);
       setReward({
@@ -549,6 +579,7 @@ export default function BelusWorldGame() {
           playSound={sfx}
           onQuestComplete={handleQuestComplete}
           onQuestStatus={setQuestStatus}
+          helpRequestRef={helpRequestRef}
         />
       </Suspense>
 
@@ -574,7 +605,10 @@ export default function BelusWorldGame() {
 
       <AnimatePresence>
         {questStatus && !paused && (
-          <QuestPanel status={questStatus} />
+          <QuestPanel
+            status={questStatus}
+            onHelp={() => { sfx('tap'); helpRequestRef.current(); }}
+          />
         )}
       </AnimatePresence>
 
@@ -614,8 +648,36 @@ export default function BelusWorldGame() {
           <RewardToast
             reward={reward}
             reduceMotion={settings.reduceMotion || settings.calmMode}
-            onClose={() => setReward(null)}
+            onClose={() => {
+              setReward(null);
+              const pending = pendingGrowthRef.current;
+              pendingGrowthRef.current = null;
+              if (!pending) return;
+              const isl = ISLANDS[pending.zone];
+              const wording = GROWTH_WORDING[pending.zone as 'meadow' | 'forest' | 'cove' | 'shore'];
+              playSound('growup', settingsRef.current.sound);
+              if (pending.mastered) {
+                speak(`${isl.label} is complete! Look at the glowing victory totem! ⭐`);
+              } else {
+                speak(`Look! ${isl.label} is growing! ${wording.emoji} ${wording.grew}`);
+              }
+              setEmotion('excited');
+              setGrowthToast({
+                zone: pending.zone,
+                label: isl.label,
+                emoji: wording.emoji,
+                text: pending.mastered ? `${isl.label} is complete! ⭐` : wording.grew,
+                mastered: pending.mastered,
+              });
+            }}
           />
+        )}
+      </AnimatePresence>
+
+      {/* "the island grew!" celebration for a skill island's newly-finished level */}
+      <AnimatePresence>
+        {growthToast && (
+          <IslandGrewToast info={growthToast} onClose={() => setGrowthToast(null)} />
         )}
       </AnimatePresence>
 
@@ -876,7 +938,7 @@ function LoadingWorld() {
 
 // The persistent "what to do right now" task card, pinned top-center. Keeps the
 // current question + progress on screen so the child always knows the next step.
-function QuestPanel({ status }: { status: QuestStatus }) {
+function QuestPanel({ status, onHelp }: { status: QuestStatus; onHelp: () => void }) {
   const correct = status.phase === 'correct';
   return (
     <motion.div
@@ -929,6 +991,19 @@ function QuestPanel({ status }: { status: QuestStatus }) {
           <p className="mt-1 text-xs font-semibold text-slate-500">
             {status.hint ?? 'Walk Nilu into the matching glowing orb 🫧 (or tap it)'}
           </p>
+        )}
+
+        {/* Stage-2 stuck-help: a friendly, no-pressure way out after ~36s of
+            no progress. Tapping it never costs stars — a friend just helps. */}
+        {!correct && status.helpOffered && (
+          <motion.button
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            onClick={onHelp}
+            className="pointer-events-auto mt-2 rounded-full bg-gradient-to-b from-amber-300 to-orange-400 px-5 py-2 text-sm font-bold text-amber-950 shadow-[0_4px_0_#e8920c,0_6px_10px_rgba(0,0,0,0.15)] transition active:translate-y-0.5"
+          >
+            🤝 Help me
+          </motion.button>
         )}
       </div>
     </motion.div>
@@ -1080,6 +1155,43 @@ function IslandFormedToast({ info, reduceMotion, onClose }: { info: { zone: Acti
           Let's go! →
         </button>
       </motion.div>
+    </motion.div>
+  );
+}
+
+// A small, brief "the island is growing!" toast for skill islands (meadow/
+// forest/cove/shore) — those bloom silently in the 3D world on every
+// finished level, so this is the only cue that a level just finished. Kept
+// short and auto-dismissing so it never blocks play, unlike the bigger
+// once-ever "a new island appeared!" toast above.
+function IslandGrewToast({
+  info,
+  onClose,
+}: {
+  info: { zone: ActivityZone; label: string; emoji: string; text: string; mastered: boolean };
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const t = setTimeout(onClose, 4500);
+    return () => clearTimeout(t);
+  }, [onClose]);
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -12 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -12 }}
+      className="fixed left-1/2 top-40 z-40 -translate-x-1/2"
+    >
+      <div
+        className="flex items-center gap-2 rounded-full bg-white px-5 py-2.5 text-center shadow-2xl"
+        style={{ border: info.mastered ? '2px solid #ffd166' : '2px solid #7ec850' }}
+      >
+        <span className="text-2xl">{info.emoji}</span>
+        <div className="text-left">
+          <p className="text-sm font-black text-slate-800">{info.label} is growing!</p>
+          <p className="text-xs font-semibold text-slate-500">{info.text}</p>
+        </div>
+      </div>
     </motion.div>
   );
 }

--- a/components/game/BelusWorld/index.tsx
+++ b/components/game/BelusWorld/index.tsx
@@ -66,6 +66,7 @@ import {
   recordDayStage,
   setDayChoice,
   markDayCelebrated,
+  isAdvancedZoneUnlocked,
   type GameProgress,
   type ActivityZone,
   type CosmeticSlot,
@@ -133,6 +134,10 @@ const STICKER_KEYS: Record<ActivityZone, string> = {
   school: '🏫',
   afternoon: '🏡',
   night: '🌙',
+  garden: '🌷',
+  deepforest: '🌲',
+  lagoon: '🪷',
+  bay: '⛵',
 };
 
 // Nilu's Day arc — the four stages of one day, in order (☀️→🏫→🏡→🌙)
@@ -221,6 +226,28 @@ export default function BelusWorldGame() {
     [dayUnlocks],
   );
 
+  // ---- Advanced sister islands: plain gating — each forms once its PARENT
+  // skill island reaches 5/5 completed levels (no dayArc/fresh choice). ----
+  const gardenUnlocked = useMemo(() => isAdvancedZoneUnlocked(progress, 'garden'), [progress]);
+  const deepforestUnlocked = useMemo(() => isAdvancedZoneUnlocked(progress, 'deepforest'), [progress]);
+  const lagoonUnlocked = useMemo(() => isAdvancedZoneUnlocked(progress, 'lagoon'), [progress]);
+  const bayUnlocked = useMemo(() => isAdvancedZoneUnlocked(progress, 'bay'), [progress]);
+  worldRuntime.gardenUnlocked = gardenUnlocked;
+  worldRuntime.deepforestUnlocked = deepforestUnlocked;
+  worldRuntime.lagoonUnlocked = lagoonUnlocked;
+  worldRuntime.bayUnlocked = bayUnlocked;
+  const advancedUnlocks = useMemo(
+    () => ({ garden: gardenUnlocked, deepforest: deepforestUnlocked, lagoon: lagoonUnlocked, bay: bayUnlocked }),
+    [gardenUnlocked, deepforestUnlocked, lagoonUnlocked, bayUnlocked],
+  );
+  const unlockedAdvancedZones = useMemo(
+    () =>
+      (['garden', 'deepforest', 'lagoon', 'bay'] as ActivityZone[]).filter(
+        (z) => advancedUnlocks[z as 'garden' | 'deepforest' | 'lagoon' | 'bay'],
+      ),
+    [advancedUnlocks],
+  );
+
   // the one-time fresh/continue chooser (players updating with real progress)
   const needsDayChoice = progress.dayArc.choice === null && totalCompletedLevels(progress) > 0;
   // new players never see the chooser — they simply live the day in order
@@ -244,8 +271,9 @@ export default function BelusWorldGame() {
     playSound('tap', settingsRef.current.sound);
   }, []);
 
-  // island-forming celebration — fires once per day-arc island, the moment its
-  // unlock condition flips true (and any reward toast is out of the way)
+  // island-forming celebration — fires once per day-arc OR advanced sister
+  // island, the moment its unlock condition flips true (and any reward toast
+  // is out of the way)
   const [islandFormed, setIslandFormed] = useState<{ zone: ActivityZone; label: string; emoji: string } | null>(null);
 
   // skill-island "it's growing!" celebration — queued by handleQuestComplete,
@@ -282,8 +310,15 @@ export default function BelusWorldGame() {
   useEffect(() => {
     if (phase !== 'world' || reward !== null || islandFormed !== null) return;
     if (progress.dayArc.choice === null) return; // chooser still open
-    const unlockedFlags: Record<'school' | 'afternoon' | 'night', boolean> = dayUnlocks;
-    for (const z of ['school', 'afternoon', 'night'] as const) {
+    // day-arc stages + advanced sister islands share the same "a new island
+    // formed!" celebration and the same tolerant `dayArc.celebrated` list —
+    // advanced zones just use plain parent-mastery gating (advancedUnlocks),
+    // no dayArc/fresh choice involved.
+    const unlockedFlags: Record<'school' | 'afternoon' | 'night' | 'garden' | 'deepforest' | 'lagoon' | 'bay', boolean> = {
+      ...dayUnlocks,
+      ...advancedUnlocks,
+    };
+    for (const z of ['school', 'afternoon', 'night', 'garden', 'deepforest', 'lagoon', 'bay'] as const) {
       if (!unlockedFlags[z] || progress.dayArc.celebrated.includes(z)) continue;
       const isl = ISLANDS[z];
       setProgress((p) => {
@@ -297,7 +332,7 @@ export default function BelusWorldGame() {
       setEmotion('excited');
       break; // one celebration at a time
     }
-  }, [phase, reward, islandFormed, progress, dayUnlocks, speak]);
+  }, [phase, reward, islandFormed, progress, dayUnlocks, advancedUnlocks, speak]);
 
   // persist comfort + speed settings so they don't reset each visit
   useEffect(() => {
@@ -560,6 +595,8 @@ export default function BelusWorldGame() {
           rainbowUnlocked={rainbowUnlocked}
           dayUnlocks={dayUnlocks}
           unlockedDayZones={unlockedDayZones}
+          advancedUnlocks={advancedUnlocks}
+          unlockedAdvancedZones={unlockedAdvancedZones}
           islandNextLevel={islandNextLevel}
           sound={settings.sound}
           dateKey={dateKey}

--- a/components/game/BelusWorld/three/GameCanvas.tsx
+++ b/components/game/BelusWorld/three/GameCanvas.tsx
@@ -14,7 +14,7 @@ import { Sky, PerformanceMonitor } from '@react-three/drei';
 import { EffectComposer, Bloom } from '@react-three/postprocessing';
 import * as THREE from 'three';
 import Player, { type PlayerHandle } from './Player';
-import World, { type DayUnlocks } from './World';
+import World, { type DayUnlocks, type AdvancedUnlocks } from './World';
 import HomeLife from './HomeLife';
 import RainbowPlay from './RainbowPlay';
 import type { AnimalSpecies } from './quest/Animal3D';
@@ -49,6 +49,10 @@ interface Props {
   dayUnlocks: DayUnlocks;
   /** day-arc zones whose islands exist — these run on the generic QuestLayer */
   unlockedDayZones: ActivityZone[];
+  /** which advanced sister islands have formed (garden/deepforest/lagoon/bay) */
+  advancedUnlocks: AdvancedUnlocks;
+  /** advanced-zone islands whose islands exist — these run on the generic QuestLayer */
+  unlockedAdvancedZones: ActivityZone[];
   /** which level to play next on each zone island */
   islandNextLevel: Record<ActivityZone, number>;
   sound: boolean;
@@ -118,6 +122,8 @@ export default function GameCanvas({
   rainbowUnlocked,
   dayUnlocks,
   unlockedDayZones,
+  advancedUnlocks,
+  unlockedAdvancedZones,
   islandNextLevel,
   sound,
   dateKey,
@@ -188,7 +194,7 @@ export default function GameCanvas({
       <Lighting calmMode={calmMode} />
 
       <Suspense fallback={null}>
-        <World activeZone={activeZone} reduceMotion={reduceMotion} islandLevels={islandLevels} rainbowUnlocked={rainbowUnlocked} dayUnlocks={dayUnlocks} />
+        <World activeZone={activeZone} reduceMotion={reduceMotion} islandLevels={islandLevels} rainbowUnlocked={rainbowUnlocked} dayUnlocks={dayUnlocks} advancedUnlocks={advancedUnlocks} />
         <Player
           ref={player}
           emotion={emotion}
@@ -269,10 +275,12 @@ export default function GameCanvas({
           onStatus={onQuestStatus}
         />
         {/* Sharing Shore + the Nilu's Day islands (School / Fun Corner /
-            Sleepy Island — only the ones that have formed) run on the generic
+            Sleepy Island — only the ones that have formed) + the advanced
+            sister islands (Feelings Garden / Deep Forest / Quiet Lagoon /
+            Treasure Bay — only the ones that have formed) run on the generic
             quest engine: island host + answer orbs, five levels each. */}
         <QuestLayer
-          zones={['shore', ...unlockedDayZones]}
+          zones={['shore', ...unlockedDayZones, ...unlockedAdvancedZones]}
           islandNextLevel={islandNextLevel}
           paused={paused}
           reduceMotion={reduceMotion}

--- a/components/game/BelusWorld/three/GameCanvas.tsx
+++ b/components/game/BelusWorld/three/GameCanvas.tsx
@@ -8,7 +8,7 @@
 // shadow map is modest, and the composer runs without extra multisampling.
 // ---------------------------------------------------------------------------
 
-import { Suspense, useRef, useState } from 'react';
+import { Suspense, useRef, useState, type MutableRefObject } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { Sky, PerformanceMonitor } from '@react-three/drei';
 import { EffectComposer, Bloom } from '@react-three/postprocessing';
@@ -74,6 +74,9 @@ interface Props {
   onPlant: () => void;
   onPetal: () => void;
   onFriendHealed: (species: string) => void;
+  /** the DOM "🤝 Help me" button (index.tsx QuestPanel) calls this when
+   *  tapped — QuestLayer and MountainLayer each claim it while active */
+  helpRequestRef?: MutableRefObject<() => void>;
 }
 
 function Lighting({ calmMode }: { calmMode: boolean }) {
@@ -134,6 +137,7 @@ export default function GameCanvas({
   onPlant,
   onPetal,
   onFriendHealed,
+  helpRequestRef,
 }: Props) {
   const player = useRef<PlayerHandle>(null);
   // start at a safe-ish ratio and let the monitor scale it to the device
@@ -252,6 +256,7 @@ export default function GameCanvas({
           playSound={playSound}
           onComplete={onQuestComplete}
           onStatus={onQuestStatus}
+          helpRequestRef={helpRequestRef}
         />
         <CoveLayer
           level={islandNextLevel.cove}
@@ -277,6 +282,7 @@ export default function GameCanvas({
           playSound={playSound}
           onComplete={onQuestComplete}
           onStatus={onQuestStatus}
+          helpRequestRef={helpRequestRef}
         />
       </Suspense>
 

--- a/components/game/BelusWorld/three/World.tsx
+++ b/components/game/BelusWorld/three/World.tsx
@@ -4,7 +4,8 @@
 // (which crystal is glowing because Nilu is near it).
 // ---------------------------------------------------------------------------
 
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Sparkles } from '@react-three/drei';
 import * as THREE from 'three';
 import { ISLAND_LIST, ISLANDS, BRIDGES, type ZoneId, type IslandDef } from './worldConfig';
 import { BRIDGE_SEGMENTS } from './worldMath';
@@ -85,7 +86,43 @@ function RainbowBridges({ hiddenKey, isHidden }: { hiddenKey: string; isHidden: 
 
 const MAX_BLOOM = 5;
 
-function ZoneDecor({ isl, bloom }: { isl: IslandDef; bloom: number }) {
+// Wraps the zone-specific decor with a visible "the island grew!" cue: a
+// short accent-coloured sparkle burst the moment `bloom` ticks up (a level
+// just finished), rather than the new decor simply existing on next render.
+// Static and skipped entirely under reduce-motion so the growth still reads
+// via the decor itself, without the extra flourish.
+function ZoneDecor({ isl, bloom, reduceMotion = false }: { isl: IslandDef; bloom: number; reduceMotion?: boolean }) {
+  const prevBloom = useRef(bloom);
+  const [justGrew, setJustGrew] = useState(false);
+  useEffect(() => {
+    if (bloom > prevBloom.current) {
+      prevBloom.current = bloom;
+      if (reduceMotion) return;
+      setJustGrew(true);
+      const t = setTimeout(() => setJustGrew(false), 2000);
+      return () => clearTimeout(t);
+    }
+    prevBloom.current = bloom;
+  }, [bloom, reduceMotion]);
+
+  return (
+    <>
+      <ZoneDecorContent isl={isl} bloom={bloom} />
+      {justGrew && (
+        <Sparkles
+          count={36}
+          scale={[isl.radius * 1.5, 3.2, isl.radius * 1.5]}
+          size={5}
+          speed={0.6}
+          color={isl.accent}
+          position={[isl.cx, isl.top + 1.4, isl.cz]}
+        />
+      )}
+    </>
+  );
+}
+
+function ZoneDecorContent({ isl, bloom }: { isl: IslandDef; bloom: number }) {
   const allItems = useMemo(() => {
     const rng = makeRng(isl.cx * 31 + isl.cz * 17 + 7);
     const out: { x: number; z: number; r: number }[] = [];
@@ -141,7 +178,7 @@ function ZoneDecor({ isl, bloom }: { isl: IslandDef; bloom: number }) {
           <coneGeometry args={[1.1, 1.5, 5]} />
           <meshStandardMaterial color="#ffffff" roughness={0.7} />
         </mesh>
-        {items.slice(0, 3).map((it, i) => (
+        {items.map((it, i) => (
           <mesh key={i} position={[bx * 0.7 + it.x * 0.4, y + 0.2, bz * 0.7 + it.z * 0.4]}>
             <dodecahedronGeometry args={[0.5 + it.r * 0.4, 0]} />
             <meshStandardMaterial color="#aeb8c4" roughness={1} />
@@ -171,7 +208,7 @@ function ZoneDecor({ isl, bloom }: { isl: IslandDef; bloom: number }) {
           <meshStandardMaterial color="#ffd166" emissive="#ffd166" emissiveIntensity={0.4} roughness={0.3} />
         </mesh>
         {/* book stacks */}
-        {items.slice(0, 3).map((it, i) => (
+        {items.map((it, i) => (
           <group key={i} position={[it.x * 0.6, y, it.z * 0.6]}>
             <mesh position={[0, 0.09, 0]}>
               <boxGeometry args={[0.7, 0.18, 0.5]} />
@@ -232,6 +269,13 @@ function ZoneDecor({ isl, bloom }: { isl: IslandDef; bloom: number }) {
             <meshStandardMaterial color={isl.accent} roughness={0.5} side={THREE.DoubleSide} emissive={isl.accent} emissiveIntensity={0.15} />
           </mesh>
         </group>
+        {/* scattered toys — fill in with the bloom, same as every other zone */}
+        {items.map((it, i) => (
+          <mesh key={i} position={[it.x * 0.7, y + 0.2, it.z * 0.7]}>
+            <boxGeometry args={[0.3 + it.r * 0.15, 0.3 + it.r * 0.15, 0.3 + it.r * 0.15]} />
+            <meshStandardMaterial color={i % 2 ? '#fb7185' : '#ffd166'} roughness={0.6} />
+          </mesh>
+        ))}
       </group>
     );
   }
@@ -270,9 +314,9 @@ function ZoneDecor({ isl, bloom }: { isl: IslandDef; bloom: number }) {
           </mesh>
           <pointLight color="#ffe9a3" intensity={1.2} distance={9} position={[0, 3.0, 0]} />
         </group>
-        {/* two soft stars */}
-        {[[2.6, 1.9], [-1.4, -2.8]].map(([sx, sz], i) => (
-          <mesh key={i} position={[sx, y + 1.6 + i * 0.7, sz]}>
+        {/* soft stars — fill in with the bloom, same as every other zone */}
+        {items.map((it, i) => (
+          <mesh key={i} position={[it.x * 0.5, y + 1.6 + it.r * 1.2, it.z * 0.5]}>
             <octahedronGeometry args={[0.3, 0]} />
             <meshStandardMaterial color="#fff4b0" emissive={isl.accent} emissiveIntensity={0.9} roughness={0.2} />
           </mesh>
@@ -280,7 +324,32 @@ function ZoneDecor({ isl, bloom }: { isl: IslandDef; bloom: number }) {
       </group>
     );
   }
-  // cove — a calm pool + waterfall off the rim
+  if (isl.id === 'shore') {
+    // a beach: a driftwood sandcastle backdrop + scattered shells that fill in
+    // with the bloom, same "island visibly grows" contract as every other zone
+    return (
+      <group position={[isl.cx, 0, isl.cz]}>
+        <group position={[isl.radius * 0.5, y, -isl.radius * 0.3]}>
+          <mesh position={[0, 0.5, 0]}>
+            <cylinderGeometry args={[0.55, 0.7, 1.0, 12]} />
+            <meshStandardMaterial color="#f2dfa9" roughness={0.9} />
+          </mesh>
+          <mesh position={[0, 1.15, 0]}>
+            <coneGeometry args={[0.5, 0.5, 12]} />
+            <meshStandardMaterial color="#e8c67a" roughness={0.9} />
+          </mesh>
+        </group>
+        {items.map((it, i) => (
+          <mesh key={i} position={[it.x, y + 0.03, it.z]} rotation={[-Math.PI / 2, 0, it.r * 6]}>
+            <circleGeometry args={[0.28 + it.r * 0.14, 8]} />
+            <meshStandardMaterial color={i % 2 ? '#ffb066' : '#ffffff'} roughness={0.6} />
+          </mesh>
+        ))}
+      </group>
+    );
+  }
+  // cove — a calm pool + waterfall off the rim, with rocks filling in as
+  // levels complete
   return (
     <group position={[isl.cx, 0, isl.cz]}>
       <mesh position={[0, y + 0.05, 0]} rotation={[-Math.PI / 2, 0, 0]}>
@@ -288,10 +357,12 @@ function ZoneDecor({ isl, bloom }: { isl: IslandDef; bloom: number }) {
         <meshStandardMaterial color="#4fc3e0" transparent opacity={0.8} roughness={0.1} metalness={0.2} emissive="#2a9fc0" emissiveIntensity={0.2} />
       </mesh>
       <Waterfall position={[0, y - 2.5, isl.radius - 0.5]} />
-      <mesh position={[-isl.radius * 0.55, y + 0.2, isl.radius * 0.3]}>
-        <dodecahedronGeometry args={[0.7, 0]} />
-        <meshStandardMaterial color="#8aa0b0" roughness={1} />
-      </mesh>
+      {items.map((it, i) => (
+        <mesh key={i} position={[it.x, y + 0.2, it.z]}>
+          <dodecahedronGeometry args={[0.4 + it.r * 0.4, 0]} />
+          <meshStandardMaterial color="#8aa0b0" roughness={1} />
+        </mesh>
+      ))}
     </group>
   );
 }
@@ -405,7 +476,7 @@ export default function World({ activeZone, reduceMotion, islandLevels, rainbowU
         const bloom = islandLevels[isl.id] ?? 0;
         return (
           <group key={isl.id}>
-            <ZoneDecor isl={isl} bloom={bloom} />
+            <ZoneDecor isl={isl} bloom={bloom} reduceMotion={reduceMotion} />
             {bloom >= MAX_BLOOM && <Landmark isl={isl} />}
           </group>
         );

--- a/components/game/BelusWorld/three/World.tsx
+++ b/components/game/BelusWorld/three/World.tsx
@@ -348,6 +348,160 @@ function ZoneDecorContent({ isl, bloom }: { isl: IslandDef; bloom: number }) {
       </group>
     );
   }
+  if (isl.id === 'garden') {
+    // Feelings Garden — dense flower BEDS in pinks (rows/clusters, not just
+    // scattered singles like the meadow), plus a small trellis archway
+    const palette = ['#ff8fc8', '#ffb3d9', '#ff6ba3', '#ffd6e8', '#f472b6'];
+    return (
+      <group position={[isl.cx, 0, isl.cz]}>
+        {/* trellis archway at the back edge */}
+        <group position={[isl.radius * 0.45, y, -isl.radius * 0.35]}>
+          <mesh position={[-0.8, 1.1, 0]}>
+            <cylinderGeometry args={[0.08, 0.08, 2.2, 8]} />
+            <meshStandardMaterial color="#caa46a" roughness={0.8} />
+          </mesh>
+          <mesh position={[0.8, 1.1, 0]}>
+            <cylinderGeometry args={[0.08, 0.08, 2.2, 8]} />
+            <meshStandardMaterial color="#caa46a" roughness={0.8} />
+          </mesh>
+          <mesh position={[0, 2.2, 0]}>
+            <torusGeometry args={[0.85, 0.08, 8, 20, Math.PI]} />
+            <meshStandardMaterial color="#caa46a" roughness={0.8} />
+          </mesh>
+        </group>
+        {/* flower beds — small clustered patches instead of single stems */}
+        {items.map((it, i) => (
+          <group key={i} position={[it.x, y, it.z]}>
+            {[0, 1, 2].map((k) => (
+              <Flower
+                key={k}
+                position={[Math.cos(k * 2.1) * 0.35, 0, Math.sin(k * 2.1) * 0.35]}
+                color={palette[(i + k) % palette.length]}
+              />
+            ))}
+          </group>
+        ))}
+      </group>
+    );
+  }
+  if (isl.id === 'deepforest') {
+    // Deep Forest — denser, darker-green trees than Friendship Forest, plus
+    // little mushroom clusters filling in with the bloom
+    return (
+      <group position={[isl.cx, 0, isl.cz]}>
+        {items.map((it, i) => (
+          <Tree key={`t-${i}`} position={[it.x, y, it.z]} scale={0.9 + it.r * 0.7} leaf={i % 2 ? '#1f5c34' : '#245e2e'} />
+        ))}
+        {items.map((it, i) => (
+          <group key={`m-${i}`} position={[it.x * 0.55, y, it.z * 0.55]}>
+            <mesh position={[0, 0.12, 0]}>
+              <cylinderGeometry args={[0.05, 0.06, 0.24, 8]} />
+              <meshStandardMaterial color="#f2e3c9" roughness={0.9} />
+            </mesh>
+            <mesh position={[0, 0.28, 0]}>
+              <sphereGeometry args={[0.16, 12, 8, 0, Math.PI * 2, 0, Math.PI / 2]} />
+              <meshStandardMaterial color={i % 2 ? '#e8736b' : '#caa46a'} roughness={0.7} />
+            </mesh>
+          </group>
+        ))}
+      </group>
+    );
+  }
+  if (isl.id === 'lagoon') {
+    // Quiet Lagoon — a calm pool ringed with lily pads + tall reeds
+    return (
+      <group position={[isl.cx, 0, isl.cz]}>
+        <mesh position={[0, y + 0.05, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+          <circleGeometry args={[isl.radius * 0.6, 36]} />
+          <meshStandardMaterial color="#3fb8c9" transparent opacity={0.82} roughness={0.1} metalness={0.15} emissive="#1f8a9c" emissiveIntensity={0.2} />
+        </mesh>
+        {items.map((it, i) => (
+          <mesh key={`lily-${i}`} position={[it.x, y + 0.08, it.z]} rotation={[-Math.PI / 2, 0, it.r * 5]}>
+            <circleGeometry args={[0.35 + it.r * 0.2, 10]} />
+            <meshStandardMaterial color="#3fae5a" roughness={0.7} />
+          </mesh>
+        ))}
+        {/* reeds around the rim */}
+        {[0, 1, 2, 3].map((i) => {
+          const a = (i / 4) * Math.PI * 2;
+          const rx = Math.cos(a) * isl.radius * 0.85;
+          const rz = Math.sin(a) * isl.radius * 0.85;
+          return (
+            <group key={`reed-${i}`} position={[rx, y, rz]}>
+              <mesh position={[0, 0.9, 0]}>
+                <cylinderGeometry args={[0.04, 0.05, 1.8, 6]} />
+                <meshStandardMaterial color="#2f7d4a" roughness={0.8} />
+              </mesh>
+              <mesh position={[0.08, 1.7, 0]} rotation={[0, 0, 0.3]}>
+                <coneGeometry args={[0.12, 0.5, 6]} />
+                <meshStandardMaterial color="#3fae5a" roughness={0.8} />
+              </mesh>
+            </group>
+          );
+        })}
+      </group>
+    );
+  }
+  if (isl.id === 'bay') {
+    // Treasure Bay — a beached boat hull, a treasure chest, and a leaning palm
+    return (
+      <group position={[isl.cx, 0, isl.cz]}>
+        {/* boat hull */}
+        <group position={[isl.radius * 0.45, y, -isl.radius * 0.3]} rotation={[0, 0.5, 0]}>
+          <mesh position={[0, 0.35, 0]}>
+            <cylinderGeometry args={[0.9, 0.55, 0.9, 16, 1, false, 0, Math.PI]} />
+            <meshStandardMaterial color="#caa46a" roughness={0.8} side={THREE.DoubleSide} />
+          </mesh>
+          <mesh position={[0, 1.1, 0]}>
+            <cylinderGeometry args={[0.05, 0.05, 1.6, 6]} />
+            <meshStandardMaterial color="#9a5a3b" roughness={0.8} />
+          </mesh>
+          <mesh position={[0.35, 1.55, 0]} rotation={[0, 0, -0.2]}>
+            <planeGeometry args={[0.8, 0.6]} />
+            <meshStandardMaterial color="#ffffff" roughness={0.6} side={THREE.DoubleSide} />
+          </mesh>
+        </group>
+        {/* treasure chest */}
+        <group position={[-isl.radius * 0.4, y, isl.radius * 0.2]}>
+          <mesh position={[0, 0.25, 0]}>
+            <boxGeometry args={[0.7, 0.5, 0.5]} />
+            <meshStandardMaterial color="#9a5a3b" roughness={0.8} />
+          </mesh>
+          <mesh position={[0, 0.55, 0]}>
+            <cylinderGeometry args={[0.35, 0.35, 0.5, 16, 1, false, 0, Math.PI]} />
+            <meshStandardMaterial color="#caa46a" roughness={0.7} side={THREE.DoubleSide} />
+          </mesh>
+          <mesh position={[0, 0.42, 0.26]}>
+            <sphereGeometry args={[0.06, 10, 8]} />
+            <meshStandardMaterial color="#ffd166" emissive="#ffd166" emissiveIntensity={0.6} roughness={0.3} />
+          </mesh>
+        </group>
+        {/* leaning palm */}
+        <group position={[0, y, isl.radius * 0.55]} rotation={[0, 0, 0.15]}>
+          <mesh position={[0, 1.6, 0]}>
+            <cylinderGeometry args={[0.12, 0.18, 3.2, 8]} />
+            <meshStandardMaterial color="#a5824f" roughness={0.85} />
+          </mesh>
+          {[0, 1, 2, 3, 4].map((i) => {
+            const a = (i / 5) * Math.PI * 2;
+            return (
+              <mesh key={i} position={[Math.cos(a) * 0.5, 3.2, Math.sin(a) * 0.5]} rotation={[0.5, a, 0]}>
+                <coneGeometry args={[0.25, 1.4, 4]} />
+                <meshStandardMaterial color="#3fae5a" roughness={0.8} />
+              </mesh>
+            );
+          })}
+        </group>
+        {/* scattered shells/gold — fill in with the bloom, same contract as shore */}
+        {items.map((it, i) => (
+          <mesh key={i} position={[it.x, y + 0.05, it.z]} rotation={[-Math.PI / 2, 0, it.r * 6]}>
+            <circleGeometry args={[0.22 + it.r * 0.12, 8]} />
+            <meshStandardMaterial color={i % 2 ? '#ffd166' : '#ffffff'} roughness={0.5} metalness={i % 2 ? 0.3 : 0} />
+          </mesh>
+        ))}
+      </group>
+    );
+  }
   // cove — a calm pool + waterfall off the rim, with rocks filling in as
   // levels complete
   return (
@@ -444,6 +598,14 @@ export interface DayUnlocks {
   night: boolean;
 }
 
+/** Which advanced sister islands have formed (see progress.ts isAdvancedZoneUnlocked). */
+export interface AdvancedUnlocks {
+  garden: boolean;
+  deepforest: boolean;
+  lagoon: boolean;
+  bay: boolean;
+}
+
 interface Props {
   activeZone: ZoneId | null;
   reduceMotion: boolean;
@@ -452,18 +614,24 @@ interface Props {
   rainbowUnlocked: boolean;
   /** which Nilu's Day islands have formed */
   dayUnlocks: DayUnlocks;
+  /** which advanced sister islands have formed */
+  advancedUnlocks: AdvancedUnlocks;
 }
 
-export default function World({ activeZone, reduceMotion, islandLevels, rainbowUnlocked, dayUnlocks }: Props) {
+export default function World({ activeZone, reduceMotion, islandLevels, rainbowUnlocked, dayUnlocks, advancedUnlocks }: Props) {
   // a locked island physically does not exist yet: no island, no decor, no bridge
   const isHidden = (z: ZoneId): boolean => {
     if (z === 'rainbow') return !rainbowUnlocked;
     if (z === 'school') return !dayUnlocks.school;
     if (z === 'afternoon') return !dayUnlocks.afternoon;
     if (z === 'night') return !dayUnlocks.night;
+    if (z === 'garden') return !advancedUnlocks.garden;
+    if (z === 'deepforest') return !advancedUnlocks.deepforest;
+    if (z === 'lagoon') return !advancedUnlocks.lagoon;
+    if (z === 'bay') return !advancedUnlocks.bay;
     return false;
   };
-  const hiddenKey = `${rainbowUnlocked}-${dayUnlocks.school}-${dayUnlocks.afternoon}-${dayUnlocks.night}`;
+  const hiddenKey = `${rainbowUnlocked}-${dayUnlocks.school}-${dayUnlocks.afternoon}-${dayUnlocks.night}-${advancedUnlocks.garden}-${advancedUnlocks.deepforest}-${advancedUnlocks.lagoon}-${advancedUnlocks.bay}`;
   return (
     <group>
       <Clouds reduceMotion={reduceMotion} />

--- a/components/game/BelusWorld/three/quest/CarryItem.tsx
+++ b/components/game/BelusWorld/three/quest/CarryItem.tsx
@@ -20,16 +20,23 @@ interface Props {
   carrying: boolean;
   reduceMotion: boolean;
   bobSeed?: number;
+  /** this is the NEXT thing the child should fetch — a small ⬇️ arrow hovers
+   *  above it and it bounces a touch more, so "which one do I grab?" is
+   *  always answerable at a glance (static arrow, no extra bounce under
+   *  reduce-motion). */
+  isNext?: boolean;
 }
 
 const HEAD_HEIGHT = 2.15;
 
 export default function CarryItem({
-  pedestalPosition, emoji, caption, color, carrying, reduceMotion, bobSeed = 0,
+  pedestalPosition, emoji, caption, color, carrying, reduceMotion, bobSeed = 0, isNext = false,
 }: Props) {
   const grp = useRef<THREE.Group>(null);
+  const arrow = useRef<THREE.Sprite>(null);
   const t = useRef(bobSeed);
   const tex = useMemo(() => makeLabelTexture(emoji, caption), [emoji, caption]);
+  const arrowTex = useMemo(() => makeLabelTexture('⬇️'), []);
 
   useFrame((_, dt) => {
     t.current += dt;
@@ -42,6 +49,12 @@ export default function CarryItem({
       const bob = reduceMotion ? 0 : Math.sin(t.current * 2) * 0.14;
       g.position.set(pedestalPosition[0], pedestalPosition[1] + bob, pedestalPosition[2]);
     }
+    // the "fetch this one next" arrow — a gentle bounce, or a static hover
+    // under reduce-motion so it's never overlooked but never overwhelming
+    if (arrow.current) {
+      const bounce = reduceMotion ? 0 : Math.abs(Math.sin(t.current * 3)) * 0.18;
+      arrow.current.position.y = 1.05 + bounce;
+    }
   });
 
   return (
@@ -51,7 +64,7 @@ export default function CarryItem({
         <meshStandardMaterial
           color={color}
           emissive={color}
-          emissiveIntensity={carrying ? 1.5 : 0.9}
+          emissiveIntensity={carrying ? 1.5 : isNext ? 1.3 : 0.9}
           roughness={0.3}
           transparent
           opacity={0.8}
@@ -65,6 +78,11 @@ export default function CarryItem({
           <ringGeometry args={[0.4, 0.56, 24]} />
           <meshBasicMaterial color={color} transparent opacity={0.5} side={THREE.DoubleSide} />
         </mesh>
+      )}
+      {!carrying && isNext && (
+        <sprite ref={arrow} position={[0, 1.05, 0]} scale={[0.9, 0.9, 1]} renderOrder={12}>
+          <spriteMaterial map={arrowTex} transparent depthWrite={false} depthTest={false} />
+        </sprite>
       )}
     </group>
   );

--- a/components/game/BelusWorld/three/quest/CoveLayer.tsx
+++ b/components/game/BelusWorld/three/quest/CoveLayer.tsx
@@ -30,8 +30,11 @@ import type { QuestStatus } from './QuestLayer';
 const ZONE = 'cove' as const;
 const POSE_HOLD_TICK = 0.9; // seconds between each spoken count of a pose hold
 const COUNT_WORDS = ['One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight'];
-const TOTEM_DIST = 3.0; // how far the totems sit out in front, toward home
-const TOTEM_SPREAD = 2.9; // sideways gap between totems (no overlap)
+const TOTEM_DIST = 2.0; // how far the FRONT row of totems sits, toward home
+const TOTEM_ROW_GAP = 4.8; // depth between the front and back row (plan round)
+const TOTEM_SPREAD = 5.0; // sideways gap between totems (a parent reported the
+// Forest word-orb version of this same fan being too tight to steer between —
+// PICK_RADIUS-sized circles need real daylight between centres)
 const TOTEM_PICK = 1.6; // walk this close to a totem to choose it
 const SHELL_FIND = 1.5; // walk this close to a hidden shell to discover it
 const INVITE_START = 2.6; // walk this close to the calm-friend to BEGIN (consent)
@@ -125,24 +128,33 @@ export default function CoveLayer(props: Props) {
     return [isl.cx + (-isl.cx / len) * 2.6, isl.top + 2.4, isl.cz + (-isl.cz / len) * 2.6];
   };
 
-  // lay the pre-step totems out in an arc on the home-facing side of the cove
+  // lay the pre-step totems out on the home-facing side of the cove. Up to 4
+  // fit comfortably in one row at the ≥5-apart spacing; the level-5 calm-plan
+  // round offers all 6 strategies, which needs a second row (further back)
+  // to keep every totem inside the island's walkable radius.
   function totemLayout(n: number): [number, number, number][] {
     const len = Math.hypot(isl.cx, isl.cz) || 1;
     const dx = -isl.cx / len; // toward home
     const dz = -isl.cz / len;
     const px = -dz;
     const pz = dx;
-    const out: [number, number, number][] = [];
-    for (let i = 0; i < n; i++) {
-      const frac = n === 1 ? 0 : i / (n - 1) - 0.5;
-      const off = frac * (n - 1) * TOTEM_SPREAD;
-      out.push([
-        isl.cx + dx * TOTEM_DIST + px * off,
-        isl.top + 1.0,
-        isl.cz + dz * TOTEM_DIST + pz * off,
-      ]);
-    }
-    return out;
+    const row = (count: number, dist: number): [number, number, number][] => {
+      const out: [number, number, number][] = [];
+      for (let i = 0; i < count; i++) {
+        const frac = count === 1 ? 0 : i / (count - 1) - 0.5;
+        const off = frac * (count - 1) * TOTEM_SPREAD;
+        out.push([
+          isl.cx + dx * dist + px * off,
+          isl.top + 1.0,
+          isl.cz + dz * dist + pz * off,
+        ]);
+      }
+      return out;
+    };
+    if (n <= 4) return row(n, TOTEM_DIST);
+    const front = Math.ceil(n / 2);
+    const back = n - front;
+    return [...row(front, TOTEM_DIST), ...row(back, TOTEM_DIST + TOTEM_ROW_GAP)];
   }
 
   function emitStatus(phase: 'question' | 'correct', instruction: string, hint?: string) {

--- a/components/game/BelusWorld/three/quest/ForestLayer.tsx
+++ b/components/game/BelusWorld/three/quest/ForestLayer.tsx
@@ -35,9 +35,15 @@ import type { QuestStatus } from './QuestLayer';
 const ZONE = 'forest' as const;
 const APPROACH = 4.8; // stay this close to a friend while it listens & you cast
 const LINGER = 1.4; // seconds close before the word bubbles appear
-const WORD_DIST = 3.0; // how far the word bubbles sit in front of the friend
-const WORD_SPREAD = 2.6; // sideways gap between word bubbles (no overlap)
-const WORD_PICK = 1.5; // walk this close to a word bubble to "say" it
+const WORD_DIST = 2.0; // how far the word bubbles sit in front of the friend
+// Sideways gap between word bubbles. A parent reported these exact orbs
+// ("sleeping/eating/running") sitting "too close together to navigate
+// precisely". Several forest friends are authored close to the island's
+// edge, so this is the largest spread that still keeps every word bubble on
+// the island for the biggest round (4 words); WORD_PICK is trimmed slightly
+// too, so the gap still clears it with real room to spare.
+const WORD_SPREAD = 3.0;
+const WORD_PICK = 1.3; // walk this close to a word bubble to "say" it
 const TWINKLE_PICK = 1.9; // walk this close to a hidden twinkle to collect it
 const INVITE_START = 2.4; // walk this close to the waving host to BEGIN (consent)
 const GREET_DIST = 4.0; // a healed friend recognises Nilu from this far

--- a/components/game/BelusWorld/three/quest/MountainLayer.tsx
+++ b/components/game/BelusWorld/three/quest/MountainLayer.tsx
@@ -57,7 +57,20 @@ interface State {
   // companion cloud + Nimbus cheer pulse
   cheerUntil: number;
   nimbusLine: number;
+  /** stuck-help: same two-stage escalation as QuestLayer (18s coach hint +
+   *  spotlight, 36s "Help me" button) — reset whenever a station is reached */
+  lastProgressAt: number;
+  helpStage: 0 | 1 | 2 | 3;
+  helping: boolean;
+  helpFinishAt: number;
+  /** the instruction text last sent to the DOM card, so a stuck-help status
+   *  re-emit (to flip on helpOffered) doesn't clobber it */
+  lastInstruction: string;
 }
+
+const HELP_HINT_AT = 18;
+const HELP_BUTTON_AT = 36;
+const HELP_ANIM_TIME = 1.6;
 
 interface Props {
   level: number;
@@ -72,6 +85,9 @@ interface Props {
   playSound: (kind: 'tap' | 'correct' | 'star' | 'levelup' | 'growup') => void;
   onComplete: (zone: 'mountain', level: number, stars: number, moment: string, slips?: number) => void;
   onStatus: (s: QuestStatus | null) => void;
+  /** the DOM "🤝 Help me" button (index.tsx QuestPanel) calls this ref when
+   *  tapped, while this layer is the active one */
+  helpRequestRef?: import('react').MutableRefObject<() => void>;
 }
 
 function clampLevel(level: number) {
@@ -134,9 +150,16 @@ export default function MountainLayer(props: Props) {
     doneCount: 0, disarmed: false, wrongIdx: -1, wrongUntil: 0, lockUntil: 0, finishAt: 0, slips: 0,
     starsAt: (MOUNTAIN_ROUTINE[clampLevel(props.level)].stars ?? []).map(() => -99),
     starsFound: 0, cheerUntil: 0, nimbusLine: -1,
+    lastProgressAt: 0, helpStage: 0, helping: false, helpFinishAt: 0, lastInstruction: '',
   });
   const frame = useRef<(dt: number) => void>(() => {});
   const isl = ISLANDS[ZONE];
+
+  // wire the DOM "🤝 Help me" button to this layer only while its routine
+  // is actually active
+  if (props.helpRequestRef && S.current.active) {
+    props.helpRequestRef.current = () => doHelp();
+  }
 
   // today's pedestal-placement shuffle — stable all day, fresh tomorrow
   const shuffledPos = useMemo(() => dailyStationShuffle(props.dateKey), [props.dateKey]);
@@ -166,11 +189,55 @@ export default function MountainLayer(props: Props) {
 
   function emitStatus(phase: 'question' | 'correct', instruction: string, hint?: string) {
     const lvl = MOUNTAIN_ROUTINE[clampLevel(S.current.level)];
+    S.current.lastInstruction = instruction;
     props.onStatus({
       zone: ZONE, title: isl.label, emoji: isl.emoji, accent: isl.accent,
       level: S.current.level, instruction, step: S.current.doneCount,
       total: targetCount(lvl.stations), phase, hint,
+      helpOffered: S.current.helpStage >= 2,
     });
+  }
+
+  /** the correct next station to visit right now (works for ordered chains,
+   *  safety pairs, and the any-order finale alike — the un-safe twin is
+   *  never "correct") */
+  function nextCorrectStationIdx(): number {
+    const lvl = MOUNTAIN_ROUTINE[clampLevel(S.current.level)];
+    return lvl.stations.findIndex((s, i) => s.kind !== 'unsafe' && !S.current.stations[i].done);
+  }
+
+  /** Fill in the rest of the routine as if the child had walked it, then
+   *  finish — used after the "watch me" assist beat. Never counted as a slip. */
+  function completeRoutineAssisted() {
+    const st = S.current;
+    st.helping = false;
+    const lvl = MOUNTAIN_ROUTINE[clampLevel(st.level)];
+    lvl.stations.forEach((s, i) => {
+      if (s.kind !== 'unsafe' && !st.stations[i].done) {
+        st.stations[i].done = true;
+        st.stations[i].doneAt = st.clock;
+        st.doneCount += 1;
+      }
+    });
+    props.playSound('levelup');
+    st.cheerUntil = st.clock + 2.0;
+    emitStatus('correct', 'Now you did it! 💙', 'Routine complete! 🌟');
+    st.finishAt = st.clock + 1.8;
+    bump();
+  }
+
+  /** Tapping "🤝 Help me" (Stage 2). Nimbus does the rest of the routine
+   *  together with Nilu — stars are never docked for asking for help. */
+  function doHelp() {
+    const st = S.current;
+    if (!st.active || st.helpStage < 2 || st.helping) return;
+    st.helpStage = 3; // used — one help per routine
+    st.helping = true;
+    st.helpFinishAt = st.clock + HELP_ANIM_TIME;
+    props.setEmotion('curious');
+    props.speak('Let’s do it together! Watch me…');
+    emitStatus('question', st.lastInstruction);
+    bump();
   }
 
   // the hint depends on the level's mechanic so the task card guides the child
@@ -199,6 +266,10 @@ export default function MountainLayer(props: Props) {
     S.current.cheerUntil = 0;
     S.current.nimbusLine = -1;
     S.current.slips = 0;
+    S.current.lastProgressAt = S.current.clock;
+    S.current.helpStage = 0;
+    S.current.helping = false;
+    S.current.helpFinishAt = 0;
     props.setEmotion('curious');
     props.speak(lvl.intro);
     emitStatus('question', lvl.intro, actionHint());
@@ -270,6 +341,8 @@ export default function MountainLayer(props: Props) {
     st.stations[i].doneAt = st.clock;
     st.doneCount += 1;
     st.lockUntil = st.clock + 0.4;
+    st.lastProgressAt = st.clock;
+    if (st.helpStage > 0 && st.helpStage < 3) st.helpStage = 0;
     props.playSound('correct');
     props.setEmotion('excited');
 
@@ -330,6 +403,30 @@ export default function MountainLayer(props: Props) {
       stopRoutine();
       return;
     }
+
+    // stuck-help: same two-stage escalation as the generic quest engine —
+    // 18s without a station completed → coach hint + spotlight; 18s more →
+    // "Help me" button. Reset whenever a station is reached (see reach()).
+    if (!st.helping) {
+      const stuckFor = st.clock - st.lastProgressAt;
+      if (st.helpStage < 1 && stuckFor >= HELP_HINT_AT) {
+        st.helpStage = 1;
+        const idx = nextCorrectStationIdx();
+        if (idx >= 0) props.speak(`${lvl.stations[idx].label}! Walk to it ${lvl.stations[idx].emoji}!`);
+        bump();
+      } else if (st.helpStage === 1 && stuckFor >= HELP_BUTTON_AT) {
+        st.helpStage = 2;
+        emitStatus('question', st.lastInstruction, actionHint());
+        bump();
+      }
+    }
+
+    // mid "watch me" assist — freeze normal picking until it lands
+    if (st.helping) {
+      if (st.clock >= st.helpFinishAt) completeRoutineAssisted();
+      return;
+    }
+
     // hidden morning stars: collect any Nilu walks near (no lock — pure bonus)
     const stars = lvl.stars ?? [];
     for (let i = 0; i < stars.length; i++) {
@@ -374,6 +471,8 @@ export default function MountainLayer(props: Props) {
   const cheering = S.current.active && S.current.clock < S.current.cheerUntil;
   const awake = S.current.active; // Nimbus naps until the routine begins
   const starList = lvl.stars ?? [];
+  // Stage-1 stuck-help spotlight: which station is the correct next one?
+  const helpBeaconIdx = S.current.active && S.current.helpStage >= 1 ? nextCorrectStationIdx() : -1;
   return (
     <group>
       <Ticker fnRef={frame} />
@@ -437,9 +536,34 @@ export default function MountainLayer(props: Props) {
             )}
             {/* a glowing footprint pad that lights up once this step is done */}
             <StepStone position={[0, 0.06, 1.05]} lit={rt.done} accent={isl.accent} />
+            {/* Stage-1 stuck-help spotlight — a bright beacon on the correct station */}
+            {i === helpBeaconIdx && <HelpBeacon reduceMotion={props.reduceMotion} />}
           </Station3D>
         );
       })}
+    </group>
+  );
+}
+
+// Stuck-help spotlight: a bright pulsing gold beacon dropped above whatever
+// station the child should walk to next. Static (no pulse) under
+// reduce-motion so it reads as a clear, calm spotlight rather than a
+// distraction. Rendered as a child of Station3D, so it inherits its position.
+function HelpBeacon({ reduceMotion }: { reduceMotion: boolean }) {
+  const ring = useRef<THREE.Mesh>(null);
+  const t = useRef(0);
+  useFrame((_, dt) => {
+    t.current += dt;
+    if (!ring.current) return;
+    ring.current.scale.setScalar(reduceMotion ? 1.3 : 1.1 + Math.sin(t.current * 3.2) * 0.25);
+  });
+  return (
+    <group position={[0, 2.4, 0]}>
+      <mesh ref={ring} rotation={[-Math.PI / 2, 0, 0]}>
+        <ringGeometry args={[0.5, 0.72, 28]} />
+        <meshBasicMaterial color="#ffe066" transparent opacity={0.85} side={THREE.DoubleSide} depthWrite={false} />
+      </mesh>
+      <pointLight color="#ffe066" intensity={1.4} distance={4} />
     </group>
   );
 }

--- a/components/game/BelusWorld/three/quest/QuestLayer.tsx
+++ b/components/game/BelusWorld/three/quest/QuestLayer.tsx
@@ -27,6 +27,7 @@ import CarrySlot, { type SlotStatus } from './CarrySlot';
 const ALL_ZONES: ActivityZone[] = [
   'meadow', 'mountain', 'cove', 'forest', 'shore',
   'school', 'afternoon', 'night',
+  'garden', 'deepforest', 'lagoon', 'bay',
 ];
 
 // idle "host" friends so each island feels inhabited before you arrive
@@ -39,6 +40,10 @@ const HOSTS: Record<ActivityZone, { face: string; mood: Mood }> = {
   school: { face: '🦉', mood: 'happy' },
   afternoon: { face: '🐕', mood: 'happy' },
   night: { face: '🐑', mood: 'calm' },
+  garden: { face: '🦋', mood: 'happy' },
+  deepforest: { face: '🦌', mood: 'happy' },
+  lagoon: { face: '🐬', mood: 'calm' },
+  bay: { face: '🦜', mood: 'happy' },
 };
 
 const PICK_RADIUS = 2.4; // how close Nilu must walk to choose an orb (generous +
@@ -913,6 +918,10 @@ export default function QuestLayer(props: Props) {
     school: ISLANDS.school.accent,
     afternoon: ISLANDS.afternoon.accent,
     night: ISLANDS.night.accent,
+    garden: ISLANDS.garden.accent,
+    deepforest: ISLANDS.deepforest.accent,
+    lagoon: ISLANDS.lagoon.accent,
+    bay: ISLANDS.bay.accent,
   };
 
   return (

--- a/components/game/BelusWorld/three/quest/QuestLayer.tsx
+++ b/components/game/BelusWorld/three/quest/QuestLayer.tsx
@@ -10,8 +10,9 @@
 // finished level back up so the island blooms and Nilu grows.
 // ---------------------------------------------------------------------------
 
-import { useRef, useState } from 'react';
+import { useRef, useState, type MutableRefObject } from 'react';
 import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
 import { ISLANDS } from '../worldConfig';
 import { beluPos, dynamicSolids } from '../playerState';
 import type { ActivityZone } from '../../belu/progress';
@@ -42,16 +43,33 @@ const HOSTS: Record<ActivityZone, { face: string; mood: Mood }> = {
 
 const PICK_RADIUS = 2.4; // how close Nilu must walk to choose an orb (generous +
 //                          overlapping so you can never thread between orbs)
-const ORB_DIST = 3.0; // orb arc distance out in front of the friend
+const ORB_DIST = 2.4; // orb arc distance out in front of the friend
 const ORB_H = 1.0; // orb float height above the island top (near Nilu's body)
+
+// Adjacent-choice spacing: a joystick can't reliably steer between two things
+// whose walk-in circles overlap. PICK_RADIUS is 2.4, so two centres closer
+// than 4.8 apart are ambiguous — a parent reported exactly this on Forest's
+// word orbs ("too close together to navigate precisely"). 5.0 gives clean
+// daylight between every pair while staying inside the smallest island's
+// walkable radius (8.5) even at the largest option count QuestLayer ever
+// lays out (4, for a couple of Sleepy Island sequence rounds).
+const ORB_SPACING = 5.0;
 
 // carry/sort: items sit further out on their own pedestals; the delivery pads
 // (numbered slots or labeled tables) sit a bit closer to the friend, so the
-// child's walk naturally reads as "pick up, then bring it in".
-const CARRY_ITEM_DIST = ORB_DIST + 2.6;
-const CARRY_SLOT_DIST = ORB_DIST;
+// child's walk naturally reads as "pick up, then bring it in". Items get the
+// same ≥5-apart rule as orbs; pads (fewer, and only ever a target, never a
+// multi-way choice to distinguish) get a slightly tighter ≥4.
+const CARRY_ITEM_DIST = 5.4;
+const CARRY_SPACING = 5.0;
+const CARRY_SLOT_DIST = 2.4;
+const SLOT_SPACING = 4.2;
 // steps: a little path of stones receding from the friend, each a touch
-// higher than the last — a gentle rising staircase to walk in order.
+// higher than the last — a gentle rising staircase to walk in order. This is
+// a single-file path (not a side-by-side choice fan), so the ≥5 rule doesn't
+// apply the same way; the fix here is nearest-match picking (below) rather
+// than spacing, since widening it enough to beat PICK_RADIUS would push the
+// last stone off the smaller islands.
 const STEP_DIST = ORB_DIST + 0.4;
 const STEP_SPACING = 1.9;
 const STEP_RISE = 0.28;
@@ -69,8 +87,10 @@ function orbCount(round: QuestRound): number {
 
 /** Lay `n` things out in an arc at `dist` in front of the friend, facing
  *  Nilu's approach (the same fan used for answer orbs, carry items/slots,
- *  and sort tables — only the distance differs). */
-function layoutArc(zone: ActivityZone, n: number, dist: number): Layout {
+ *  and sort tables — only the distance + spacing differ). `spacing` is the
+ *  centre-to-centre gap between adjacent things, chosen by the caller so it
+ *  clears PICK_RADIUS with real room (see the constants above). */
+function layoutArc(zone: ActivityZone, n: number, dist: number, spacing: number = ORB_SPACING): Layout {
   const isl = ISLANDS[zone];
   // approach direction = from the island centre toward home (0,0)
   const len = Math.hypot(isl.cx, isl.cz) || 1;
@@ -79,9 +99,6 @@ function layoutArc(zone: ActivityZone, n: number, dist: number): Layout {
   // perpendicular (for spreading things left/right)
   const px = -az;
   const pz = ax;
-  // wider fan = easier to reach from any approach angle; pick radius (2.4) is
-  // bigger than half the spacing so coverage never has a gap to walk through.
-  const spacing = n <= 2 ? 3.8 : n <= 3 ? 3.4 : n <= 4 ? 3.0 : 2.6;
   const positions: [number, number, number][] = [];
   for (let i = 0; i < n; i++) {
     const frac = n === 1 ? 0 : i / (n - 1) - 0.5;
@@ -95,7 +112,7 @@ function layoutArc(zone: ActivityZone, n: number, dist: number): Layout {
 
 /** Lay the answer orbs out in an arc in front of the friend. */
 function layoutOrbs(zone: ActivityZone, n: number): Layout {
-  return layoutArc(zone, n, ORB_DIST);
+  return layoutArc(zone, n, ORB_DIST, ORB_SPACING);
 }
 
 /** A little path of stepping stones receding from the friend, rising as it
@@ -111,6 +128,30 @@ function layoutSteps(zone: ActivityZone, n: number): Layout {
     positions.push([isl.cx + ax * dist, isl.top + ORB_H * 0.6 + i * STEP_RISE, isl.cz + az * dist]);
   }
   return { positions };
+}
+
+/** Find the CLOSEST candidate to Nilu within `radius`, or -1. Each candidate
+ *  is `[id, position]` — `id` is whatever the caller wants back (an item's
+ *  original index, a pad number, ...). Several rounds lay pedestals/pads
+ *  close enough together that their walk-in circles overlap (that's fine —
+ *  it's what makes picking feel forgiving) but picking must always resolve
+ *  to the thing Nilu is actually nearest to, never just the first one
+ *  checked in array order — otherwise a child standing right on item B can
+ *  end up "picking up" item A because it happened to be checked first. */
+function nearestWithin(
+  candidates: [id: number, pos: [number, number, number]][],
+  radius: number,
+): number {
+  let best = -1;
+  let bestD = radius;
+  for (const [id, p] of candidates) {
+    const d = Math.hypot(beluPos.x - p[0], beluPos.z - p[2]);
+    if (d < bestD) {
+      bestD = d;
+      best = id;
+    }
+  }
+  return best;
 }
 
 /** Deterministic shuffle (no Math.random at render/module time — like the
@@ -168,6 +209,16 @@ interface State {
   /** carry/sort/steps: which slot/table/stone is wobbling right now, or -1 */
   wrongSlot: number;
   wrongSlotUntil: number;
+  /** stuck-help: clock time of the last correct pick/delivery/step (or round
+   *  start) — the two-stage help escalation counts idle time from here */
+  lastProgressAt: number;
+  /** stuck-help: 0 = nothing yet, 1 = coach hint + beacon shown, 2 = "Help
+   *  me" button offered, 3 = help already used this round (one per round) */
+  helpStage: 0 | 1 | 2 | 3;
+  /** stuck-help: true while the assisted "watch me" animation is playing,
+   *  between tapping Help me and the round actually completing */
+  helping: boolean;
+  helpFinishAt: number;
 }
 
 export interface QuestStatus {
@@ -182,7 +233,19 @@ export interface QuestStatus {
   phase: 'question' | 'correct';
   /** optional override for the small hint line under the instruction */
   hint?: string;
+  /** the child has been stuck long enough that a "🤝 Help me" button should
+   *  appear on the quest card (two-stage stuck-help escalation) */
+  helpOffered?: boolean;
 }
+
+// Stuck-help timing: a coach hint + spotlight at 18s without progress, then a
+// "Help me" button at 18s more (36s total). Reset on every correct pick,
+// delivery or step so a child who's actively working never sees it.
+const HELP_HINT_AT = 18;
+const HELP_BUTTON_AT = 36;
+// how long the assisted "watch me" animation plays before the round
+// actually completes, once Help me is tapped
+const HELP_ANIM_TIME = 1.6;
 
 interface Props {
   islandNextLevel: Record<ActivityZone, number>;
@@ -196,6 +259,11 @@ interface Props {
   onStatus: (s: QuestStatus | null) => void;
   /** which islands this layer owns (others are handled elsewhere, e.g. StoryLayer) */
   zones?: ActivityZone[];
+  /** the DOM "🤝 Help me" button (rendered by QuestPanel in index.tsx) calls
+   *  this ref when tapped. Assigned every render this layer is active, so it
+   *  always points at whichever quest layer currently owns the on-screen
+   *  status card (StoryLayer/ForestLayer/CoveLayer don't use it). */
+  helpRequestRef?: MutableRefObject<() => void>;
 }
 
 export default function QuestLayer(props: Props) {
@@ -209,6 +277,7 @@ export default function QuestLayer(props: Props) {
     lockUntil: 0, wrongIdx: -1, wrongUntil: 0, disarmed: null,
     pendingSay: null, sayAt: 0,
     carrying: null, stepIdx: 0, stepWrongStreak: 0, wrongSlot: -1, wrongSlotUntil: 0,
+    lastProgressAt: 0, helpStage: 0, helping: false, helpFinishAt: 0,
   });
 
   // The frame logic is re-bound every render so it never closes over stale
@@ -217,6 +286,13 @@ export default function QuestLayer(props: Props) {
 
   const curQuest: Quest | null = S.current.zone ? getQuest(S.current.zone, S.current.level) : null;
   const curRound: QuestRound | null = curQuest ? curQuest.rounds[S.current.roundIdx] : null;
+
+  // wire the DOM "🤝 Help me" button to this layer only while it's the one
+  // actually running a quest — StoryLayer/ForestLayer/CoveLayer never touch
+  // this ref, so whichever of them (or QuestLayer) is active always owns it
+  if (props.helpRequestRef && S.current.zone) {
+    props.helpRequestRef.current = () => doHelp();
+  }
 
   function resetRound() {
     S.current.seqDone = [];
@@ -228,6 +304,18 @@ export default function QuestLayer(props: Props) {
     S.current.stepWrongStreak = 0;
     S.current.wrongSlot = -1;
     S.current.wrongSlotUntil = 0;
+    S.current.lastProgressAt = S.current.clock;
+    S.current.helpStage = 0;
+    S.current.helping = false;
+    S.current.helpFinishAt = 0;
+  }
+
+  // stuck-help: call whenever the child makes REAL progress (a correct pick,
+  // delivery or step) so the 18s/36s escalation timer restarts and any
+  // coach hint/beacon already shown clears.
+  function recordProgress() {
+    S.current.lastProgressAt = S.current.clock;
+    if (S.current.helpStage > 0 && S.current.helpStage < 3) S.current.helpStage = 0;
   }
 
   // tell the DOM HUD what the player should be doing right now (persistent card)
@@ -244,6 +332,7 @@ export default function QuestLayer(props: Props) {
       zone: z, title: isl.label, emoji: isl.emoji, accent: isl.accent,
       level: S.current.level, instruction, step: S.current.roundIdx,
       total: q.rounds.length, phase, hint: hintFor(round.kind),
+      helpOffered: S.current.helpStage >= 2,
     });
   }
 
@@ -349,65 +438,65 @@ export default function QuestLayer(props: Props) {
     const n = items.length;
     const seed = st.roundIdx * 7 + st.level * 3 + (st.zone?.length ?? 0);
     const perm = seededShuffle(items.map((_, i) => i), seed);
-    const itemPositions = layoutArc(st.zone!, n, CARRY_ITEM_DIST).positions;
-    const slotPositions = layoutArc(st.zone!, n, CARRY_SLOT_DIST).positions;
+    const itemPositions = layoutArc(st.zone!, n, CARRY_ITEM_DIST, CARRY_SPACING).positions;
+    const slotPositions = layoutArc(st.zone!, n, CARRY_SLOT_DIST, SLOT_SPACING).positions;
 
     if (st.carrying == null) {
+      const candidates: [number, [number, number, number]][] = [];
       for (let p = 0; p < n; p++) {
         const idx = perm[p];
         if (st.seqDone.includes(items[idx].caption ?? String(idx))) continue;
-        const pos = itemPositions[p];
-        const d = Math.hypot(beluPos.x - pos[0], beluPos.z - pos[2]);
-        if (d < PICK_RADIUS) {
-          st.carrying = idx;
-          props.playSound('tap');
-          st.lockUntil = st.clock + 0.3;
-          bump();
-          return;
-        }
+        candidates.push([idx, itemPositions[p]]);
+      }
+      const near = nearestWithin(candidates, PICK_RADIUS);
+      if (near >= 0) {
+        st.carrying = near;
+        props.playSound('tap');
+        st.lockUntil = st.clock + 0.3;
+        recordProgress();
+        bump();
       }
       return;
     }
 
     // already carrying something — walking into a different, unplaced item
     // swaps politely (no penalty, it's still just one thing at a time)
+    const swapCandidates: [number, [number, number, number]][] = [];
     for (let p = 0; p < n; p++) {
       const idx = perm[p];
       if (idx === st.carrying || st.seqDone.includes(items[idx].caption ?? String(idx))) continue;
-      const pos = itemPositions[p];
-      const d = Math.hypot(beluPos.x - pos[0], beluPos.z - pos[2]);
-      if (d < PICK_RADIUS) {
-        st.carrying = idx;
-        props.playSound('tap');
-        st.lockUntil = st.clock + 0.3;
-        bump();
-        return;
-      }
+      swapCandidates.push([idx, itemPositions[p]]);
+    }
+    const swap = nearestWithin(swapCandidates, PICK_RADIUS);
+    if (swap >= 0) {
+      st.carrying = swap;
+      props.playSound('tap');
+      st.lockUntil = st.clock + 0.3;
+      bump();
+      return;
     }
 
     // walking onto a numbered pad — right item + right pad (the next one in
     // order) delivers it; anything else is a gentle "not yet, try again"
-    for (let s = 0; s < n; s++) {
-      const pos = slotPositions[s];
-      const d = Math.hypot(beluPos.x - pos[0], beluPos.z - pos[2]);
-      if (d < PICK_RADIUS) {
-        const expected = st.seqDone.length;
-        if (s === expected && st.carrying === expected) {
-          st.seqDone.push(items[expected].caption ?? String(expected));
-          st.carrying = null;
-          props.playSound('correct');
-          if (st.seqDone.length >= n) {
-            solveRound(round.doneLine ?? 'Perfect! Everything is in its place!');
-          } else {
-            st.lockUntil = st.clock + 0.3;
-            props.setEmotion('happy');
-            bump();
-          }
+    const slotCandidates: [number, [number, number, number]][] = slotPositions.map((pos, s) => [s, pos]);
+    const s = nearestWithin(slotCandidates, PICK_RADIUS);
+    if (s >= 0) {
+      const expected = st.seqDone.length;
+      if (s === expected && st.carrying === expected) {
+        st.seqDone.push(items[expected].caption ?? String(expected));
+        st.carrying = null;
+        props.playSound('correct');
+        recordProgress();
+        if (st.seqDone.length >= n) {
+          solveRound(round.doneLine ?? 'Perfect! Everything is in its place!');
         } else {
-          st.carrying = null; // returns to its pedestal
-          carrySlip(s, 'Hmm — what comes first?');
+          st.lockUntil = st.clock + 0.3;
+          props.setEmotion('happy');
+          bump();
         }
-        return;
+      } else {
+        st.carrying = null; // returns to its pedestal
+        carrySlip(s, 'Hmm — what comes first?');
       }
     }
   }
@@ -420,61 +509,61 @@ export default function QuestLayer(props: Props) {
     const n = items.length;
     const seed = st.roundIdx * 11 + st.level * 5 + (st.zone?.length ?? 0);
     const perm = seededShuffle(items.map((_, i) => i), seed);
-    const itemPositions = layoutArc(st.zone!, n, CARRY_ITEM_DIST).positions;
-    const tablePositions = layoutArc(st.zone!, tables.length, CARRY_SLOT_DIST).positions;
+    const itemPositions = layoutArc(st.zone!, n, CARRY_ITEM_DIST, CARRY_SPACING).positions;
+    const tablePositions = layoutArc(st.zone!, tables.length, CARRY_SLOT_DIST, SLOT_SPACING).positions;
 
     if (st.carrying == null) {
+      const candidates: [number, [number, number, number]][] = [];
       for (let p = 0; p < n; p++) {
         const idx = perm[p];
         if (st.seqDone.includes(items[idx].caption ?? String(idx))) continue;
-        const pos = itemPositions[p];
-        const d = Math.hypot(beluPos.x - pos[0], beluPos.z - pos[2]);
-        if (d < PICK_RADIUS) {
-          st.carrying = idx;
-          props.playSound('tap');
-          st.lockUntil = st.clock + 0.3;
-          bump();
-          return;
-        }
+        candidates.push([idx, itemPositions[p]]);
+      }
+      const near = nearestWithin(candidates, PICK_RADIUS);
+      if (near >= 0) {
+        st.carrying = near;
+        props.playSound('tap');
+        st.lockUntil = st.clock + 0.3;
+        recordProgress();
+        bump();
       }
       return;
     }
 
+    const swapCandidates: [number, [number, number, number]][] = [];
     for (let p = 0; p < n; p++) {
       const idx = perm[p];
       if (idx === st.carrying || st.seqDone.includes(items[idx].caption ?? String(idx))) continue;
-      const pos = itemPositions[p];
-      const d = Math.hypot(beluPos.x - pos[0], beluPos.z - pos[2]);
-      if (d < PICK_RADIUS) {
-        st.carrying = idx;
-        props.playSound('tap');
-        st.lockUntil = st.clock + 0.3;
-        bump();
-        return;
-      }
+      swapCandidates.push([idx, itemPositions[p]]);
+    }
+    const swap = nearestWithin(swapCandidates, PICK_RADIUS);
+    if (swap >= 0) {
+      st.carrying = swap;
+      props.playSound('tap');
+      st.lockUntil = st.clock + 0.3;
+      bump();
+      return;
     }
 
-    for (let t = 0; t < tables.length; t++) {
-      const pos = tablePositions[t];
-      const d = Math.hypot(beluPos.x - pos[0], beluPos.z - pos[2]);
-      if (d < PICK_RADIUS) {
-        const carried = items[st.carrying];
-        if (carried.table === t) {
-          st.seqDone.push(carried.caption ?? String(st.carrying));
-          st.carrying = null;
-          props.playSound('correct');
-          if (st.seqDone.length >= n) {
-            solveRound(round.doneLine ?? 'Everything sorted!');
-          } else {
-            st.lockUntil = st.clock + 0.3;
-            props.setEmotion('happy');
-            bump();
-          }
+    const tableCandidates: [number, [number, number, number]][] = tablePositions.map((pos, t) => [t, pos]);
+    const t = nearestWithin(tableCandidates, PICK_RADIUS);
+    if (t >= 0) {
+      const carried = items[st.carrying];
+      if (carried.table === t) {
+        st.seqDone.push(carried.caption ?? String(st.carrying));
+        st.carrying = null;
+        props.playSound('correct');
+        recordProgress();
+        if (st.seqDone.length >= n) {
+          solveRound(round.doneLine ?? 'Everything sorted!');
         } else {
-          st.carrying = null;
-          carrySlip(t, `Hmm — where does the ${carried.caption ?? 'thing'} go?`);
+          st.lockUntil = st.clock + 0.3;
+          props.setEmotion('happy');
+          bump();
         }
-        return;
+      } else {
+        st.carrying = null;
+        carrySlip(t, `Hmm — where does the ${carried.caption ?? 'thing'} go?`);
       }
     }
   }
@@ -488,41 +577,42 @@ export default function QuestLayer(props: Props) {
     const n = round.count ?? 4;
     const positions = layoutSteps(st.zone!, n).positions;
     const expected = st.stepIdx;
-    for (let i = 0; i < n; i++) {
-      const pos = positions[i];
-      const d = Math.hypot(beluPos.x - pos[0], beluPos.z - pos[2]);
-      if (d < PICK_RADIUS) {
-        if (i === expected) {
-          st.stepIdx += 1;
-          st.stepWrongStreak = 0;
-          const label = round.labels?.[i] ?? String(i + 1);
-          props.playSound(st.stepIdx >= n ? 'star' : 'correct');
-          if (st.stepIdx >= n) {
-            solveRound(round.doneLine ?? 'You did every step!');
-          } else {
-            props.speak(`${label}!`);
-            st.lockUntil = st.clock + 0.35;
-            props.setEmotion('happy');
-            bump();
-          }
-        } else if (i > expected) {
-          st.stepWrongStreak += 1;
-          st.wrongSlot = i;
-          st.wrongSlotUntil = st.clock + 0.5;
-          st.lockUntil = st.clock + 0.4;
-          if (st.stepWrongStreak >= 2) {
-            st.slips += 1;
-            st.stepWrongStreak = 0;
-          }
-          props.playSound('tap');
-          props.setEmotion('curious');
-          props.speak('Which number comes next?');
-          bump();
-        }
-        // stepping on an already-done stone (i < expected): no reaction
-        return;
+    // this is a receding single-file path (not a side-by-side fan), so
+    // adjacent stones' walk-in circles can overlap however close they sit —
+    // always resolve to the NEAREST stone, never the first index checked,
+    // so standing on stone 3 can't get silently swallowed by stone 2's radius.
+    const candidates: [number, [number, number, number]][] = positions.map((pos, i) => [i, pos]);
+    const i = nearestWithin(candidates, PICK_RADIUS);
+    if (i < 0) return;
+    if (i === expected) {
+      st.stepIdx += 1;
+      st.stepWrongStreak = 0;
+      const label = round.labels?.[i] ?? String(i + 1);
+      props.playSound(st.stepIdx >= n ? 'star' : 'correct');
+      recordProgress();
+      if (st.stepIdx >= n) {
+        solveRound(round.doneLine ?? 'You did every step!');
+      } else {
+        props.speak(`${label}!`);
+        st.lockUntil = st.clock + 0.35;
+        props.setEmotion('happy');
+        bump();
       }
+    } else if (i > expected) {
+      st.stepWrongStreak += 1;
+      st.wrongSlot = i;
+      st.wrongSlotUntil = st.clock + 0.5;
+      st.lockUntil = st.clock + 0.4;
+      if (st.stepWrongStreak >= 2) {
+        st.slips += 1;
+        st.stepWrongStreak = 0;
+      }
+      props.playSound('tap');
+      props.setEmotion('curious');
+      props.speak('Which number comes next?');
+      bump();
     }
+    // stepping on an already-done stone (i < expected): no reaction
   }
 
   function pick(i: number) {
@@ -532,6 +622,7 @@ export default function QuestLayer(props: Props) {
       const o = curRound.options![i];
       if (o.correct) {
         props.playSound('correct');
+        recordProgress();
         solveRound(curRound.doneLine ?? 'Yes! You got it!');
       } else slip(i);
     } else if (curRound.kind === 'sequence') {
@@ -540,6 +631,7 @@ export default function QuestLayer(props: Props) {
       if (cap === expected && !st.seqDone.includes(cap)) {
         st.seqDone.push(cap);
         props.playSound('correct');
+        recordProgress();
         if (st.seqDone.length >= curRound.order!.length) {
           solveRound(curRound.doneLine ?? 'Perfect!');
         } else {
@@ -554,6 +646,7 @@ export default function QuestLayer(props: Props) {
       if (st.picked.has(i)) return;
       st.picked.add(i);
       props.playSound('correct');
+      recordProgress();
       if (st.picked.size >= (curRound.picks ?? 1)) {
         solveRound(curRound.doneLine ?? 'Wonderful!');
       } else {
@@ -562,6 +655,97 @@ export default function QuestLayer(props: Props) {
         bump();
       }
     }
+  }
+
+  // ---- stuck-help ----------------------------------------------------------
+
+  /** What's the single correct next thing to do right now, in plain words?
+   *  Derived entirely from round data — no per-quest authoring needed. Used
+   *  both for the Stage-1 coach hint and to know where to draw the beacon. */
+  function stuckHint(): { text: string; kind: 'orb' | 'carryItem' | 'carrySlot' | 'sortTable' | 'step'; idx: number } | null {
+    const st = S.current;
+    if (!curRound) return null;
+    if (curRound.kind === 'choice') {
+      const idx = curRound.options!.findIndex((o) => o.correct);
+      if (idx < 0) return null;
+      const cap = curRound.options![idx].caption;
+      return { text: cap ? `${cap}! Walk to it!` : 'Walk to the glowing one!', kind: 'orb', idx };
+    }
+    if (curRound.kind === 'sequence') {
+      const nextCap = curRound.order![st.seqDone.length];
+      const idx = curRound.pool!.findIndex((o) => o.caption === nextCap);
+      if (idx < 0) return null;
+      return { text: `"${nextCap}" next! Walk to it!`, kind: 'orb', idx };
+    }
+    if (curRound.kind === 'multiPick') {
+      const idx = curRound.options!.findIndex((_, i) => !st.picked.has(i));
+      if (idx < 0) return null;
+      const cap = curRound.options![idx].caption;
+      return { text: cap ? `Try ${cap}!` : 'Walk to one you haven’t tried!', kind: 'orb', idx };
+    }
+    if (curRound.kind === 'carry') {
+      const items = curRound.items!;
+      if (st.carrying != null) {
+        return { text: `Carry it to spot ${st.seqDone.length + 1}!`, kind: 'carrySlot', idx: st.seqDone.length };
+      }
+      const idx = st.seqDone.length;
+      if (idx >= items.length) return null;
+      const it = items[idx];
+      return { text: `The ${it.caption ?? 'thing'} goes next! Walk to it ${it.emoji}!`, kind: 'carryItem', idx };
+    }
+    if (curRound.kind === 'sort') {
+      const items = curRound.items!;
+      const tables = curRound.tables!;
+      if (st.carrying != null) {
+        const t = items[st.carrying].table ?? 0;
+        const tCap = tables[t]?.caption;
+        return { text: tCap ? `Carry it to ${tCap}!` : 'Carry it to its table!', kind: 'sortTable', idx: t };
+      }
+      const idx = items.findIndex((it, i) => !st.seqDone.includes(it.caption ?? String(i)));
+      if (idx < 0) return null;
+      const it = items[idx];
+      return { text: `The ${it.caption ?? 'thing'} goes next! Walk to it ${it.emoji}!`, kind: 'carryItem', idx };
+    }
+    if (curRound.kind === 'steps') {
+      const label = curRound.labels?.[st.stepIdx] ?? String(st.stepIdx + 1);
+      return { text: `Walk to ${label}!`, kind: 'step', idx: st.stepIdx };
+    }
+    return null;
+  }
+
+  /** Fill in the whole round as if the child had done it, then solve — used
+   *  after the "watch me" assist animation. Never counts as a slip. */
+  function completeRoundAssisted() {
+    const st = S.current;
+    st.helping = false;
+    if (!curRound || st.solved) return;
+    if (curRound.kind === 'sequence') {
+      st.seqDone = [...curRound.order!];
+    } else if (curRound.kind === 'multiPick') {
+      curRound.options!.forEach((_, i) => st.picked.add(i));
+    } else if (curRound.kind === 'carry' || curRound.kind === 'sort') {
+      st.seqDone = curRound.items!.map((it, i) => it.caption ?? String(i));
+      st.carrying = null;
+    } else if (curRound.kind === 'steps') {
+      st.stepIdx = curRound.count ?? 4;
+    }
+    props.playSound('star');
+    solveRound(curRound.doneLine ?? 'Now you did it! 💙');
+  }
+
+  /** Tapping the quest card's "🤝 Help me" button (Stage 2). Nilu's friend
+   *  does it together with her: a short "watch me" beat, then the round
+   *  finishes for real — stars are never docked for asking for help. */
+  function doHelp() {
+    const st = S.current;
+    if (!st.zone || st.solved || st.helpStage < 2 || st.helping) return;
+    st.helpStage = 3; // used — one help per round
+    st.helping = true;
+    st.helpFinishAt = st.clock + HELP_ANIM_TIME;
+    props.setEmotion('curious');
+    props.speak('Let’s do it together! Watch me…');
+    emitStatus('question', curQuest ? curQuest.rounds[st.roundIdx].say : '');
+    bump();
   }
 
   // ---- per-frame logic ----
@@ -641,6 +825,30 @@ export default function QuestLayer(props: Props) {
 
     // orb pick detection (walk-in). Breathe rounds handle themselves.
     const round = getQuest(st.zone, st.level).rounds[st.roundIdx];
+
+    // stuck-help: two-stage escalation. Breathe rounds auto-advance on their
+    // own (no "stuck" state is possible), so they're excluded.
+    if (round.kind !== 'breathe' && !st.solved && !st.helping) {
+      const stuckFor = st.clock - st.lastProgressAt;
+      if (st.helpStage < 1 && stuckFor >= HELP_HINT_AT) {
+        st.helpStage = 1;
+        const h = stuckHint();
+        if (h) props.speak(h.text);
+        bump();
+      } else if (st.helpStage === 1 && stuckFor >= HELP_BUTTON_AT) {
+        st.helpStage = 2;
+        emitStatus('question', round.say);
+        bump();
+      }
+    }
+
+    // mid "watch me" assist — freeze normal picking until it lands, then
+    // fill in the round for real (never counted as a slip)
+    if (st.helping) {
+      if (st.clock >= st.helpFinishAt) completeRoundAssisted();
+      return;
+    }
+
     if (round.kind === 'breathe' || st.solved || st.clock < st.lockUntil) return;
     if (round.kind === 'carry') {
       carryFrame(st, round);
@@ -691,6 +899,10 @@ export default function QuestLayer(props: Props) {
     }
     return 'idle';
   }
+
+  // Stage-1 stuck-help spotlight target (recomputed each render so it tracks
+  // live state — cheap, and only non-null while genuinely stuck)
+  const help = S.current.helpStage >= 1 && !S.current.solved ? stuckHint() : null;
 
   const accent: Record<ActivityZone, string> = {
     meadow: ISLANDS.meadow.accent,
@@ -759,8 +971,8 @@ export default function QuestLayer(props: Props) {
               const n = items.length;
               const seed = st.roundIdx * 7 + st.level * 3 + zone.length;
               const perm = seededShuffle(items.map((_, i) => i), seed);
-              const itemPositions = layoutArc(zone, n, CARRY_ITEM_DIST).positions;
-              const slotPositions = layoutArc(zone, n, CARRY_SLOT_DIST).positions;
+              const itemPositions = layoutArc(zone, n, CARRY_ITEM_DIST, CARRY_SPACING).positions;
+              const slotPositions = layoutArc(zone, n, CARRY_SLOT_DIST, SLOT_SPACING).positions;
               return (
                 <group>
                   {perm.map((idx, p) => {
@@ -775,6 +987,7 @@ export default function QuestLayer(props: Props) {
                         carrying={st.carrying === idx}
                         reduceMotion={props.reduceMotion}
                         bobSeed={p * 0.6}
+                        isNext={st.carrying == null && idx === st.seqDone.length}
                       />
                     );
                   })}
@@ -793,6 +1006,12 @@ export default function QuestLayer(props: Props) {
                       />
                     );
                   })}
+                  {help && help.kind === 'carryItem' && (
+                    <HelpBeacon position={itemPositions[perm.indexOf(help.idx)]} reduceMotion={props.reduceMotion} />
+                  )}
+                  {help && help.kind === 'carrySlot' && (
+                    <HelpBeacon position={slotPositions[help.idx]} reduceMotion={props.reduceMotion} />
+                  )}
                 </group>
               );
             })()
@@ -805,8 +1024,8 @@ export default function QuestLayer(props: Props) {
               const n = items.length;
               const seed = st.roundIdx * 11 + st.level * 5 + zone.length;
               const perm = seededShuffle(items.map((_, i) => i), seed);
-              const itemPositions = layoutArc(zone, n, CARRY_ITEM_DIST).positions;
-              const tablePositions = layoutArc(zone, tables.length, CARRY_SLOT_DIST).positions;
+              const itemPositions = layoutArc(zone, n, CARRY_ITEM_DIST, CARRY_SPACING).positions;
+              const tablePositions = layoutArc(zone, tables.length, CARRY_SLOT_DIST, SLOT_SPACING).positions;
               return (
                 <group>
                   {perm.map((idx, p) => {
@@ -835,6 +1054,12 @@ export default function QuestLayer(props: Props) {
                       caption={tb.caption}
                     />
                   ))}
+                  {help && help.kind === 'carryItem' && (
+                    <HelpBeacon position={itemPositions[perm.indexOf(help.idx)]} reduceMotion={props.reduceMotion} />
+                  )}
+                  {help && help.kind === 'sortTable' && (
+                    <HelpBeacon position={tablePositions[help.idx]} reduceMotion={props.reduceMotion} />
+                  )}
                 </group>
               );
             })()
@@ -862,6 +1087,9 @@ export default function QuestLayer(props: Props) {
                       />
                     );
                   })}
+                  {help && help.kind === 'step' && (
+                    <HelpBeacon position={positions[help.idx]} reduceMotion={props.reduceMotion} />
+                  )}
                 </group>
               );
             })()
@@ -875,18 +1103,25 @@ export default function QuestLayer(props: Props) {
                   : curRound.kind === 'sequence'
                     ? curRound.pool!
                     : curRound.options!;
-              return items.map((o, i) => (
-                <AnswerOrb
-                  key={`${S.current.roundIdx}-${i}`}
-                  position={positions[i]}
-                  emoji={o.emoji}
-                  caption={o.caption}
-                  color={accent[S.current.zone!]}
-                  status={orbStatus(i)}
-                  bobSeed={i * 0.7}
-                  onPick={() => pick(i)}
-                />
-              ));
+              return (
+                <group>
+                  {items.map((o, i) => (
+                    <AnswerOrb
+                      key={`${S.current.roundIdx}-${i}`}
+                      position={positions[i]}
+                      emoji={o.emoji}
+                      caption={o.caption}
+                      color={accent[S.current.zone!]}
+                      status={orbStatus(i)}
+                      bobSeed={i * 0.7}
+                      onPick={() => pick(i)}
+                    />
+                  ))}
+                  {help && help.kind === 'orb' && (
+                    <HelpBeacon position={positions[help.idx]} reduceMotion={props.reduceMotion} />
+                  )}
+                </group>
+              );
             })()
           )}
         </group>
@@ -898,4 +1133,30 @@ export default function QuestLayer(props: Props) {
 function Ticker({ fnRef }: { fnRef: React.MutableRefObject<(dt: number) => void> }) {
   useFrame((_, dt) => fnRef.current(Math.min(dt, 0.05)));
   return null;
+}
+
+// Stage-1 stuck-help spotlight: a bright pulsing gold beacon dropped on top
+// of whatever the child should walk to next. Static (no pulse) under
+// reduce-motion so it stays a clear, calm spotlight rather than a distraction.
+function HelpBeacon({ position, reduceMotion }: { position: [number, number, number]; reduceMotion: boolean }) {
+  const ring = useRef<THREE.Mesh>(null);
+  const t = useRef(0);
+  useFrame((_, dt) => {
+    t.current += dt;
+    if (!ring.current) return;
+    if (reduceMotion) {
+      ring.current.scale.setScalar(1.3);
+    } else {
+      ring.current.scale.setScalar(1.1 + Math.sin(t.current * 3.2) * 0.25);
+    }
+  });
+  return (
+    <group position={position}>
+      <mesh ref={ring} rotation={[-Math.PI / 2, 0, 0]} position={[0, 1.1, 0]}>
+        <ringGeometry args={[0.55, 0.78, 28]} />
+        <meshBasicMaterial color="#ffe066" transparent opacity={0.85} side={THREE.DoubleSide} depthWrite={false} />
+      </mesh>
+      <pointLight color="#ffe066" intensity={1.4} distance={4} position={[0, 1.2, 0]} />
+    </group>
+  );
 }

--- a/components/game/BelusWorld/three/quest/StoryLayer.tsx
+++ b/components/game/BelusWorld/three/quest/StoryLayer.tsx
@@ -27,8 +27,13 @@ import StartSign from './StartSign';
 const ZONE = 'meadow' as const;
 const APPROACH = 4.6; // stay this close to a friend while observing & choosing
 const LINGER = 1.6; // seconds of staying close before the clue appears
-const HELP_DIST = 2.3; // how far the help bubbles sit in front of a friend
-const HELP_SPREAD = 2.8; // sideways gap between the 3 help bubbles (no overlap)
+const HELP_DIST = 1.8; // how far the help bubbles sit in front of a friend
+// Sideways gap between the 3 help bubbles. A parent reported the Forest
+// word-orb version of this same fan being too tight to steer between with a
+// joystick — HELP_PICK-sized circles need real daylight between centres.
+// Some friends sit close to the meadow's edge, so this is the largest value
+// that keeps every bubble on the island for every authored friend position.
+const HELP_SPREAD = 4.5;
 const HELP_PICK = 1.5; // walk this close to a help bubble to choose it
 const FIREFLY_FIND = 2.2; // walk this close to a hidden firefly to collect it
 const INVITE_START = 2.4; // walk this close to the waving host to BEGIN (consent)

--- a/components/game/BelusWorld/three/quest/advancedQuests.ts
+++ b/components/game/BelusWorld/three/quest/advancedQuests.ts
@@ -1,0 +1,629 @@
+// ---------------------------------------------------------------------------
+// ADVANCED SISTER ISLANDS — unlocked when a skill island reaches 5/5:
+//   meadow  → garden     (Feelings Garden 🌷)   advanced feelings
+//   forest  → deepforest (Deep Forest 🌲)        advanced friendship & words
+//   cove    → lagoon     (Quiet Lagoon 🪷)       advanced calm
+//   shore   → bay        (Treasure Bay ⛵)       advanced sharing & cooperation
+//
+// Same shape and voice as quests.ts: 5 levels per island, short warm rounds,
+// errorless, no timers, no losing. Faces vary per helper but each island has
+// a "home" face: garden 🦋, deepforest 🦌, lagoon 🐬, bay 🦜.
+//
+// TODO(engine agent): `Quest.zone` in quests.ts is typed `ActivityZone`, which
+// does not yet include 'garden' | 'deepforest' | 'lagoon' | 'bay'. Rather than
+// edit quests.ts (other agents are mid-edit on it), this file defines its own
+// `AdvancedZone` union and a local `AdvancedQuest` type — an `Omit<Quest,
+// 'zone'> & { zone: AdvancedZone }` — so this file compiles standalone today.
+// Once ActivityZone is widened to include the four advanced zones, the engine
+// agent can simply re-type ADVANCED_QUESTS as Record<ActivityZone, Quest[]>
+// (or merge these arrays into QUESTS) with no changes needed to the data below.
+// ---------------------------------------------------------------------------
+
+import type { Quest, Orb } from './quests';
+import type { Mood } from './QuestNPC';
+
+/** The four new zone ids — not yet part of ActivityZone. See TODO above. */
+export type AdvancedZone = 'garden' | 'deepforest' | 'lagoon' | 'bay';
+
+/** Same shape as Quest, but with our own zone union until quests.ts is widened. */
+export type AdvancedQuest = Omit<Quest, 'zone'> & { zone: AdvancedZone };
+
+const MOOD = (m: Mood): Mood => m;
+
+function opt(emoji: string, caption: string, correct = false): Orb {
+  return { emoji, caption, correct };
+}
+
+// ===========================================================================
+// FEELINGS GARDEN 🌷 — Advanced Feelings (sister island of meadow)
+// ===========================================================================
+
+const GARDEN: AdvancedQuest[] = [
+  {
+    zone: 'garden', level: 1, goal: 'Two feelings at once',
+    intro: "Welcome to my garden! Sometimes we feel TWO feelings at the same time. Both are okay.",
+    outro: 'You know that two feelings can happen together. That is a big-kid thing to know!',
+    moment: 'read mixed feelings in the garden',
+    rounds: [
+      { kind: 'choice', say: "It's Bea's first day at a new class. She feels happy AND nervous. Can both be true?",
+        npc: { face: '🐛', mood: MOOD('neutral'), thought: { emoji: '🏫' } },
+        options: [
+          opt('✅', 'Yes, both at once', true),
+          opt('❌', 'No, just one feeling'),
+        ], doneLine: 'Yes! Happy and nervous can both be there. Both are okay.' },
+      { kind: 'multiPick', say: 'Walk into BOTH feelings Bea might have on her first day.', picks: 2,
+        npc: { face: '🐛', mood: MOOD('neutral'), thought: { emoji: '🏫' } },
+        options: [
+          opt('🤩', 'excited', true),
+          opt('😟', 'a little nervous', true),
+          opt('😡', 'angry'),
+          opt('😴', 'bored'),
+        ], doneLine: 'Excited AND a little nervous — both at the same time. That happens to everyone.' },
+      { kind: 'choice', say: 'Sol is going on a fun trip, but will miss his dog. What two feelings fit best?',
+        npc: { face: '🦋', mood: MOOD('neutral'), thought: { emoji: '🧳' } },
+        options: [
+          opt('🥹', 'excited and a little sad', true),
+          opt('😡', 'only angry'),
+          opt('😐', 'only bored'),
+        ], doneLine: 'Excited about the trip, and a little sad to miss his dog — both true.' },
+    ],
+  },
+  {
+    zone: 'garden', level: 2, goal: 'Faces don\'t always match feelings',
+    intro: "A face doesn't always show the real feeling underneath. Let's look closer.",
+    outro: 'You looked past the face and found the real feeling. That takes great noticing!',
+    moment: 'looked past faces in the garden',
+    rounds: [
+      { kind: 'choice', say: 'Milo is smiling, but he yawns and his eyes look heavy. How might Milo really feel?',
+        npc: { face: '🦋', mood: MOOD('happy'), thought: { emoji: '😪' } },
+        options: [
+          opt('😴', 'tired, even with a smile', true),
+          opt('😡', 'angry'),
+          opt('😨', 'scared'),
+        ], doneLine: 'A smile can hide a tired feeling underneath. Good noticing.' },
+      { kind: 'choice', say: 'Pip says "I\'m fine" but her voice is quiet and she looks at the ground. What might be true?',
+        npc: { face: '🐛', mood: MOOD('neutral'), thought: { emoji: '🤔' } },
+        options: [
+          opt('😞', 'She might feel sad inside', true),
+          opt('🤩', 'She is very excited'),
+          opt('😤', 'She is very angry'),
+        ], doneLine: 'Sometimes "I\'m fine" hides a feeling. It is kind to check in.' },
+      { kind: 'choice', say: 'What is a kind thing to say if you think a friend\'s face doesn\'t match how they feel?',
+        npc: { face: '🦋', mood: MOOD('calm') },
+        options: [
+          opt('💬', 'Are you really okay?', true),
+          opt('🙉', 'Nothing, just guess'),
+          opt('😏', 'You look fine to me'),
+        ], doneLine: '"Are you really okay?" gives a friend a chance to share.' },
+    ],
+  },
+  {
+    zone: 'garden', level: 3, goal: "Noticing a friend's feelings from what happened",
+    intro: "We can guess a friend's feeling by remembering what just happened to them.",
+    outro: 'You noticed feelings from what happened — that is real empathy!',
+    moment: "noticed a friend's feelings in the garden",
+    rounds: [
+      { kind: 'choice', say: "Sam's block tower just fell down with a crash. How does Sam feel right now?",
+        npc: { face: '🐛', mood: MOOD('sad'), thought: { emoji: '🧱' } },
+        options: [
+          opt('😞', 'sad or frustrated', true),
+          opt('🤩', 'excited'),
+          opt('😴', 'bored'),
+        ], doneLine: 'A tower falling would make most of us feel sad or frustrated too.' },
+      { kind: 'choice', say: "Lulu's balloon just flew away into the sky. How does Lulu feel?",
+        npc: { face: '🦋', mood: MOOD('disappointed'), thought: { emoji: '🎈' } },
+        options: [
+          opt('😞', 'disappointed', true),
+          opt('😌', 'calm'),
+          opt('🏆', 'proud'),
+        ], doneLine: 'Losing a balloon is disappointing — that makes sense.' },
+      { kind: 'choice', say: "Otto's friend had to move away to a new town. How might Otto feel?",
+        npc: { face: '🐛', mood: MOOD('sad'), thought: { emoji: '📦' } },
+        options: [
+          opt('😢', 'sad, missing his friend', true),
+          opt('😄', 'happy'),
+          opt('😲', 'surprised'),
+        ], doneLine: 'Missing a friend who moved away is a real, sad feeling.' },
+    ],
+  },
+  {
+    zone: 'garden', level: 4, goal: 'Helping a sad friend',
+    intro: "When a friend feels sad, there are gentle ways to help. Let's practice.",
+    outro: 'You know just how to help a sad friend. That is real kindness.',
+    moment: 'helped a sad friend in the garden',
+    rounds: [
+      { kind: 'choice', say: "Sam's tower fell down and he looks sad. What is a kind first step?",
+        npc: { face: '🐛', mood: MOOD('sad'), thought: { emoji: '🧱' } },
+        options: [
+          opt('🧎', 'Sit with him', true),
+          opt('😆', 'Laugh'),
+          opt('🚶', 'Walk away'),
+        ], doneLine: 'Sitting with a sad friend shows them they are not alone.' },
+      { kind: 'choice', say: 'Sam is still sad about the tower. What can you offer next?',
+        npc: { face: '🐛', mood: MOOD('sad'), thought: { emoji: '🧱' } },
+        options: [
+          opt('🤝', 'Offer to help rebuild', true),
+          opt('🙅', 'Tell him to stop being sad'),
+          opt('🏃', 'Go play somewhere else'),
+        ], doneLine: 'Offering to help is a wonderful way to show you care.' },
+      { kind: 'choice', say: "Sam is STILL very sad, even after sitting and helping. What is a good next step?",
+        npc: { face: '🐛', mood: MOOD('sad'), thought: { emoji: '💭' } },
+        options: [
+          opt('🙋', 'Get a grown-up', true),
+          opt('🤐', 'Say nothing at all'),
+          opt('😤', 'Get upset too'),
+        ], doneLine: 'When a feeling is big, getting a grown-up is a great idea.' },
+    ],
+  },
+  {
+    zone: 'garden', level: 5, goal: 'My feelings change like clouds',
+    intro: "Feelings move and change, like clouds passing by. A big feeling now does not last forever.",
+    outro: 'You learned that feelings pass, like clouds in the sky. You will always feel calm again.',
+    moment: 'learned that feelings pass in the garden',
+    rounds: [
+      { kind: 'choice', say: 'Bea felt very mad when her game got paused. A little later, how might she feel?',
+        npc: { face: '🦋', mood: MOOD('angry'), thought: { emoji: '⏸️' } },
+        options: [
+          opt('😌', 'calm again, after some time', true),
+          opt('😡', 'mad forever'),
+        ], doneLine: 'Yes — even big mad feelings pass, like a cloud moving on.' },
+      { kind: 'breathe', say: "Let's help a big feeling pass, like a cloud. Breathe with me.",
+        npc: { face: '🦋', mood: MOOD('calm') }, cycles: 3,
+        doneLine: 'The big feeling floated by, like a cloud. You feel calmer now.' },
+      { kind: 'steps', say: 'Walk the cloud path — watch each feeling drift by, one step at a time.',
+        npc: { face: '🐛', mood: MOOD('calm') },
+        count: 4,
+        labels: ['Mad ☁️', 'A little calmer ⛅', 'Calmer still 🌤️', 'Calm again ☀️'],
+        doneLine: 'From mad, to calm — feelings really do change, like clouds passing by.' },
+    ],
+  },
+];
+
+// ===========================================================================
+// DEEP FOREST 🌲 — Advanced Friendship & Words (sister island of forest)
+// ===========================================================================
+
+const DEEPFOREST: AdvancedQuest[] = [
+  {
+    zone: 'deepforest', level: 1, goal: 'Joining kids already playing',
+    intro: "Some friends are already playing deep in the forest. Let's learn how to join in.",
+    outro: 'You learned how to ask to join a game. That takes real courage!',
+    moment: 'learned to join a game in the deep forest',
+    rounds: [
+      { kind: 'choice', say: 'Fox and Bunny are playing tag without you. What can you say?',
+        npc: { face: '🦌', mood: MOOD('happy'), thought: { emoji: '🏃' } },
+        options: [
+          opt('🙋', 'Can I play too?', true),
+          opt('🤐', 'Say nothing and watch'),
+          opt('😤', 'Grab the ball and run'),
+        ], doneLine: '"Can I play too?" is a great way to ask.' },
+      { kind: 'choice', say: 'You asked "Can I play too?" — now what do you do?',
+        npc: { face: '🦊', mood: MOOD('happy'), thought: { emoji: '❓' } },
+        options: [
+          opt('⏳', 'Wait for their answer', true),
+          opt('🏃', 'Start playing right away without waiting'),
+        ], doneLine: 'Waiting for the answer is polite and kind.' },
+      { kind: 'choice', say: 'Fox says "Yes, come play!" What do you do?',
+        npc: { face: '🦊', mood: MOOD('happy'), thought: { emoji: '✅' } },
+        options: [
+          opt('🎉', 'Join in happily', true),
+          opt('🙅', 'Say no thanks'),
+        ], doneLine: 'You joined the game. Great asking!' },
+    ],
+  },
+  {
+    zone: 'deepforest', level: 2, goal: 'When a friend says no',
+    intro: "Sometimes a friend says no, and that is okay too. Let's learn what to do.",
+    outro: "You learned that 'no' is okay, and there is always another game. Well done.",
+    moment: 'learned what to do when a friend says no in the deep forest',
+    rounds: [
+      { kind: 'choice', say: 'You ask "Can I play too?" and Bear says "Not right now." How do you feel first?',
+        npc: { face: '🐻', mood: MOOD('neutral'), thought: { emoji: '🙅' } },
+        options: [
+          opt('😞', 'A little disappointed — that is okay', true),
+          opt('😡', 'I must yell'),
+        ], doneLine: 'It is okay to feel a little disappointed. That feeling passes.' },
+      { kind: 'choice', say: 'Bear said not right now. What can you do next?',
+        npc: { face: '🐻', mood: MOOD('neutral') },
+        options: [
+          opt('🔍', 'Find another game to play', true),
+          opt('😤', 'Push in anyway'),
+          opt('😭', 'Cry loudly at Bear'),
+        ], doneLine: 'Finding another game keeps your day fun.' },
+      { kind: 'choice', say: 'Maybe later you still want to play with Bear. What can you try?',
+        npc: { face: '🐻', mood: MOOD('happy') },
+        options: [
+          opt('🙋', 'Ask again later', true),
+          opt('🙅', 'Never ask Bear again'),
+        ], doneLine: 'Asking again later is a great idea. "Not now" is not "never."' },
+    ],
+  },
+  {
+    zone: 'deepforest', level: 3, goal: 'Losing a game gracefully',
+    intro: "Sometimes we don't win. There is a friendly way to lose a game.",
+    outro: 'You lost a game with a friendly heart. That makes you fun to play with!',
+    moment: 'lost a game gracefully in the deep forest',
+    rounds: [
+      { kind: 'choice', say: 'Deer won the race and you came in second. What do you say to Deer?',
+        npc: { face: '🦌', mood: MOOD('proud'), thought: { emoji: '🏁' } },
+        options: [
+          opt('👏', 'Good game!', true),
+          opt('😤', 'That was not fair'),
+          opt('🙄', 'I did not even try'),
+        ], doneLine: '"Good game!" shows you can be a gracious friend.' },
+      { kind: 'choice', say: 'You feel a little disappointed you did not win. What can you do with that feeling?',
+        npc: { face: '🦌', mood: MOOD('neutral') },
+        options: [
+          opt('🌬️', 'Take a breath, it is okay', true),
+          opt('😡', 'Kick the ground'),
+        ], doneLine: 'A breath helps the disappointed feeling pass.' },
+      { kind: 'choice', say: 'What is a good next step after losing a game?',
+        npc: { face: '🦌', mood: MOOD('happy') },
+        options: [
+          opt('🔁', 'Try again', true),
+          opt('🚪', 'Never play again'),
+        ], doneLine: 'Trying again is how we get better and have more fun.' },
+    ],
+  },
+  {
+    zone: 'deepforest', level: 4, goal: 'Politely disagreeing',
+    intro: "Friends don't always want the same thing. Let's learn to disagree kindly.",
+    outro: 'You disagreed kindly and found a fair answer. That is a big friendship skill!',
+    moment: 'disagreed politely in the deep forest',
+    rounds: [
+      { kind: 'choice', say: 'You and Bunny both want the red block. What can you say?',
+        npc: { face: '🐰', mood: MOOD('neutral'), thought: { emoji: '🟥' } },
+        options: [
+          opt('💬', 'I want the red one', true),
+          opt('😤', 'Grab it and run'),
+          opt('🤐', 'Say nothing and feel upset'),
+        ], doneLine: 'Saying what you want clearly is a good first step.' },
+      { kind: 'choice', say: 'Bunny wants the red block too. What can you both try?',
+        npc: { face: '🐰', mood: MOOD('neutral') },
+        options: [
+          opt('🔄', 'Can we take turns?', true),
+          opt('😡', 'It is mine, no turns'),
+        ], doneLine: '"Can we take turns?" is a fair, kind way to solve it.' },
+      { kind: 'choice', say: 'You both agree to take turns. Who goes first can be decided by...',
+        npc: { face: '🐰', mood: MOOD('happy') },
+        options: [
+          opt('🪙', 'A fair pick, like a coin flip', true),
+          opt('😤', 'Whoever grabs it first'),
+        ], doneLine: 'A fair pick keeps it friendly for everyone.' },
+    ],
+  },
+  {
+    zone: 'deepforest', level: 5, goal: 'Giving and receiving compliments',
+    intro: "Kind words about a friend's work are called compliments. Let's practice giving and getting them.",
+    outro: 'You gave and received compliments so kindly. That is how friendships grow!',
+    moment: 'shared compliments in the deep forest',
+    rounds: [
+      { kind: 'choice', say: 'Owl built a very tall tower. What kind thing can you say?',
+        npc: { face: '🦉', mood: MOOD('proud'), thought: { emoji: '🗼' } },
+        options: [
+          opt('👏', 'Wow, great tower!', true),
+          opt('😐', 'That is boring'),
+          opt('🤐', 'Say nothing'),
+        ], doneLine: 'A kind compliment can make a friend\'s whole day.' },
+      { kind: 'choice', say: 'Deer says "I love your drawing!" What do you say back?',
+        npc: { face: '🦌', mood: MOOD('happy'), thought: { emoji: '🎨' } },
+        options: [
+          opt('😊', 'Thank you!', true),
+          opt('🙅', 'It is not good'),
+        ], doneLine: '"Thank you!" is the perfect way to take a compliment.' },
+      { kind: 'multiPick', say: 'Walk into two kind things you could say about a friend\'s work.', picks: 2,
+        npc: { face: '🦌', mood: MOOD('happy') },
+        options: [
+          opt('🌈', 'I love the colors!', true),
+          opt('💪', 'You worked so hard!', true),
+          opt('😒', 'It could be better'),
+          opt('🥱', "That's boring"),
+        ], doneLine: 'Those are wonderful compliments — friends love hearing them.' },
+    ],
+  },
+];
+
+// ===========================================================================
+// QUIET LAGOON 🪷 — Advanced Calm (sister island of cove)
+// ===========================================================================
+
+const LAGOON: AdvancedQuest[] = [
+  {
+    zone: 'lagoon', level: 1, goal: 'Noticing early body signals',
+    intro: "Our body sends little signals before a big feeling grows. Let's learn to notice them early.",
+    outro: 'You noticed the early signals in your body. That is a superpower for staying calm!',
+    moment: 'noticed early body signals at the lagoon',
+    rounds: [
+      { kind: 'choice', say: 'Before a big feeling grows, your hands might feel...',
+        npc: { face: '🐬', mood: MOOD('neutral'), thought: { emoji: '✊' } },
+        options: [
+          opt('✊', 'tight or clenched', true),
+          opt('🖐️', 'loose and floppy'),
+        ], doneLine: 'Tight hands can be an early signal — good noticing!' },
+      { kind: 'choice', say: 'Your heart might start to feel...',
+        npc: { face: '🐬', mood: MOOD('neutral'), thought: { emoji: '💓' } },
+        options: [
+          opt('💓', 'fast, beating quickly', true),
+          opt('💤', 'sleepy and slow'),
+        ], doneLine: 'A fast heart can be an early signal too.' },
+      { kind: 'choice', say: 'When you notice a signal like tight hands or a fast heart, what is a good first step?',
+        npc: { face: '🐬', mood: MOOD('calm') },
+        options: [
+          opt('🌬️', 'Take a calm breath', true),
+          opt('🙈', 'Ignore it and keep going'),
+        ], doneLine: 'Noticing early and breathing helps keep feelings small and manageable.' },
+    ],
+  },
+  {
+    zone: 'lagoon', level: 2, goal: 'A longer breathing ladder',
+    intro: "Let's climb the calm stepping stones — five breaths, one stone at a time.",
+    outro: 'You climbed all five calm stones. What a peaceful ladder of breaths!',
+    moment: 'climbed the breathing ladder at the lagoon',
+    rounds: [
+      { kind: 'steps', say: "Climb the calm stones with me — one slow breath on each stone.",
+        npc: { face: '🐬', mood: MOOD('calm') },
+        count: 5,
+        labels: ['Breathe 1 🌊', 'Breathe 2 🌊', 'Breathe 3 🌊', 'Breathe 4 🌊', 'Breathe 5 🌊'],
+        doneLine: 'Five slow breaths, five calm stones — you feel peaceful now.' },
+      { kind: 'breathe', say: 'One more gentle breath together, just because it feels nice.',
+        npc: { face: '🐬', mood: MOOD('calm') }, cycles: 2,
+        doneLine: 'So calm and quiet, like the lagoon itself.' },
+    ],
+  },
+  {
+    zone: 'lagoon', level: 3, goal: 'Making a plan for loud places',
+    intro: "Loud places can feel like too much. Let's sort helpful ideas from ones that are not helpful.",
+    outro: 'You built a smart plan for loud places. You are ready for anywhere now!',
+    moment: 'made a plan for loud places at the lagoon',
+    rounds: [
+      { kind: 'sort', say: "Let's sort ideas for loud places! Carry each one to helpful or not helpful.",
+        npc: { face: '🐬', mood: MOOD('neutral'), thought: { emoji: '🔊' } },
+        tables: [
+          opt('✅', 'Helpful'),
+          opt('❌', 'Not helpful'),
+        ],
+        items: [
+          { emoji: '🙉', caption: 'Cover ears', table: 0 },
+          { emoji: '🙋', caption: 'Ask for a quiet corner', table: 0 },
+          { emoji: '🌬️', caption: 'Take a deep breath', table: 0 },
+          { emoji: '😡', caption: 'Yell louder', table: 1 },
+          { emoji: '🏃', caption: 'Run off alone', table: 1 },
+        ],
+        doneLine: 'Covering ears, asking for quiet, and breathing — those really help!' },
+      { kind: 'choice', say: 'A loud room feels like too much right now. What do you try first?',
+        npc: { face: '🐬', mood: MOOD('neutral'), thought: { emoji: '🔊' } },
+        options: [
+          opt('🙉', 'Cover my ears', true),
+          opt('😡', 'Yell louder'),
+        ], doneLine: 'Covering your ears is a great first plan.' },
+    ],
+  },
+  {
+    zone: 'lagoon', level: 4, goal: 'Waiting calmly',
+    intro: "Waiting can feel long. Let's practice fun ways to wait calmly.",
+    outro: 'You waited so calmly with your own waiting games. Wonderful patience!',
+    moment: 'practiced waiting calmly at the lagoon',
+    rounds: [
+      { kind: 'multiPick', say: 'Walk into TWO waiting games that help the time pass calmly.', picks: 2,
+        npc: { face: '🐬', mood: MOOD('calm'), thought: { emoji: '⏳' } },
+        options: [
+          opt('🔢', 'Count slowly', true),
+          opt('✊', 'Squeeze my hands', true),
+          opt('😡', 'Yell "hurry up!"'),
+          opt('🏃', 'Run around loudly'),
+        ], doneLine: 'Counting and squeezing hands are great ways to wait calmly.' },
+      { kind: 'steps', say: "Let's count slowly together while we wait, one number at a time.",
+        npc: { face: '🐬', mood: MOOD('calm') },
+        count: 5,
+        doneLine: 'One, two, three, four, five — the wait is over, and you stayed so calm!' },
+      { kind: 'choice', say: 'While you wait, thinking of your favorite thing can help. What is a good favorite to think of?',
+        npc: { face: '🐬', mood: MOOD('calm'), thought: { emoji: '💭' } },
+        options: [
+          opt('🌟', 'My favorite thing', true),
+          opt('😤', 'How slow this is'),
+        ], doneLine: 'Thinking of a favorite thing makes waiting feel shorter.' },
+    ],
+  },
+  {
+    zone: 'lagoon', level: 5, goal: 'When plans change',
+    intro: "Sometimes plans change without warning. Let's practice thinking of a new idea.",
+    outro: 'You found a new plan when the old one changed. That is flexible thinking — so strong!',
+    moment: 'handled a changed plan at the lagoon',
+    rounds: [
+      { kind: 'choice', say: 'The park is closed today, and that was the plan. How might you feel first?',
+        npc: { face: '🐬', mood: MOOD('disappointed'), thought: { emoji: '🚫' } },
+        options: [
+          opt('😞', 'A little disappointed — that is okay', true),
+          opt('😡', 'I must yell about it'),
+        ], doneLine: 'Feeling disappointed when a plan changes is okay.' },
+      { kind: 'breathe', say: 'Let\'s breathe through the surprise together.',
+        npc: { face: '🐬', mood: MOOD('calm') }, cycles: 2,
+        doneLine: 'A calm breath makes room for a new idea.' },
+      { kind: 'choice', say: 'The park is closed. What can we do instead?',
+        npc: { face: '🐬', mood: MOOD('calm'), thought: { emoji: '❓' } },
+        options: [
+          opt('🏠', 'Think of a fun thing to do at home', true),
+          opt('😤', 'Stay upset all day'),
+        ], doneLine: 'Finding a new plan turns a hard moment into a good one.' },
+    ],
+  },
+];
+
+// ===========================================================================
+// TREASURE BAY ⛵ — Advanced Sharing & Cooperation (sister island of shore)
+// ===========================================================================
+
+const BAY: AdvancedQuest[] = [
+  {
+    zone: 'bay', level: 1, goal: 'Borrowing and returning',
+    intro: "Sometimes we borrow a friend's thing. Let's practice asking, and giving it back.",
+    outro: 'You borrowed and returned so kindly. That builds friend trust!',
+    moment: 'practiced borrowing and returning at the bay',
+    rounds: [
+      { kind: 'choice', say: 'Parrot has a shovel you want to use. What do you say?',
+        npc: { face: '🦜', mood: MOOD('happy'), thought: { emoji: '🪏' } },
+        options: [
+          opt('🙋', 'Can I borrow it?', true),
+          opt('🤚', 'Take it without asking'),
+        ], doneLine: '"Can I borrow it?" is the kind way to ask.' },
+      { kind: 'choice', say: 'You are done with the shovel. What do you do now?',
+        npc: { face: '🦜', mood: MOOD('happy') },
+        options: [
+          opt('🔙', 'Give it back and say thank you', true),
+          opt('🙅', 'Keep it'),
+        ], doneLine: '"Here it is back — thank you!" That is how borrowing works.' },
+      { kind: 'choice', say: 'Parrot says "Thanks for bringing it back!" How do you feel?',
+        npc: { face: '🦜', mood: MOOD('happy') },
+        options: [
+          opt('😊', 'Happy — I was a good friend', true),
+          opt('😐', 'It does not matter'),
+        ], doneLine: 'Being trusted with borrowed things feels great.' },
+    ],
+  },
+  {
+    zone: 'bay', level: 2, goal: 'Trading and compromise',
+    intro: "Sometimes two friends want different things. A trade can make everyone happy.",
+    outro: 'You made a fair trade. Compromise makes everyone a winner!',
+    moment: 'made a fair trade at the bay',
+    rounds: [
+      { kind: 'choice', say: 'You have a blue shell, Turtle has a pink shell. You both like the other one. What can you try?',
+        npc: { face: '🐢', mood: MOOD('neutral'), thought: { emoji: '🐚' } },
+        options: [
+          opt('🔄', 'Trade shells', true),
+          opt('🙅', 'Keep mine and take theirs too'),
+        ], doneLine: 'A trade means you both get something you like!' },
+      { kind: 'choice', say: 'You both want to pick the game first. What is a fair way to decide?',
+        npc: { face: '🦜', mood: MOOD('neutral') },
+        options: [
+          opt('🥇', 'You pick first this time, I pick next time', true),
+          opt('😤', 'I always pick first'),
+        ], doneLine: 'Taking turns picking is a fair compromise.' },
+      { kind: 'choice', say: 'It worked out fairly for both of you. How do you both feel?',
+        npc: { face: '🐢', mood: MOOD('happy') },
+        options: [
+          opt('😊', 'Happy, it felt fair', true),
+          opt('😤', 'Still upset'),
+        ], doneLine: 'A fair trade leaves everyone feeling good.' },
+    ],
+  },
+  {
+    zone: 'bay', level: 3, goal: 'Building together',
+    intro: "Let's build a sandcastle together, one piece at a time — taking turns adding to it.",
+    outro: 'You built the whole castle together, turn by turn. It is even better made together!',
+    moment: 'built a sandcastle together at the bay',
+    rounds: [
+      { kind: 'choice', say: 'One pile of sand, two builders. How should you start?',
+        npc: { face: '🦜', mood: MOOD('excited'), thought: { emoji: '🏰' } },
+        options: [
+          opt('🤝', 'Take turns adding pieces', true),
+          opt('🙅', 'Build separately with no turns'),
+        ], doneLine: 'Taking turns means the castle is truly built together.' },
+      { kind: 'carry', say: "Let's build it! Carry each piece to the castle, one turn at a time — your piece, my piece, your piece.",
+        npc: { face: '🦜', mood: MOOD('happy') },
+        items: [
+          { emoji: '🧱', caption: 'my piece' },
+          { emoji: '🐚', caption: "Parrot's piece" },
+          { emoji: '🚩', caption: 'my piece' },
+        ],
+        doneLine: 'Piece by piece, turn by turn — the castle grew tall!' },
+      { kind: 'choice', say: 'The castle is finished! How do you feel about building it together?',
+        npc: { face: '🦜', mood: MOOD('proud'), thought: { emoji: '🏰' } },
+        options: [
+          opt('🎉', 'Proud — we built it together!', true),
+          opt('😤', 'I wish I built it alone'),
+        ], doneLine: '"We built it together!" — the best kind of proud.' },
+    ],
+  },
+  {
+    zone: 'bay', level: 4, goal: 'When there is only one',
+    intro: "Only one boat, and two friends who want to ride. Let's find fair ways to share it.",
+    outro: 'You found fair ways to share one thing. That takes real teamwork!',
+    moment: 'shared one thing fairly at the bay',
+    rounds: [
+      { kind: 'choice', say: 'There is only one boat, and both you and Turtle want to ride. What is a fair idea?',
+        npc: { face: '🐢', mood: MOOD('neutral'), thought: { emoji: '⛵' } },
+        options: [
+          opt('⏱️', 'Take turns with a timer', true),
+          opt('😤', 'Whoever gets there first keeps it'),
+        ], doneLine: 'A timer makes turns fair for everyone.' },
+      { kind: 'choice', say: 'The boat is big enough for two. What else could you try?',
+        npc: { face: '🐢', mood: MOOD('happy') },
+        options: [
+          opt('🤝', 'Ride together', true),
+          opt('🙅', 'Push Turtle out'),
+        ], doneLine: 'Riding together means no one has to wait at all!' },
+      { kind: 'choice', say: 'If you cannot ride together or use a timer, what is one more fair idea?',
+        npc: { face: '🦜', mood: MOOD('neutral') },
+        options: [
+          opt('🎲', 'Choose together, like a fair pick', true),
+          opt('😡', 'Argue until someone gives up'),
+        ], doneLine: 'Choosing together, fairly, keeps everyone as friends.' },
+    ],
+  },
+  {
+    zone: 'bay', level: 5, goal: "Celebrating a friend's win",
+    intro: "When a friend wins or does something great, we can celebrate WITH them.",
+    outro: "You celebrated a friend's win with your whole heart. That is true friendship!",
+    moment: "celebrated a friend's win at the bay",
+    rounds: [
+      { kind: 'choice', say: 'Turtle just won the swimming race! What can you do?',
+        npc: { face: '🐢', mood: MOOD('proud'), thought: { emoji: '🏆' } },
+        options: [
+          opt('👏', 'Clap for Turtle', true),
+          opt('😤', 'Look away, upset'),
+        ], doneLine: 'Clapping for a friend shows you are happy for them.' },
+      { kind: 'choice', say: 'What kind words can you say to Turtle?',
+        npc: { face: '🐢', mood: MOOD('proud') },
+        options: [
+          opt('🎉', 'Congrats, great job!', true),
+          opt('😒', 'You just got lucky'),
+        ], doneLine: '"Congrats, great job!" makes a winner feel truly seen.' },
+      { kind: 'choice', say: 'You did not win this time, but you cheered for Turtle. How can that feel?',
+        npc: { face: '🦜', mood: MOOD('happy') },
+        options: [
+          opt('💖', 'Good — being happy for others feels nice too', true),
+          opt('😡', 'Only bad'),
+        ], doneLine: 'Being happy for a friend is its own kind of winning.' },
+    ],
+  },
+];
+
+// ===========================================================================
+
+export const ADVANCED_QUESTS: Record<AdvancedZone, AdvancedQuest[]> = {
+  garden: GARDEN,
+  deepforest: DEEPFOREST,
+  lagoon: LAGOON,
+  bay: BAY,
+};
+
+/** Get the advanced quest for a zone at a 1-based level (clamped). */
+export function getAdvancedQuest(zone: AdvancedZone, level: number): AdvancedQuest {
+  const list = ADVANCED_QUESTS[zone];
+  const idx = Math.max(0, Math.min(list.length - 1, level - 1));
+  return list[idx];
+}
+
+/** Suggested Day Book sticker entries for each advanced level, 'garden-1'..'bay-5'. */
+export const ADVANCED_STICKERS: Record<string, { emoji: string; label: string }> = {
+  'garden-1': { emoji: '🌦️', label: 'Mixed feelings are okay! 🌦️' },
+  'garden-2': { emoji: '🎭', label: 'A face doesn\'t always tell it all! 🎭' },
+  'garden-3': { emoji: '🧠', label: 'I can guess how a friend feels! 🧠' },
+  'garden-4': { emoji: '🤗', label: 'I know how to help a sad friend! 🤗' },
+  'garden-5': { emoji: '☁️', label: 'Feelings pass, like clouds! ☁️' },
+  'deepforest-1': { emoji: '🙋', label: 'Can I play too? I know how to ask! 🙋' },
+  'deepforest-2': { emoji: '🔍', label: 'When a friend says no, I find another game! 🔍' },
+  'deepforest-3': { emoji: '👏', label: 'Good game! I can lose with a smile! 👏' },
+  'deepforest-4': { emoji: '🔄', label: 'Can we take turns? I disagree kindly! 🔄' },
+  'deepforest-5': { emoji: '💛', label: 'I give and take compliments! 💛' },
+  'lagoon-1': { emoji: '✊', label: 'I notice tight hands and a fast heart early! ✊' },
+  'lagoon-2': { emoji: '🪨', label: 'Five calm breaths, five calm stones! 🪨' },
+  'lagoon-3': { emoji: '🔊', label: 'I have a plan for loud places! 🔊' },
+  'lagoon-4': { emoji: '⏳', label: 'I can wait calmly with my own games! ⏳' },
+  'lagoon-5': { emoji: '🔀', label: 'When plans change, I think of something new! 🔀' },
+  'bay-1': { emoji: '🔙', label: 'I borrow kindly and give it back! 🔙' },
+  'bay-2': { emoji: '🔄', label: 'I can trade and compromise! 🔄' },
+  'bay-3': { emoji: '🏰', label: 'We built it together, turn by turn! 🏰' },
+  'bay-4': { emoji: '⛵', label: 'When there is only one, we share it fairly! ⛵' },
+  'bay-5': { emoji: '🎉', label: 'I celebrate my friend\'s win! 🎉' },
+};

--- a/components/game/BelusWorld/three/quest/advancedQuests.ts
+++ b/components/game/BelusWorld/three/quest/advancedQuests.ts
@@ -9,24 +9,20 @@
 // errorless, no timers, no losing. Faces vary per helper but each island has
 // a "home" face: garden 🦋, deepforest 🦌, lagoon 🐬, bay 🦜.
 //
-// TODO(engine agent): `Quest.zone` in quests.ts is typed `ActivityZone`, which
-// does not yet include 'garden' | 'deepforest' | 'lagoon' | 'bay'. Rather than
-// edit quests.ts (other agents are mid-edit on it), this file defines its own
-// `AdvancedZone` union and a local `AdvancedQuest` type — an `Omit<Quest,
-// 'zone'> & { zone: AdvancedZone }` — so this file compiles standalone today.
-// Once ActivityZone is widened to include the four advanced zones, the engine
-// agent can simply re-type ADVANCED_QUESTS as Record<ActivityZone, Quest[]>
-// (or merge these arrays into QUESTS) with no changes needed to the data below.
+// ActivityZone (belu/progress.ts) has been widened to include the four
+// advanced zones, so AdvancedQuest is now just an alias for Quest and
+// ADVANCED_QUESTS merges straight into QUESTS in quests.ts.
 // ---------------------------------------------------------------------------
 
 import type { Quest, Orb } from './quests';
 import type { Mood } from './QuestNPC';
+import type { ActivityZone } from '../../belu/progress';
 
-/** The four new zone ids — not yet part of ActivityZone. See TODO above. */
-export type AdvancedZone = 'garden' | 'deepforest' | 'lagoon' | 'bay';
+/** The four advanced zone ids — a subset of ActivityZone. */
+export type AdvancedZone = Extract<ActivityZone, 'garden' | 'deepforest' | 'lagoon' | 'bay'>;
 
-/** Same shape as Quest, but with our own zone union until quests.ts is widened. */
-export type AdvancedQuest = Omit<Quest, 'zone'> & { zone: AdvancedZone };
+/** Same shape as Quest — kept as its own name for readability in this file. */
+export type AdvancedQuest = Quest;
 
 const MOOD = (m: Mood): Mood => m;
 

--- a/components/game/BelusWorld/three/quest/quests.ts
+++ b/components/game/BelusWorld/three/quest/quests.ts
@@ -9,6 +9,7 @@
 
 import type { ActivityZone } from '../../belu/progress';
 import type { Mood } from './QuestNPC';
+import { ADVANCED_QUESTS } from './advancedQuests';
 
 export interface Orb {
   emoji: string;
@@ -1027,6 +1028,8 @@ export const QUESTS: Record<ActivityZone, Quest[]> = {
   school: SCHOOL,
   afternoon: AFTERNOON,
   night: NIGHT,
+  // Advanced sister islands (garden/deepforest/lagoon/bay) — see advancedQuests.ts
+  ...ADVANCED_QUESTS,
 };
 
 /** Get the quest for a zone at a 1-based level (clamped to the available set). */

--- a/components/game/BelusWorld/three/worldConfig.ts
+++ b/components/game/BelusWorld/three/worldConfig.ts
@@ -7,7 +7,8 @@
 
 export type ZoneId =
   | 'home' | 'meadow' | 'mountain' | 'cove' | 'forest' | 'shore' | 'rainbow'
-  | 'school' | 'afternoon' | 'night';
+  | 'school' | 'afternoon' | 'night'
+  | 'garden' | 'deepforest' | 'lagoon' | 'bay';
 
 export interface IslandDef {
   id: ZoneId;
@@ -177,6 +178,59 @@ export const ISLANDS: Record<ZoneId, IslandDef> = {
     label: 'Sleepy Island',
     emoji: '🌙',
   },
+  // ---- Advanced sister islands — these FORM once their parent skill island
+  // reaches 5/5 completed levels (plain gating, no dayArc/fresh choice
+  // involved). Each sits further out beyond its parent, away from home, so
+  // the bridge always runs parent → advanced (never home → advanced). See
+  // three/quest/advancedQuests.ts for the lesson content. ----
+  garden: {
+    id: 'garden',
+    cx: -75.18,
+    cz: -15.83,
+    radius: 8.5,
+    top: 3,
+    grass: '#ffd3e6',
+    rock: '#c98aa8',
+    accent: '#ec4899',
+    label: 'Feelings Garden',
+    emoji: '🌷',
+  },
+  deepforest: {
+    id: 'deepforest',
+    cx: 59.72,
+    cz: 56,
+    radius: 8.5,
+    top: 1.5,
+    grass: '#2f7d4a',
+    rock: '#4a5a3c',
+    accent: '#16a34a',
+    label: 'Deep Forest',
+    emoji: '🌲',
+  },
+  lagoon: {
+    id: 'lagoon',
+    cx: -53.93,
+    cz: 57.78,
+    radius: 8.5,
+    top: -1.5,
+    grass: '#8fd8d0',
+    rock: '#5a8a95',
+    accent: '#06b6d4',
+    label: 'Quiet Lagoon',
+    emoji: '🪷',
+  },
+  bay: {
+    id: 'bay',
+    cx: 3.73,
+    cz: 81.96,
+    radius: 8.5,
+    top: 1,
+    grass: '#f2dfa9',
+    rock: '#b09a72',
+    accent: '#f97316',
+    label: 'Treasure Bay',
+    emoji: '⛵',
+  },
 };
 
 export const ISLAND_LIST = Object.values(ISLANDS);
@@ -198,6 +252,12 @@ export const BRIDGES: BridgeDef[] = [
   { from: 'mountain', to: 'school', halfWidth: 2.2, colors: RAINBOW_STRIPES },
   { from: 'school', to: 'afternoon', halfWidth: 2.2, colors: RAINBOW_STRIPES },
   { from: 'afternoon', to: 'night', halfWidth: 2.2, colors: RAINBOW_STRIPES },
+  // Advanced sister islands — the bridge always runs FROM the parent skill
+  // island (never from home), so finishing that island always leads onward.
+  { from: 'meadow', to: 'garden', halfWidth: 2.2, colors: RAINBOW_STRIPES },
+  { from: 'forest', to: 'deepforest', halfWidth: 2.2, colors: RAINBOW_STRIPES },
+  { from: 'cove', to: 'lagoon', halfWidth: 2.2, colors: RAINBOW_STRIPES },
+  { from: 'shore', to: 'bay', halfWidth: 2.2, colors: RAINBOW_STRIPES },
 ];
 
 // The zone islands that host a learning activity (everything except home + the
@@ -205,16 +265,22 @@ export const BRIDGES: BridgeDef[] = [
 export const ZONE_ISLANDS: ZoneId[] = [
   'meadow', 'mountain', 'cove', 'forest', 'shore',
   'school', 'afternoon', 'night',
+  'garden', 'deepforest', 'lagoon', 'bay',
 ];
 
-// Runtime flags: the reward island + the Day Arc islands (and their bridges)
-// only physically exist once earned. Rendering AND ground-collision both read
-// these so a locked island is neither visible nor walkable.
+// Runtime flags: the reward island + the Day Arc islands + the advanced
+// sister islands (and their bridges) only physically exist once earned.
+// Rendering AND ground-collision both read these so a locked island is
+// neither visible nor walkable.
 export const worldRuntime = {
   rainbowUnlocked: false,
   schoolUnlocked: false,
   afternoonUnlocked: false,
   nightUnlocked: false,
+  gardenUnlocked: false,
+  deepforestUnlocked: false,
+  lagoonUnlocked: false,
+  bayUnlocked: false,
 };
 
 /** Does this island physically exist right now? (locked islands are neither
@@ -224,6 +290,10 @@ export function isZoneFormed(id: ZoneId): boolean {
   if (id === 'school') return worldRuntime.schoolUnlocked;
   if (id === 'afternoon') return worldRuntime.afternoonUnlocked;
   if (id === 'night') return worldRuntime.nightUnlocked;
+  if (id === 'garden') return worldRuntime.gardenUnlocked;
+  if (id === 'deepforest') return worldRuntime.deepforestUnlocked;
+  if (id === 'lagoon') return worldRuntime.lagoonUnlocked;
+  if (id === 'bay') return worldRuntime.bayUnlocked;
   return true;
 }
 

--- a/components/game/BelusWorld/ui/GrowthMap.tsx
+++ b/components/game/BelusWorld/ui/GrowthMap.tsx
@@ -33,6 +33,10 @@ const SKILLS: Record<ActivityZone, string> = {
   school: 'School Skills',
   afternoon: 'Home Routines',
   night: 'Bedtime Routines',
+  garden: 'Advanced Feelings',
+  deepforest: 'Advanced Friendship',
+  lagoon: 'Advanced Calm',
+  bay: 'Advanced Sharing',
 };
 
 const GROWTH_EMOJI = ['🐣', '🐘', '🐘', '🐘']; // baby vs grown handled by scale below

--- a/components/game/BelusWorld/ui/HUD.tsx
+++ b/components/game/BelusWorld/ui/HUD.tsx
@@ -5,6 +5,7 @@
 // them, so movement taps still reach the canvas underneath.
 // ---------------------------------------------------------------------------
 
+import { useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { ISLANDS, type ZoneId } from '../three/worldConfig';
 import { nudgeZoom, CAM_ZOOM_STEP } from '../three/playerState';
@@ -34,6 +35,24 @@ interface Props {
 export default function HUD({ beluLine, nearZone, starQuestZone, stickers, totalStars, isTouch, onOpenSettings, onOpenMap, onOpenWardrobe, onToggleFullscreen, onGoHome, onExit, onPause, onCycleSpeed, speedLabel, onToggleMute, muted }: Props) {
   const zoneMeta = nearZone && nearZone !== 'home' ? ISLANDS[nearZone] : null;
   const hasStarQuest = !!starQuestZone && starQuestZone === nearZone;
+  const [showMore, setShowMore] = useState(false);
+
+  // Tucked into the "More" popover so a stray tap can't dress up Nilu, open the
+  // map, change speed, go fullscreen, open settings, or exit by accident — a
+  // child should only ever see mute / pause / home / more as instant taps.
+  const moreRows: Array<{ label: string; onClick: () => void; ariaLabel: string }> = [
+    { label: '🎩 Dress up', onClick: onOpenWardrobe, ariaLabel: 'Dress up Nilu' },
+    { label: '🗺️ Growth map', onClick: onOpenMap, ariaLabel: 'Growth map' },
+    { label: `🎛️ Speed: ${speedLabel}`, onClick: onCycleSpeed, ariaLabel: `Game speed: ${speedLabel} — tap for more time or faster` },
+    { label: '⛶ Full screen', onClick: onToggleFullscreen, ariaLabel: 'Full screen' },
+    { label: '⚙️ For grown-ups & settings', onClick: onOpenSettings, ariaLabel: 'Settings' },
+    { label: '🚪 Leave game', onClick: onExit, ariaLabel: 'Exit game' },
+  ];
+
+  const runMoreAction = (fn: () => void) => {
+    fn();
+    setShowMore(false);
+  };
 
   return (
     <div className="pointer-events-none fixed inset-0 z-30">
@@ -60,97 +79,97 @@ export default function HUD({ beluLine, nearZone, starQuestZone, stickers, total
         </AnimatePresence>
       </div>
 
-      {/* Stars + stickers + map + settings — top right */}
+      {/* Stars + stickers — top right, info only so it's small */}
       <div className="absolute right-4 top-4 flex items-center gap-2">
-        <div className="flex items-center gap-1 rounded-full bg-white/90 px-3 py-1.5 shadow-lg backdrop-blur">
-          <span className="text-sm">⭐</span>
-          <span className="text-sm font-bold text-slate-700">{totalStars}</span>
+        <div className="flex items-center gap-1 rounded-full bg-white/80 px-2.5 py-1 shadow backdrop-blur">
+          <span className="text-xs">⭐</span>
+          <span className="text-xs font-bold text-slate-700">{totalStars}</span>
           {stickers.length > 0 && (
-            <span className="ml-1 flex gap-0.5">
+            <span className="ml-0.5 flex gap-0.5">
               {stickers.map((s, i) => (
-                <span key={i} className="text-base">{s}</span>
+                <span key={i} className="text-sm">{s}</span>
               ))}
             </span>
           )}
         </div>
+      </div>
+
+      {/* Always-visible controls — big (48px+) and few, for a 4-10yo audience.
+          Everything else (wardrobe/map/speed/fullscreen/settings/exit) lives
+          behind "More" so a stray tap can't dress up Nilu or exit the game. */}
+      <div className="absolute right-4 top-14 flex items-center gap-2">
         <button
           onClick={onToggleMute}
-          className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg shadow-lg backdrop-blur transition hover:bg-white"
+          className="pointer-events-auto flex h-12 w-12 items-center justify-center rounded-full bg-white/90 text-xl shadow-lg backdrop-blur transition hover:bg-white active:scale-95"
           aria-label={muted ? 'Unmute sound' : 'Mute sound'}
           title={muted ? 'Unmute sound' : 'Mute sound'}
         >
           {muted ? '🔇' : '🔊'}
         </button>
-        {/* labeled + emerald so a child hunting for "how do I get back?" spots it
-            among the icon-only buttons — it teleports Nilu straight to home base */}
-        <button
-          onClick={onGoHome}
-          className="pointer-events-auto flex h-11 items-center gap-1.5 rounded-full bg-emerald-500/95 px-3 text-lg shadow-lg backdrop-blur transition hover:bg-emerald-400"
-          aria-label="Go back to home base"
-          title="Go back to home base"
-        >
-          🏡<span className="text-sm font-bold text-white">Home</span>
-        </button>
-        <button
-          onClick={onOpenWardrobe}
-          className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg shadow-lg backdrop-blur transition hover:bg-white"
-          aria-label="Dress up Nilu"
-          title="Dress up Nilu"
-        >
-          🎩
-        </button>
-        <button
-          onClick={onOpenMap}
-          className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg shadow-lg backdrop-blur transition hover:bg-white"
-          aria-label="Growth map"
-        >
-          🗺️
-        </button>
-        <button
-          onClick={onCycleSpeed}
-          className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg shadow-lg backdrop-blur transition hover:bg-white"
-          aria-label="Game speed"
-          title={`Game speed: ${speedLabel} — tap for more time 🐢 or faster 🚀`}
-        >
-          🎛️
-        </button>
-        <button
-          onClick={onToggleFullscreen}
-          className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg shadow-lg backdrop-blur transition hover:bg-white"
-          aria-label="Full screen"
-          title="Full screen"
-        >
-          ⛶
-        </button>
         <button
           onClick={onPause}
-          className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg shadow-lg backdrop-blur transition hover:bg-white"
+          className="pointer-events-auto flex h-12 w-12 items-center justify-center rounded-full bg-white/90 text-xl shadow-lg backdrop-blur transition hover:bg-white active:scale-95"
           aria-label="Take a break"
           title="Take a break"
         >
           ⏸️
         </button>
+        {/* labeled + emerald so a child hunting for "how do I get back?" spots it
+            among the icon-only buttons — it teleports Nilu straight to home base */}
         <button
-          onClick={onOpenSettings}
-          className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg shadow-lg backdrop-blur transition hover:bg-white"
-          aria-label="Settings"
+          onClick={onGoHome}
+          className="pointer-events-auto flex h-12 items-center gap-1.5 rounded-full bg-emerald-500/95 px-4 text-xl shadow-lg backdrop-blur transition hover:bg-emerald-400 active:scale-95"
+          aria-label="Go back to home base"
+          title="Go back to home base"
         >
-          ⚙️
+          🏡<span className="text-base font-bold text-white">Home</span>
         </button>
-        {/* Exit — kept visually separate (left border gap + warmer tint) from
-            settings/pause so a stray tap doesn't read as "just another button" */}
         <button
-          onClick={onExit}
-          className="pointer-events-auto ml-1.5 flex h-10 w-10 items-center justify-center rounded-full border-l-2 border-white/60 bg-rose-50/90 pl-0.5 text-lg text-rose-500 shadow-lg backdrop-blur transition hover:bg-rose-100"
-          aria-label="Exit game"
-          title="Exit"
+          onClick={() => setShowMore(v => !v)}
+          className="pointer-events-auto flex h-12 items-center gap-1 rounded-full bg-white/90 px-4 text-xl shadow-lg backdrop-blur transition hover:bg-white active:scale-95"
+          aria-label="More options"
+          title="More options"
+          aria-expanded={showMore}
         >
-          ✕
+          ⋯<span className="text-base font-bold text-slate-700">More</span>
         </button>
       </div>
 
+      {/* "More" popover — big labeled rows for dress up / map / speed /
+          fullscreen / settings / exit, kept one deliberate tap away. */}
+      <AnimatePresence>
+        {showMore && (
+          <motion.div
+            initial={{ opacity: 0, y: -8, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -8, scale: 0.97 }}
+            className="pointer-events-auto absolute right-4 top-28 z-40 flex w-64 flex-col overflow-hidden rounded-3xl bg-white/95 shadow-2xl backdrop-blur"
+          >
+            {moreRows.map(row => (
+              <button
+                key={row.ariaLabel}
+                onClick={() => runMoreAction(row.onClick)}
+                className="flex h-14 items-center px-5 text-left text-base font-bold text-slate-700 transition hover:bg-slate-100 active:bg-slate-200"
+                aria-label={row.ariaLabel}
+                title={row.ariaLabel}
+              >
+                {row.label}
+              </button>
+            ))}
+            <button
+              onClick={() => setShowMore(false)}
+              className="flex h-14 items-center border-t border-slate-200 px-5 text-left text-base font-bold text-rose-500 transition hover:bg-rose-50 active:bg-rose-100"
+              aria-label="Close menu"
+              title="Close menu"
+            >
+              ✕ Close
+            </button>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       {/* Camera zoom — under the top-right menu, clear of the bottom controls */}
-      <div className="absolute right-4 top-16 flex flex-col gap-2">
+      <div className="absolute right-4 top-32 flex flex-col gap-2">
         <button
           onClick={() => nudgeZoom(-CAM_ZOOM_STEP)}
           className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-sm font-bold text-slate-700 shadow-lg backdrop-blur transition hover:bg-white active:scale-90"


### PR DESCRIPTION
Two batches:

## Help when stuck (parent request)
- 18s without progress → the friend speaks the exact answer + a gold beacon lights the target
- 36s more → **🤝 Help me** button: the friend does it together with the child, no penalty, full stars
- Root-cause fix for the 'invisible book' + crowded Forest orbs: pick-up circles overlapped and ties resolved by list order — now nearest-wins with widened spacing (audited per island)
- Next-item ⬇️ arrow on carry/sort rounds; simpler HUD (4 big buttons + labeled More menu)
- Skill islands now celebrate growth every level ('🌳 Friendship Forest grew!' + sparkles) — also fixed decor that literally never grew on several islands

## Every domain grows new land (parent request)
Finish all 5 levels of a skill island → its **advanced sister island** rises, bridged from it:
- 🌷 Feelings Garden — mixed feelings, faces vs feelings, helping a sad friend, feelings pass
- 🌲 Deep Forest — joining play, when a friend says no, losing gracefully, disagreeing politely, compliments
- 🪷 Quiet Lagoon — body signals, breathing ladder, loud-place plans, waiting calmly, flexible thinking
- ⛵ Treasure Bay — borrow & return, trading, building together, only-one-toy, celebrating a friend's win

20 levels / 62 rounds of new content; growth retuned for 12 islands (180⭐); Day Book grows to 60 stickers; +8 outfit unlocks. Old saves migrate tolerantly.

Verified: tsc + full build clean; island/bridge geometry checked numerically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)