### PR TITLE
Nilu's World: island forms after every island's first task + tap-to-walk

### DIFF
--- a/components/game/BelusWorld/belu/progress.ts
+++ b/components/game/BelusWorld/belu/progress.ts
@@ -26,8 +26,9 @@ export const ZONES: ActivityZone[] = [
 export const DAY_ARC: ActivityZone[] = ['mountain', 'school', 'afternoon', 'night'];
 
 /** Advanced sister islands (see three/quest/advancedQuests.ts): each FORMS once
- *  its PARENT skill island reaches 5/5 completed levels. Plain gating — no
- *  dayArc/fresh choice involved, unlike the Nilu's Day arc above. */
+ *  its PARENT skill island completes its CURRENT task (>= 1 completed level) —
+ *  the same "form immediately after one success" rule as the Nilu's Day arc
+ *  above (dayStageComplete). Plain gating — no dayArc/fresh choice involved. */
 export const ADVANCED_PARENT: Record<'garden' | 'deepforest' | 'lagoon' | 'bay', ActivityZone> = {
   garden: 'meadow',
   deepforest: 'forest',
@@ -449,11 +450,15 @@ export function markDayCelebrated(p: GameProgress, zone: ActivityZone): GameProg
 // Plain gating: no dayArc/fresh choice involved. Each simply forms once its
 // PARENT skill island reaches 5/5 completed levels.
 
-/** Has this advanced sister island formed yet? */
+/** Has this advanced sister island formed yet? Forms the moment its PARENT
+ *  island's current task is completed once (>= 1 completed level) — the
+ *  island rises immediately, bridged from its parent. Levels 2-5 on the
+ *  parent stay available as richer replays; they don't gate the sister
+ *  island any further. */
 export function isAdvancedZoneUnlocked(p: GameProgress, zone: ActivityZone): boolean {
   const parent = (ADVANCED_PARENT as Partial<Record<ActivityZone, ActivityZone>>)[zone];
   if (!parent) return true; // not an advanced zone — always considered unlocked
-  return completedLevels(p, parent) >= MAX_LEVEL;
+  return completedLevels(p, parent) >= 1;
 }
 
 // ---- totals ----

--- a/components/game/BelusWorld/three/GameCanvas.tsx
+++ b/components/game/BelusWorld/three/GameCanvas.tsx
@@ -15,6 +15,7 @@ import { EffectComposer, Bloom } from '@react-three/postprocessing';
 import * as THREE from 'three';
 import Player, { type PlayerHandle } from './Player';
 import World, { type DayUnlocks, type AdvancedUnlocks } from './World';
+import WalkTargetMarker from './WalkTargetMarker';
 import HomeLife from './HomeLife';
 import RainbowPlay from './RainbowPlay';
 import type { AnimalSpecies } from './quest/Animal3D';
@@ -154,6 +155,11 @@ export default function GameCanvas({
       shadows
       // mouse-wheel zoom over the world (same channel as the 🔍 HUD buttons)
       onWheel={(e) => nudgeZoom(e.deltaY > 0 ? CAM_ZOOM_STEP : -CAM_ZOOM_STEP)}
+      // a tap that hits nothing walkable (open sky/water between islands) —
+      // island tops + bridge planks + interactive things all handle their own
+      // taps and stopPropagation, so this only fires for genuine misses; a
+      // silent no-op is the calm, no-fail choice here (never a buzzer)
+      onPointerMissed={() => {}}
       dpr={dpr}
       gl={{
         antialias: false, // the composer + dpr handle edges; saves fill-rate
@@ -195,6 +201,9 @@ export default function GameCanvas({
 
       <Suspense fallback={null}>
         <World activeZone={activeZone} reduceMotion={reduceMotion} islandLevels={islandLevels} rainbowUnlocked={rainbowUnlocked} dayUnlocks={dayUnlocks} advancedUnlocks={advancedUnlocks} />
+        {/* tap-to-walk: a small fading accent ring wherever Nilu is currently
+            headed (ground tap, or a tapped orb/item/pad/NPC/sign) */}
+        <WalkTargetMarker reduceMotion={reduceMotion} />
         <Player
           ref={player}
           emotion={emotion}

--- a/components/game/BelusWorld/three/Player.tsx
+++ b/components/game/BelusWorld/three/Player.tsx
@@ -94,7 +94,26 @@ const Player = forwardRef<PlayerHandle, Props>(function Player(
     // ---- horizontal movement (world-relative, camera is fixed-angle) ----
     const ix = input.moveX;
     const iz = input.moveZ;
-    const target = new THREE.Vector3(ix, 0, iz);
+    let mx = ix;
+    let mz = iz;
+    if (ix !== 0 || iz !== 0) {
+      // manual joystick/keyboard input always overrides — and cancels — any
+      // queued tap-to-walk target so it never fights the child's own steering
+      if (input.walkTarget) input.walkTarget = null;
+    } else if (input.walkTarget) {
+      // point-and-tap movement: walk straight toward the queued target,
+      // reusing the same speed/turn logic as manual steering
+      const dx = input.walkTarget.x - pos.current.x;
+      const dz = input.walkTarget.z - pos.current.z;
+      const d = Math.hypot(dx, dz);
+      if (d < 0.6) {
+        input.walkTarget = null; // arrived
+      } else {
+        mx = dx / d;
+        mz = dz / d;
+      }
+    }
+    const target = new THREE.Vector3(mx, 0, mz);
     if (target.lengthSq() > 1) target.normalize();
     vel.current.x = target.x * SPEED;
     vel.current.z = target.z * SPEED;

--- a/components/game/BelusWorld/three/WalkTargetMarker.tsx
+++ b/components/game/BelusWorld/three/WalkTargetMarker.tsx
@@ -1,0 +1,54 @@
+// ---------------------------------------------------------------------------
+// Tap-to-walk ground marker. A small accent ring that appears wherever the
+// child last tapped (ground, an orb, an item, a pad, an NPC, a start sign) so
+// it's always visible where Nilu is heading — the same trust-building cue as
+// the answer-orb "tap me" ring. Gently pulses; static (no pulse) when
+// reduceMotion is on. Reads the shared `input.walkTarget` channel directly
+// (module-level, like HelpBeacon reads quest state) so it needs no props from
+// the reward/pause React tree.
+// ---------------------------------------------------------------------------
+
+import { useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { input } from './input';
+import { sampleGround } from './worldMath';
+
+export default function WalkTargetMarker({ reduceMotion }: { reduceMotion: boolean }) {
+  const grp = useRef<THREE.Group>(null);
+  const ring = useRef<THREE.Mesh>(null);
+  const t = useRef(0);
+
+  useFrame((_, dt) => {
+    t.current += dt;
+    const g = grp.current;
+    const r = ring.current;
+    if (!g || !r) return;
+    const target = input.walkTarget;
+    if (!target) {
+      if (g.visible) g.visible = false;
+      return;
+    }
+    g.visible = true;
+    const gy = sampleGround(target.x, target.z).y;
+    g.position.set(target.x, gy + 0.06, target.z);
+    const mat = r.material as THREE.MeshBasicMaterial;
+    if (reduceMotion) {
+      r.scale.setScalar(1);
+      mat.opacity = 0.55;
+    } else {
+      const pulse = (Math.sin(t.current * 4) + 1) / 2; // 0..1
+      r.scale.setScalar(1 + pulse * 0.2);
+      mat.opacity = 0.75 - pulse * 0.4;
+    }
+  });
+
+  return (
+    <group ref={grp} visible={false}>
+      <mesh ref={ring} rotation={[-Math.PI / 2, 0, 0]}>
+        <ringGeometry args={[0.5, 0.72, 32]} />
+        <meshBasicMaterial color="#ffe066" transparent opacity={0.6} side={THREE.DoubleSide} depthWrite={false} />
+      </mesh>
+    </group>
+  );
+}

--- a/components/game/BelusWorld/three/World.tsx
+++ b/components/game/BelusWorld/three/World.tsx
@@ -13,6 +13,7 @@ import { useFrame } from '@react-three/fiber';
 import { Tree, Flower, Waterfall, Clouds, makeRng } from './Scenery';
 import WorldLife from './WorldLife';
 import { makeInfinityTexture } from './quest/emojiTexture';
+import { queueWalkTo } from './input';
 
 function Island({ isl }: { isl: IslandDef }) {
   return (
@@ -22,8 +23,19 @@ function Island({ isl }: { isl: IslandDef }) {
         <cylinderGeometry args={[isl.radius, isl.radius * 0.94, 1.4, 48]} />
         <meshStandardMaterial color={isl.grass} roughness={0.85} />
       </mesh>
-      {/* soft grassy rim cap so the edge reads round */}
-      <mesh position={[0, isl.top - 0.1, 0]}>
+      {/* soft grassy rim cap so the edge reads round — this is the surface the
+          camera actually sees from above, so it's also the tap-to-walk target:
+          a tap anywhere on an island walks Nilu straight there (e.point is the
+          real world-space hit, already guaranteed on walkable ground) */}
+      <mesh
+        position={[0, isl.top - 0.1, 0]}
+        onPointerDown={(e) => {
+          e.stopPropagation();
+          queueWalkTo(e.point.x, e.point.z);
+        }}
+        onPointerOver={() => (document.body.style.cursor = 'pointer')}
+        onPointerOut={() => (document.body.style.cursor = 'auto')}
+      >
         <cylinderGeometry args={[isl.radius * 0.99, isl.radius, 0.5, 48]} />
         <meshStandardMaterial color={isl.grass} roughness={0.85} />
       </mesh>
@@ -70,7 +82,18 @@ function RainbowBridges({ hiddenKey, isHidden }: { hiddenKey: string; isHidden: 
   return (
     <group>
       {planks.map((p, i) => (
-        <mesh key={i} position={p.pos} rotation={[0, p.rot, 0]} receiveShadow>
+        <mesh
+          key={i}
+          position={p.pos}
+          rotation={[0, p.rot, 0]}
+          receiveShadow
+          onPointerDown={(e) => {
+            e.stopPropagation();
+            queueWalkTo(e.point.x, e.point.z);
+          }}
+          onPointerOver={() => (document.body.style.cursor = 'pointer')}
+          onPointerOut={() => (document.body.style.cursor = 'auto')}
+        >
           <boxGeometry args={[p.w, 0.28, 1.3]} />
           <meshStandardMaterial
             color={p.color}

--- a/components/game/BelusWorld/three/input.ts
+++ b/components/game/BelusWorld/three/input.ts
@@ -15,6 +15,11 @@ export interface InputState {
   interactQueued: boolean;
   /** edge-triggered "warp back to home island" request */
   goHomeQueued: boolean;
+  /** point-and-tap movement target (world XZ), or null when none is queued /
+   *  active. The Player controller walks Nilu toward it every frame it's set
+   *  AND no manual joystick/keyboard input is active (manual input always
+   *  wins and cancels it); it's cleared on arrival too. */
+  walkTarget: { x: number; z: number } | null;
 }
 
 export const input: InputState = {
@@ -23,10 +28,18 @@ export const input: InputState = {
   jumpQueued: false,
   interactQueued: false,
   goHomeQueued: false,
+  walkTarget: null,
 };
 
 export function queueGoHome() {
   input.goHomeQueued = true;
+}
+
+/** Tap-to-walk: queue a world XZ point for Nilu to walk toward (a tap on the
+ *  ground, or on an orb/item/pad/NPC/sign — see the callers). Overwrites any
+ *  previous target. Cleared automatically by manual input or on arrival. */
+export function queueWalkTo(x: number, z: number) {
+  input.walkTarget = { x, z };
 }
 
 const keys = new Set<string>();

--- a/components/game/BelusWorld/three/quest/AnswerOrb.tsx
+++ b/components/game/BelusWorld/three/quest/AnswerOrb.tsx
@@ -10,6 +10,7 @@ import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { makeLabelTexture } from './emojiTexture';
 import { beluPos } from '../playerState';
+import { queueWalkTo } from '../input';
 
 const NEAR_DIST = 2.4; // matches QuestLayer PICK_RADIUS
 
@@ -23,7 +24,6 @@ interface Props {
   status: OrbStatus;
   /** a phase offset so a row of orbs doesn't bob in lockstep */
   bobSeed?: number;
-  onPick: () => void;
 }
 
 // Detect prefers-reduced-motion locally so the ring/pulse can respect it
@@ -33,7 +33,7 @@ const prefersReducedMotion =
     ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
     : false;
 
-export default function AnswerOrb({ position, emoji, caption, color, status, bobSeed = 0, onPick }: Props) {
+export default function AnswerOrb({ position, emoji, caption, color, status, bobSeed = 0 }: Props) {
   const grp = useRef<THREE.Group>(null);
   const sphere = useRef<THREE.Mesh>(null);
   const ring = useRef<THREE.Mesh>(null);
@@ -113,12 +113,16 @@ export default function AnswerOrb({ position, emoji, caption, color, status, bob
           depthWrite
         />
       </mesh>
-      {/* invisible, larger hit-target so an imprecise tap still lands */}
+      {/* invisible, larger hit-target so an imprecise tap still lands — a tap
+          walks Nilu straight to the orb (select-and-go); the actual pick only
+          fires once she arrives via the normal walk-in proximity check in
+          QuestLayer, so tapping from across the island can never pick from
+          range. */}
       <mesh
         visible={false}
         onPointerDown={(e) => {
           e.stopPropagation();
-          onPick();
+          queueWalkTo(position[0], position[2]);
         }}
         onPointerOver={() => (document.body.style.cursor = 'pointer')}
         onPointerOut={() => (document.body.style.cursor = 'auto')}

--- a/components/game/BelusWorld/three/quest/CarryItem.tsx
+++ b/components/game/BelusWorld/three/quest/CarryItem.tsx
@@ -11,6 +11,7 @@ import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { makeLabelTexture } from './emojiTexture';
 import { beluPos } from '../playerState';
+import { queueWalkTo } from '../input';
 
 interface Props {
   pedestalPosition: [number, number, number];
@@ -59,7 +60,16 @@ export default function CarryItem({
 
   return (
     <group ref={grp} position={pedestalPosition}>
-      <mesh>
+      <mesh
+        onPointerDown={(e) => {
+          e.stopPropagation();
+          // a tap walks Nilu to the pedestal precisely — the pick-up itself
+          // still only happens via the normal walk-in proximity check
+          queueWalkTo(pedestalPosition[0], pedestalPosition[2]);
+        }}
+        onPointerOver={() => (document.body.style.cursor = 'pointer')}
+        onPointerOut={() => (document.body.style.cursor = 'auto')}
+      >
         <sphereGeometry args={[0.42, 20, 16]} />
         <meshStandardMaterial
           color={color}

--- a/components/game/BelusWorld/three/quest/CarrySlot.tsx
+++ b/components/game/BelusWorld/three/quest/CarrySlot.tsx
@@ -12,6 +12,7 @@ import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { makeLabelTexture } from './emojiTexture';
+import { queueWalkTo } from '../input';
 
 export type SlotStatus = 'idle' | 'next' | 'filled' | 'wrong';
 
@@ -97,7 +98,17 @@ export default function CarrySlot({
 
   return (
     <group ref={grp} position={position}>
-      <mesh rotation={[-Math.PI / 2, 0, 0]}>
+      <mesh
+        rotation={[-Math.PI / 2, 0, 0]}
+        onPointerDown={(e) => {
+          e.stopPropagation();
+          // a tap walks Nilu to the pad/table precisely — the delivery itself
+          // still only happens via the normal walk-in proximity check
+          queueWalkTo(position[0], position[2]);
+        }}
+        onPointerOver={() => (document.body.style.cursor = 'pointer')}
+        onPointerOut={() => (document.body.style.cursor = 'auto')}
+      >
         <cylinderGeometry args={[isSign ? 0.85 : 0.62, isSign ? 0.95 : 0.7, 0.14, 24]} />
         <meshStandardMaterial
           color={glow}

--- a/components/game/BelusWorld/three/quest/CoveLayer.tsx
+++ b/components/game/BelusWorld/three/quest/CoveLayer.tsx
@@ -570,7 +570,6 @@ export default function CoveLayer(props: Props) {
               color={isl.accent}
               status={status}
               bobSeed={i * 0.7}
-              onPick={() => pickTotem(i)}
             />
           );
         })}
@@ -584,7 +583,6 @@ export default function CoveLayer(props: Props) {
           caption={`${senseStep.senseLabel} ${senseStep.targetLabel}`}
           color={isl.accent}
           status="idle"
-          onPick={pickSense}
         />
       )}
 
@@ -597,7 +595,6 @@ export default function CoveLayer(props: Props) {
           caption={lvl.pose.name}
           color={isl.accent}
           status={S.current.poseHolding ? 'chosen' : 'idle'}
-          onPick={beginPoseHold}
         />
       )}
 

--- a/components/game/BelusWorld/three/quest/ForestLayer.tsx
+++ b/components/game/BelusWorld/three/quest/ForestLayer.tsx
@@ -555,7 +555,6 @@ export default function ForestLayer(props: Props) {
                     color={isl.accent}
                     status={status}
                     bobSeed={k * 0.7}
-                    onPick={() => castWord(i, k)}
                   />
                 );
               })}

--- a/components/game/BelusWorld/three/quest/QuestLayer.tsx
+++ b/components/game/BelusWorld/three/quest/QuestLayer.tsx
@@ -1123,7 +1123,6 @@ export default function QuestLayer(props: Props) {
                       color={accent[S.current.zone!]}
                       status={orbStatus(i)}
                       bobSeed={i * 0.7}
-                      onPick={() => pick(i)}
                     />
                   ))}
                   {help && help.kind === 'orb' && (

--- a/components/game/BelusWorld/three/quest/QuestNPC.tsx
+++ b/components/game/BelusWorld/three/quest/QuestNPC.tsx
@@ -10,6 +10,7 @@ import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { makeLabelTexture } from './emojiTexture';
+import { queueWalkTo } from '../input';
 
 export type Mood =
   | 'neutral' | 'happy' | 'excited' | 'proud' | 'calm'
@@ -80,8 +81,18 @@ export default function QuestNPC({ position, face, mood, color, thought, beckon,
   return (
     <group position={position}>
       <group ref={body}>
-        {/* rounded body */}
-        <mesh castShadow position={[0, 0.55, 0]} scale={[0.95, slump ? 0.85 : 1, 0.95]}>
+        {/* rounded body — a tap walks Nilu straight up to this friend */}
+        <mesh
+          castShadow
+          position={[0, 0.55, 0]}
+          scale={[0.95, slump ? 0.85 : 1, 0.95]}
+          onPointerDown={(e) => {
+            e.stopPropagation();
+            queueWalkTo(position[0], position[2]);
+          }}
+          onPointerOver={() => (document.body.style.cursor = 'pointer')}
+          onPointerOut={() => (document.body.style.cursor = 'auto')}
+        >
           <sphereGeometry args={[0.7, 24, 18]} />
           <meshStandardMaterial color={color} roughness={0.6} />
         </mesh>

--- a/components/game/BelusWorld/three/quest/StartSign.tsx
+++ b/components/game/BelusWorld/three/quest/StartSign.tsx
@@ -12,6 +12,7 @@ import { useFrame } from '@react-three/fiber';
 import { Sparkles } from '@react-three/drei';
 import * as THREE from 'three';
 import { makeStartTexture } from './emojiTexture';
+import { queueWalkTo } from '../input';
 
 interface Props {
   /** where the sign board floats (above the host friend's head) */
@@ -72,8 +73,20 @@ export default function StartSign({ position, ground, color, reduceMotion }: Pro
         <Sparkles count={10} scale={2.2} size={4.5} speed={0.4} color={color} position={[ground[0], ground[1] + 1, ground[2]]} />
       )}
 
-      {/* pulsing accent ring on the ground — static (still visible) when reduceMotion */}
-      <mesh ref={ring} rotation={[-Math.PI / 2, 0, 0]} position={[ground[0], ground[1] + 0.06, ground[2]]}>
+      {/* pulsing accent ring on the ground — static (still visible) when
+          reduceMotion. Also the tap target: a tap walks Nilu straight to the
+          sign; walking in (as usual) is what actually begins the quest. */}
+      <mesh
+        ref={ring}
+        rotation={[-Math.PI / 2, 0, 0]}
+        position={[ground[0], ground[1] + 0.06, ground[2]]}
+        onPointerDown={(e) => {
+          e.stopPropagation();
+          queueWalkTo(ground[0], ground[2]);
+        }}
+        onPointerOver={() => (document.body.style.cursor = 'pointer')}
+        onPointerOut={() => (document.body.style.cursor = 'auto')}
+      >
         <ringGeometry args={[1.1, 1.55, 32]} />
         <meshBasicMaterial color={color} transparent opacity={0.38} side={THREE.DoubleSide} />
       </mesh>

--- a/components/game/BelusWorld/three/quest/StoryLayer.tsx
+++ b/components/game/BelusWorld/three/quest/StoryLayer.tsx
@@ -408,7 +408,6 @@ export default function StoryLayer(props: Props) {
                     color={isl.accent}
                     status={status}
                     bobSeed={oi * 0.7}
-                    onPick={() => pickHelp(oi)}
                   />
                 );
               })}


### PR DESCRIPTION
- **Uniform formation rule**: any island with a successor forms it after ONE completed task — Feelings Meadow → Feelings Garden now rises immediately (was gated on all 5 levels; day arc and skill domains now behave identically)
- **Tap-to-walk**: tap anything — ground, bridge, an answer orb, a carry item — and Nilu walks there herself with a target ring; joystick still overrides. Precision steering is never required for selection anymore.
- Fixed a real pre-existing bug found along the way: tapping an orb triggered the pick from any distance, bypassing the walk-in mechanic.

Verified: tsc + full build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)