### PR TITLE
COPPA hardening: no tracking on game pages + children's-games privacy disclosure

### DIFF
--- a/pages/PrivacyPolicy.tsx
+++ b/pages/PrivacyPolicy.tsx
@@ -28,7 +28,7 @@ const PrivacyPolicy: React.FC = () => {
                     <p className="text-xl font-medium text-sky-600 dark:text-sky-400">
                         Aaria's Blue Elephant is committed to transparency, inclusion, and the safeguarding of our community. The following documents detail our privacy, terms of use, donation policies, and security commitments.
                     </p>
-                    <p className="text-sm text-slate-500 mb-12">Last updated: February 28, 2025</p>
+                    <p className="text-sm text-slate-500 mb-12">Last updated: July 10, 2026</p>
 
                     {/* Table of Contents */}
                     <div className="bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl p-6 mb-12">
@@ -139,6 +139,23 @@ const PrivacyPolicy: React.FC = () => {
                         <h3 className="text-xl font-semibold text-slate-800 dark:text-slate-200 mt-6">Children's Participation</h3>
                         <p>
                             While our mission is to serve neurodivergent and neurotypical children at community events, all <strong>data collection through our digital platform is the responsibility of the attending adult</strong> (parent or legal guardian). We do not collect personal data directly from children. Parents who share any information about their children in testimonials or event registrations do so on behalf of their child as legal guardians.
+                        </p>
+
+                        <h3 className="text-xl font-semibold text-slate-800 dark:text-slate-200 mt-6">Our Free Games for Children</h3>
+                        <p>
+                            Our website hosts free browser games designed for children (including Nilu's World, Block Craft 3D, Elly-Tubbies, Dough Lab, Magnet Blocks, Road Safety Heroes, and Nilu's Helping Hands). These games were deliberately built to <strong>collect no personal information from children</strong>:
+                        </p>
+                        <ul>
+                            <li><strong>No accounts, no sign-in.</strong> The games never ask a child to register, and playing them requires no personal information.</li>
+                            <li><strong>Everything stays on your device.</strong> Game progress, settings, creations, and in-game photos are saved only in your browser's local storage on your own device. None of it is transmitted to us or to any third party, and we cannot see it.</li>
+                            <li><strong>Names are optional and local.</strong> Some games let a child enter a first name or nickname so the game can greet them. That name is stored only on your device and is never sent anywhere. A nickname works just as well as a real name.</li>
+                            <li><strong>No advertising and no analytics in the games.</strong> The game pages contain no ads, no ad networks, and no analytics or tracking scripts.</li>
+                            <li><strong>Sharing is a file you control.</strong> Some games can export a creation or replay as a small file so a child can share it with a friend. These files contain only game data (blocks, paths, dough shapes) — never a name or any personal information. Sharing happens entirely outside our systems, through whatever channel the parent chooses.</li>
+                            <li><strong>Voice features use your browser.</strong> Read-aloud narration uses your device's built-in speech. One game offers an optional voice-answer mode that uses your browser's speech-recognition service; depending on your browser, audio may be processed by your browser's vendor (for example, Google for Chrome) to convert speech to text. We never receive or store any audio. This mode is off by default and can be disabled in the game's settings.</li>
+                            <li><strong>Printables stay with you.</strong> Certificates or photos a child can download are generated on your device and are not uploaded to us.</li>
+                        </ul>
+                        <p>
+                            <strong>Parents:</strong> you can erase all game data at any time by clearing your browser's site data for this website, or by using the "start over" / reset options inside each game. Several games also include a parent- or guardian-only summary panel (gated behind a simple adult question) showing what your child practiced — that summary is generated from the on-device data and is likewise never transmitted to us.
                         </p>
 
                         <h3 className="text-xl font-semibold text-slate-800 dark:text-slate-200 mt-6">Parental Consent</h3>

--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -1,20 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <!-- Google Tag Manager -->
-    <script>
-      ;(function (w, d, s, l, i) {
-        w[l] = w[l] || []
-        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer' ? '&l=' + l : ''
-        j.async = true
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
-        f.parentNode.insertBefore(j, f)
-      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
-    </script>
-    <!-- End Google Tag Manager -->
+    <!-- No analytics or tracking on this page: it is made for children. -->
 <meta charset="UTF-8">
 <title>Aaria's Block Craft 3D 🌈</title>
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
@@ -419,7 +406,6 @@
 </style>
 </head>
 <body>
-    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
 <script>
 (function(){
 try{localStorage.setItem('abe_last_game',JSON.stringify({url:'/blockcraft/index.html',name:'Block Craft 3D',emoji:'🧱',at:Date.now()}))}catch(e){}

--- a/public/craft3d/index.html
+++ b/public/craft3d/index.html
@@ -1,20 +1,6 @@
 <!DOCTYPE html><html><head>
-    <!-- Google Tag Manager -->
-    <script>
-      ;(function (w, d, s, l, i) {
-        w[l] = w[l] || []
-        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer' ? '&l=' + l : ''
-        j.async = true
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
-        f.parentNode.insertBefore(j, f)
-      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
-    </script>
-    <!-- End Google Tag Manager --><meta charset="UTF-8">
+    <!-- No analytics or tracking on this page: it is made for children. --><meta charset="UTF-8">
 <title>Aaria's Block Craft 3D</title>
 <meta http-equiv="refresh" content="0; url=/blockcraft/index.html">
 <link rel="canonical" href="https://aariasblueelephant.org/blockcraft/index.html">
-</head><body>
-    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) --><p>Taking you to <a href="/blockcraft/index.html">Aaria's Block Craft 3D</a>… 🐘💙</p></body></html>
+</head><body><p>Taking you to <a href="/blockcraft/index.html">Aaria's Block Craft 3D</a>… 🐘💙</p></body></html>

--- a/public/doughlab/index.html
+++ b/public/doughlab/index.html
@@ -1,20 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <!-- Google Tag Manager -->
-    <script>
-      ;(function (w, d, s, l, i) {
-        w[l] = w[l] || []
-        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer' ? '&l=' + l : ''
-        j.async = true
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
-        f.parentNode.insertBefore(j, f)
-      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
-    </script>
-    <!-- End Google Tag Manager -->
+    <!-- No analytics or tracking on this page: it is made for children. -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <title>Dough Lab 3D — playdough & slime simulator</title>
@@ -217,7 +204,6 @@
 </style>
 </head>
 <body>
-    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
 <script>
 (function(){
 try{localStorage.setItem('abe_last_game',JSON.stringify({url:'/doughlab/index.html',name:'Dough Lab',emoji:'🌈',at:Date.now()}))}catch(e){}
@@ -265,20 +251,6 @@ try{
 </div>
 
 <header>
-    <!-- Google Tag Manager -->
-    <script>
-      ;(function (w, d, s, l, i) {
-        w[l] = w[l] || []
-        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer' ? '&l=' + l : ''
-        j.async = true
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
-        f.parentNode.insertBefore(j, f)
-      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
-    </script>
-    <!-- End Google Tag Manager -->
   <h1>🧁 Dough Lab<small>squish it · slice it · sculpt it — in real 3D 🌈</small></h1>
   <div class="seg" id="modeSeg">
     <button data-mode="dough" class="on">🫓 Playdough</button>

--- a/public/elly-tubbies/index.html
+++ b/public/elly-tubbies/index.html
@@ -1,20 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <!-- Google Tag Manager -->
-    <script>
-      ;(function (w, d, s, l, i) {
-        w[l] = w[l] || []
-        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer' ? '&l=' + l : ''
-        j.async = true
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
-        f.parentNode.insertBefore(j, f)
-      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
-    </script>
-    <!-- End Google Tag Manager -->
+    <!-- No analytics or tracking on this page: it is made for children. -->
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
 <title>Elly-Tubbies 🐘 — Aaria's Blue Elephant</title>
@@ -269,7 +256,6 @@
 </style>
 </head>
 <body>
-    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
 <script>
 (function(){
 try{localStorage.setItem('abe_last_game',JSON.stringify({url:'/elly-tubbies/index.html',name:'Elly-Tubbies',emoji:'🐘',at:Date.now()}))}catch(e){}

--- a/public/helpinghands/index.html
+++ b/public/helpinghands/index.html
@@ -1,20 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <!-- Google Tag Manager -->
-    <script>
-      ;(function (w, d, s, l, i) {
-        w[l] = w[l] || []
-        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer' ? '&l=' + l : ''
-        j.async = true
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
-        f.parentNode.insertBefore(j, f)
-      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
-    </script>
-    <!-- End Google Tag Manager -->
+    <!-- No analytics or tracking on this page: it is made for children. -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <title>Nilu's Helping Hands</title>
@@ -595,7 +582,6 @@
 </style>
 </head>
 <body>
-    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
 <script>
 (function(){
 try{localStorage.setItem('abe_last_game',JSON.stringify({url:'/helpinghands/index.html',name:'Nilu\'s Helping Hands',emoji:'🖐️',at:Date.now()}))}catch(e){}
@@ -662,20 +648,6 @@ try{
 <!-- 3. HOME MENU -->
 <div id="menuScreen" class="screen" hidden>
   <header class="chrome-header">
-    <!-- Google Tag Manager -->
-    <script>
-      ;(function (w, d, s, l, i) {
-        w[l] = w[l] || []
-        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer' ? '&l=' + l : ''
-        j.async = true
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
-        f.parentNode.insertBefore(j, f)
-      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
-    </script>
-    <!-- End Google Tag Manager -->
     <div class="sticker-counter">🌟 <span class="stickerCount">0</span></div>
     <button class="mute-btn" title="Mute sounds">🔊</button>
   </header>
@@ -726,20 +698,6 @@ try{
 <!-- 5. MY HELPING HAND -->
 <div id="handScreen" class="screen" hidden>
   <header class="chrome-header">
-    <!-- Google Tag Manager -->
-    <script>
-      ;(function (w, d, s, l, i) {
-        w[l] = w[l] || []
-        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer' ? '&l=' + l : ''
-        j.async = true
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
-        f.parentNode.insertBefore(j, f)
-      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
-    </script>
-    <!-- End Google Tag Manager -->
     <button class="btn-back" data-target="menu">◀ Menu</button>
     <div style="display:flex;align-items:center;gap:8px;">
       <div class="sticker-counter">🌟 <span class="stickerCount">0</span></div>
@@ -752,20 +710,6 @@ try{
 <!-- 6. PRACTICE BEING BRAVE -->
 <div id="practiceScreen" class="screen" hidden>
   <header class="chrome-header">
-    <!-- Google Tag Manager -->
-    <script>
-      ;(function (w, d, s, l, i) {
-        w[l] = w[l] || []
-        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer' ? '&l=' + l : ''
-        j.async = true
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
-        f.parentNode.insertBefore(j, f)
-      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
-    </script>
-    <!-- End Google Tag Manager -->
     <button class="btn-back" data-target="menu">◀ Menu</button>
     <div style="display:flex;align-items:center;gap:8px;">
       <div class="sticker-counter">🌟 <span class="stickerCount">0</span></div>
@@ -790,20 +734,6 @@ try{
 <!-- 7. GROWN-UPS CORNER -->
 <div id="grownupsScreen" class="screen" hidden>
   <header class="chrome-header">
-    <!-- Google Tag Manager -->
-    <script>
-      ;(function (w, d, s, l, i) {
-        w[l] = w[l] || []
-        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer' ? '&l=' + l : ''
-        j.async = true
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
-        f.parentNode.insertBefore(j, f)
-      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
-    </script>
-    <!-- End Google Tag Manager -->
     <button class="btn-back" id="guBackBtn">◀ Back</button>
   </header>
   <div id="guGateWrap" class="gu-gate-wrap">

--- a/public/magnetblocks/index.html
+++ b/public/magnetblocks/index.html
@@ -1,20 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <!-- Google Tag Manager -->
-    <script>
-      ;(function (w, d, s, l, i) {
-        w[l] = w[l] || []
-        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer' ? '&l=' + l : ''
-        j.async = true
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
-        f.parentNode.insertBefore(j, f)
-      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
-    </script>
-    <!-- End Google Tag Manager -->
+    <!-- No analytics or tracking on this page: it is made for children. -->
 <meta charset="UTF-8">
 <title>Aaria's Magnet Blocks 🧲🧱</title>
 <link rel="icon" href="../favicon.png">
@@ -194,7 +181,6 @@
 </style>
 </head>
 <body>
-    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
 <script>
 (function(){
 try{localStorage.setItem('abe_last_game',JSON.stringify({url:'/magnetblocks/index.html',name:'Magnet Blocks',emoji:'🧲',at:Date.now()}))}catch(e){}

--- a/public/roadsafety/index.html
+++ b/public/roadsafety/index.html
@@ -1,27 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <!-- Google Tag Manager -->
-    <script>
-      ;(function (w, d, s, l, i) {
-        w[l] = w[l] || []
-        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer' ? '&l=' + l : ''
-        j.async = true
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
-        f.parentNode.insertBefore(j, f)
-      })(window, document, 'script', 'dataLayer', 'GTM-WD789BVB')
-    </script>
-    <!-- End Google Tag Manager -->
+    <!-- No analytics or tracking on this page: it is made for children. -->
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 <title>Mountain House Road Safety Heroes — Aaria's Blue Elephant</title>
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <!-- Google Tag Manager (noscript) --><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WD789BVB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->
 <script>
 (function(){
 try{localStorage.setItem('abe_last_game',JSON.stringify({url:'/roadsafety/index.html',name:'Road Safety Heroes',emoji:'🚴',at:Date.now()}))}catch(e){}


### PR DESCRIPTION
Response to compliance feedback about marketing games to children:

- **Removed Google Tag Manager from all 7 game pages.** The games are child-directed content; third-party tracking containers there collect persistent identifiers from children, which is the core COPPA exposure. The adult-facing site pages keep analytics. (Two pages had duplicate GTM blocks — all removed.)
- **Privacy policy: new 'Our Free Games for Children' section** documenting what was already true by design: no accounts, everything stored on-device only (progress/names/photos never transmitted), no ads or analytics in the games, share-files contain zero personal data, browser speech-recognition disclosure (optional voice mode, off by default), and how parents can erase all game data.
- Policy last-updated date refreshed.

Note for the org: this implements the technical and disclosure basics — it is not legal advice, and the policy should still get a review from counsel familiar with COPPA (e.g., confirming the local-storage-only design keeps the games outside 'collection', and any state-law requirements).

🤖 Generated with [Claude Code](https://claude.com/claude-code)