### PR TITLE
Forever platform: passport, profiles, offline, music, public /games, daily hooks

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -98,6 +98,7 @@ const Interventions = lazy(() => import('./pages/Interventions'));
 const Screening = lazy(() => import('./pages/Screening'));
 const CircleOfFriends = lazy(() => import('./pages/CircleOfFriends'));
 const BelusWorld = lazy(() => import('./pages/BelusWorld'));
+const Games = lazy(() => import('./pages/Games'));
 
 // Loading fallback
 const PageLoader = () => (
@@ -149,6 +150,7 @@ const App: React.FC = () => {
                 <Route path="/resources/interventions" element={<Interventions />} />
                 <Route path="/resources/screening" element={<Screening />} />
                 <Route path="/circle-of-friends" element={<CircleOfFriends />} />
+                <Route path="/games" element={<Games />} />
                 <Route path="/nelus-world" element={<BelusWorld />} />
                 {/* aliases: old link + likely spelling both land on the game */}
                 <Route path="/belus-world" element={<Navigate to="/nelus-world" replace />} />

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { Menu, X, ExternalLink, Phone, Mail, Sun, Moon, HeartPulse, UserCircle, LogOut, LayoutDashboard, Stars, Mountain, Home, Heart, Users, HandHelping, BookOpen, ChevronRight } from 'lucide-react';
+import { Menu, X, ExternalLink, Phone, Mail, Sun, Moon, HeartPulse, UserCircle, LogOut, LayoutDashboard, Stars, Mountain, Home, Heart, Users, HandHelping, BookOpen, ChevronRight, Gamepad2 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import StickerIcon from './StickerIcon';
 import Button from './Button';
@@ -86,6 +86,7 @@ const Navbar: React.FC = () => {
     { name: 'Events', path: '/events', icon: Stars, color: '#8b5cf6' },
     { name: 'Get Involved', path: '/volunteer', icon: HandHelping, color: '#10b981' },
     { name: 'Resources', path: '/resources', icon: BookOpen, color: '#00AEEF' },
+    { name: 'Games', path: '/games', icon: Gamepad2, color: '#ec4899' },
   ];
 
   const isActive = (path: string) => location.pathname === path;

--- a/components/game/BelusWorld/index.tsx
+++ b/components/game/BelusWorld/index.tsx
@@ -360,6 +360,30 @@ export default function BelusWorldGame() {
     } catch { /* ignore */ }
   }, []);
 
+  // stamp one passport day for Nilu's World — mirrors public/gamekit/passport.js
+  // inline (this is a React game, not a plain <script> include), so kit games
+  // and legacy games share the same on-device passport shelf. No identifiers,
+  // nothing transmitted.
+  useEffect(() => {
+    try {
+      const slug = 'nilus-world';
+      if (sessionStorage.getItem('abe_stamp_' + slug)) return;
+      sessionStorage.setItem('abe_stamp_' + slug, '1');
+      const prof = localStorage.getItem('abe.profile.current') || 'p1';
+      const key = prof === 'p1' ? 'abe.passport.v1' : `abe.passport.${prof}.v1`;
+      let p: Record<string, { days: number; last: string }> = {};
+      try { p = JSON.parse(localStorage.getItem(key) || '{}') || {}; } catch { /* ignore */ }
+      const today = new Date().toISOString().slice(0, 10);
+      const entry = p[slug] || { days: 0, last: '' };
+      if (entry.last !== today) {
+        entry.days++;
+        entry.last = today;
+        p[slug] = entry;
+        localStorage.setItem(key, JSON.stringify(p));
+      }
+    } catch { /* ignore */ }
+  }, []);
+
   const cycleSpeed = useCallback(() => {
     setSettings((s) => {
       const next = SPEED_ORDER[(SPEED_ORDER.indexOf(s.speed) + 1) % SPEED_ORDER.length];

--- a/data/games.ts
+++ b/data/games.ts
@@ -1,0 +1,14 @@
+export type GameCard = { id: string; title: string; emoji: string; oneLiner: string; img: string; view?: string; path?: string };
+
+export const GAME_CARDS: GameCard[] = [
+    { id: 'belus-world', title: "Nilu's World", emoji: '🐘', oneLiner: 'Explore islands, meet friends & help Nilu grow!', img: '/images/games/belus-world.jpg', path: '/nelus-world' },
+    { id: 'magnetblocks', title: "Aaria's Magnet Blocks", emoji: '🧲', oneLiner: 'Magnetic blocks that click, stack & drive!', img: '/images/games/magnetblocks.jpg', view: 'magnetblocks' },
+    { id: 'helpinghands', title: "Nilu's Helping Hands", emoji: '🖐️', oneLiner: 'Learn your world & how to get help — walk, explore, be brave!', img: '/images/games/helpinghands.jpg', view: 'helpinghands' },
+    { id: 'doughlab', title: 'Dough Lab 3D', emoji: '🫓', oneLiner: 'Squish, slice & sculpt real 3D dough!', img: '/images/games/doughlab.jpg', view: 'doughlab' },
+    { id: 'blockcraft', title: "Aaria's Block Craft 3D", emoji: '🧱', oneLiner: 'Building, animal friends, slime & cookies!', img: '/images/games/blockcraft.jpg', view: 'blockcraft' },
+    { id: 'elly-tubbies', title: 'Elly-Tubbies', emoji: '☀️', oneLiner: 'Bouncy elephant friends in sunny Trunkland!', img: '/images/games/elly-tubbies.jpg', view: 'elly-tubbies' },
+    { id: 'roadsafety', title: 'Road Safety Heroes', emoji: '🚦', oneLiner: 'Ride & drive the REAL streets of Mountain House!', img: '/images/games/roadsafety.jpg', view: 'roadsafety' },
+    { id: 'grocery', title: "Aaria's Grocery Store", emoji: '🛒', oneLiner: 'Bring your list, find the food, wait your turn, pay & bag!', img: '/images/games/grocery.jpg', path: '/8' },
+    { id: 'dayplanner', title: 'My Day Planner', emoji: '📅', oneLiner: 'Plan your day with picture cards, then live it with Nilu!', img: '/images/games/dayplanner.jpg', path: '/9' },
+    { id: 'wheel', title: 'Wheel of Fun', emoji: '🎡', oneLiner: 'Spin the rainbow wheel for surprises & giggles!', img: '/images/games/wheel.jpg', view: 'wheel' },
+];

--- a/pages/Dashboard.tsx
+++ b/pages/Dashboard.tsx
@@ -52,6 +52,7 @@ import Button from '../components/Button';
 import RichText, { extractMedia } from '../components/RichText';
 import WheelOfFun from '../components/WheelOfFun';
 import { MOCK_DONATIONS, DEFAULT_EVENT_IMAGE } from '../constants';
+import { GAME_CARDS } from '../data/games';
 import ResilientImage from '../components/ResilientImage';
 
 import { 
@@ -474,18 +475,7 @@ const Dashboard: React.FC = () => {
         return false;
     });
 
-    const GAMES: { id: string; title: string; emoji: string; oneLiner: string; img: string; view?: ViewState; path?: string }[] = [
-        { id: 'belus-world', title: "Nilu's World", emoji: '🐘', oneLiner: 'Explore islands, meet friends & help Nilu grow!', img: '/images/games/belus-world.jpg', path: '/nelus-world' },
-        { id: 'magnetblocks', title: "Aaria's Magnet Blocks", emoji: '🧲', oneLiner: 'Magnetic blocks that click, stack & drive!', img: '/images/games/magnetblocks.jpg', view: 'magnetblocks' },
-        { id: 'helpinghands', title: "Nilu's Helping Hands", emoji: '🖐️', oneLiner: 'Learn your world & how to get help — walk, explore, be brave!', img: '/images/games/helpinghands.jpg', view: 'helpinghands' },
-        { id: 'doughlab', title: 'Dough Lab 3D', emoji: '🫓', oneLiner: 'Squish, slice & sculpt real 3D dough!', img: '/images/games/doughlab.jpg', view: 'doughlab' },
-        { id: 'blockcraft', title: "Aaria's Block Craft 3D", emoji: '🧱', oneLiner: 'Building, animal friends, slime & cookies!', img: '/images/games/blockcraft.jpg', view: 'blockcraft' },
-        { id: 'elly-tubbies', title: 'Elly-Tubbies', emoji: '☀️', oneLiner: 'Bouncy elephant friends in sunny Trunkland!', img: '/images/games/elly-tubbies.jpg', view: 'elly-tubbies' },
-        { id: 'roadsafety', title: 'Road Safety Heroes', emoji: '🚦', oneLiner: 'Ride & drive the REAL streets of Mountain House!', img: '/images/games/roadsafety.jpg', view: 'roadsafety' },
-        { id: 'grocery', title: "Aaria's Grocery Store", emoji: '🛒', oneLiner: 'Bring your list, find the food, wait your turn, pay & bag!', img: '/images/games/grocery.jpg', path: '/8' },
-        { id: 'dayplanner', title: 'My Day Planner', emoji: '📅', oneLiner: 'Plan your day with picture cards, then live it with Nilu!', img: '/images/games/dayplanner.jpg', path: '/9' },
-        { id: 'wheel', title: 'Wheel of Fun', emoji: '🎡', oneLiner: 'Spin the rainbow wheel for surprises & giggles!', img: '/images/games/wheel.jpg', view: 'wheel' },
-    ];
+    const GAMES = GAME_CARDS as { id: string; title: string; emoji: string; oneLiner: string; img: string; view?: ViewState; path?: string }[];
 
     const renderSuccessView = (type: string) => (
         <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-2xl p-8 text-center animate-in zoom-in-95 duration-500">

--- a/pages/Games.tsx
+++ b/pages/Games.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { GAME_CARDS } from '../data/games';
+
+// Public games catalog — no account needed. Same cards the dashboard shows,
+// so new games registered in data/games.ts appear here automatically.
+const VIEW_ROUTES: Record<string, string> = {
+  'elly-tubbies': '/1',
+  blockcraft: '/2',
+  roadsafety: '/4',
+  doughlab: '/5',
+  magnetblocks: '/6',
+  helpinghands: '/7',
+  wheel: '/wheel',
+};
+
+const Games: React.FC = () => (
+  <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-16">
+    <div className="text-center pt-6 pb-8">
+      <h1 className="text-4xl sm:text-5xl font-extrabold text-slate-900 dark:text-white">
+        🎮 Our Games
+      </h1>
+      <p className="mt-3 text-slate-600 dark:text-slate-400 max-w-2xl mx-auto">
+        Free browser games built for Aaria and Her Friends 💖 — calm, kind, and safe.
+        No accounts, no ads, and nothing leaves your device. Collect a passport stamp in every one!
+      </p>
+    </div>
+    <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-5">
+      {GAME_CARDS.map((g) => {
+        const href = g.path ?? (g.view ? VIEW_ROUTES[g.view] : undefined);
+        if (!href) return null;
+        return (
+          <a
+            key={g.id}
+            href={href}
+            className="group rounded-2xl overflow-hidden border border-slate-200 dark:border-slate-800 bg-white dark:bg-brand-card shadow-lg hover:scale-[1.03] hover:shadow-2xl transition-all duration-300"
+          >
+            <img src={g.img} alt={g.title} className="w-full aspect-video object-cover" loading="lazy" />
+            <div className="p-4">
+              <h3 className="font-bold text-slate-900 dark:text-white">
+                {g.emoji} {g.title}
+              </h3>
+              <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">{g.oneLiner}</p>
+              <p className="text-xs font-bold text-brand-cyan mt-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                ▶️ Play now
+              </p>
+            </div>
+          </a>
+        );
+      })}
+    </div>
+    <p className="text-center text-xs text-slate-500 dark:text-slate-400 mt-10">
+      Grown-ups: our games collect no personal information — see our{' '}
+      <a href="/privacy-policy" className="underline">privacy policy</a> and{' '}
+      <a href="/legal/disclosure.html" className="underline">general disclosure</a>.
+    </p>
+  </div>
+);
+
+export default Games;

--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -607,5 +607,6 @@ try{
   }
 })();
 </script>
+<script src="/gamekit/passport.js" data-game="blockcraft" defer></script>
 </body>
 </html>

--- a/public/dayplanner/index.html
+++ b/public/dayplanner/index.html
@@ -439,7 +439,8 @@
     const r = ROUTINES[G.routine];
     K.say(`You did your whole ${r.name.toLowerCase()} plan, step by step! What a planner!`);
     const other = G.routine === "morning" ? "evening" : "morning";
-    panel(`<h2>🌟 Plan complete!</h2>
+    const streak = K.streakBump();
+    panel(`${streak.n > 1 ? `<div style="font-size:20px;font-weight:900">🔥 ${streak.n} days planned in a row!</div>` : ""}<h2>🌟 Plan complete!</h2>
       <p>You made the plan AND lived it — every step, in your order!</p>
       <div style="font-size:28px;margin:6px 0">${G.plan.map((id) => stepOf(id).emoji).join(" → ")}</div>
       <p style="font-size:14px">Days planned: <b>${G.days}</b></p>

--- a/public/doughlab/index.html
+++ b/public/doughlab/index.html
@@ -1888,5 +1888,6 @@ applyCamera();
 frame();
 })();
 </script>
+<script src="/gamekit/passport.js" data-game="doughlab" defer></script>
 </body>
 </html>

--- a/public/elly-tubbies/index.html
+++ b/public/elly-tubbies/index.html
@@ -3642,5 +3642,6 @@ renderSched();setupWants();spawnEggNode();renderNest();newQuest();
 // #loading hides only once girl.png has loaded AND the first frame has rendered (see tryHideLoading)
 requestAnimationFrame(frame);
 </script>
+<script src="/gamekit/passport.js" data-game="elly-tubbies" defer></script>
 </body>
 </html>

--- a/public/gamekit/kit.css
+++ b/public/gamekit/kit.css
@@ -97,6 +97,33 @@ body {
 .kBig.kAlt { background: linear-gradient(180deg, #93c5fd, #3b82f6); box-shadow: 0 6px 0 #1d4ed8; font-size: clamp(14px, 4vw, 17px); padding: 10px 22px; }
 .kCredit { font-size: 12px; opacity: .75; margin-top: 12px; }
 
+/* ---------- profile picker (siblings each get their own saves) ---------- */
+.kAvatars { display: flex; align-items: center; justify-content: center; gap: 8px; margin: 6px 0 10px; flex-wrap: wrap; }
+.kAvLbl { font-size: 14px; font-weight: 800; margin-right: 4px; }
+.kAvatar {
+  width: 50px; height: 50px; border-radius: 50%; border: 3px solid transparent; cursor: pointer;
+  font: inherit; font-size: 26px; background: rgba(255,255,255,.8);
+  box-shadow: 0 3px 8px rgba(40,40,90,.15); display: flex; align-items: center; justify-content: center;
+}
+.kAvatar:active { transform: scale(.9); }
+.kAvatar.on { border-color: var(--k-accent); background: #fff; transform: scale(1.12); }
+
+/* ---------- game passport shelf ---------- */
+.kPassSub { font-size: 14px; font-weight: 800; margin: 0 0 10px; }
+.kPassRow {
+  display: flex; align-items: center; gap: 10px; padding: 8px 10px; margin: 5px 0;
+  background: rgba(255,255,255,.7); border-radius: 12px; opacity: .62;
+}
+.kPassRow.got { opacity: 1; background: #fff; box-shadow: 0 2px 6px rgba(40,40,90,.12); }
+.kPassEmoji { font-size: 24px; }
+.kPassName { flex: 1; font-size: 14px; font-weight: 800; text-align: left; }
+.kPassName small { font-weight: 700; opacity: .7; }
+.kPassStars { font-size: 13px; letter-spacing: 1px; }
+.kPassGo {
+  min-width: 44px; min-height: 44px; display: flex; align-items: center; justify-content: center;
+  border-radius: 12px; background: #eef2ff; text-decoration: none; font-size: 18px;
+}
+
 /* ---------- panels (settings / grown-ups / help) ---------- */
 .kPanel {
   position: fixed; inset: 0; z-index: 90; display: flex; align-items: center; justify-content: center;

--- a/public/gamekit/kit.js
+++ b/public/gamekit/kit.js
@@ -24,15 +24,72 @@
   const $ = (id) => document.getElementById(id);
   let cfg = null;
 
-  // ---------- persistence (per-game namespace, on-device only) ----------
-  K.save = (key, val) => { try { localStorage.setItem(`abe.${cfg.slug}.${key}`, JSON.stringify(val)); } catch (e) {} };
+  // ---------- profiles (siblings share a tablet without clobbering each other) ----------
+  // Profile p1 maps to the ORIGINAL unprefixed keys so nobody's saves are lost.
+  const AVATARS = [
+    { id: 'p1', emoji: '🐘' }, { id: 'p2', emoji: '🦊' }, { id: 'p3', emoji: '🐰' }, { id: 'p4', emoji: '🦄' },
+  ];
+  let prof = 'p1';
+  try { prof = localStorage.getItem('abe.profile.current') || 'p1'; } catch (e) {}
+  if (!AVATARS.some((a) => a.id === prof)) prof = 'p1';
+  K.profile = () => prof;
+  const kk = (key) => prof === 'p1' ? `abe.${cfg.slug}.${key}` : `abe.${cfg.slug}.${prof}.${key}`;
+
+  // ---------- persistence (per-game, per-profile namespace, on-device only) ----------
+  K.save = (key, val) => { try { localStorage.setItem(kk(key), JSON.stringify(val)); } catch (e) {} };
   K.load = (key, fallback) => {
-    try { const v = localStorage.getItem(`abe.${cfg.slug}.${key}`); return v === null ? fallback : JSON.parse(v); }
+    try { const v = localStorage.getItem(kk(key)); return v === null ? fallback : JSON.parse(v); }
     catch (e) { return fallback; }
   };
 
+  // ---------- daily streak helper (any game: K.streakBump() on its "completed something today") ----------
+  const dayStr = (off) => new Date(Date.now() - (off || 0) * 86400000).toISOString().slice(0, 10);
+  K.streak = () => K.load('streak', { last: '', n: 0 }).n;
+  K.streakBump = () => {
+    const s = K.load('streak', { last: '', n: 0 });
+    if (s.last === dayStr(0)) return { n: s.n, grew: false };
+    s.n = s.last === dayStr(1) ? s.n + 1 : 1; s.last = dayStr(0);
+    K.save('streak', s);
+    return { n: s.n, grew: true };
+  };
+
+  // ---------- season helper (date-driven freshness, shared by every kit game) ----------
+  K.season = () => {
+    const m = new Date().getMonth();
+    return m === 11 || m < 2 ? { id: 'winter', emoji: '❄️' }
+      : m < 5 ? { id: 'spring', emoji: '🌸' }
+      : m < 8 ? { id: 'summer', emoji: '☀️' }
+      : { id: 'fall', emoji: '🍂' };
+  };
+
+  // ---------- game passport (cross-game sticker shelf; one stamp per game per day) ----------
+  // FUTURE GAMES: add one line here and the passport, /games page, and offline
+  // cache (public/sw.js) are the only three registration spots outside the game.
+  const CATALOG = [
+    { slug: 'nilus-world', name: "Nilu's World", emoji: '🐘', url: '/nelus-world' },
+    { slug: 'elly-tubbies', name: 'Elly-Tubbies', emoji: '☀️', url: '/1' },
+    { slug: 'blockcraft', name: 'Block Craft 3D', emoji: '🧱', url: '/2' },
+    { slug: 'roadsafety', name: 'Road Safety Heroes', emoji: '🚦', url: '/4' },
+    { slug: 'doughlab', name: 'Dough Lab 3D', emoji: '🫓', url: '/5' },
+    { slug: 'magnetblocks', name: 'Magnet Blocks', emoji: '🧲', url: '/6' },
+    { slug: 'helpinghands', name: "Nilu's Helping Hands", emoji: '🖐️', url: '/7' },
+    { slug: 'grocery', name: "Aaria's Grocery Store", emoji: '🛒', url: '/8' },
+    { slug: 'dayplanner', name: 'My Day Planner', emoji: '📅', url: '/9' },
+  ];
+  const passKey = () => prof === 'p1' ? 'abe.passport.v1' : `abe.passport.${prof}.v1`;
+  function passGet() { try { return JSON.parse(localStorage.getItem(passKey())) || {}; } catch (e) { return {}; } }
+  function stampToday() {
+    try {
+      const p = passGet(), e = p[cfg.slug] || { days: 0, last: '' };
+      if (e.last === dayStr(0)) return false;
+      e.days++; e.last = dayStr(0); p[cfg.slug] = e;
+      localStorage.setItem(passKey(), JSON.stringify(p));
+      return true;
+    } catch (e) { return false; }
+  }
+
   // ---------- settings (shared shape across all kit games) ----------
-  const S = { sound: true, calm: false, speed: 'normal', voice: true };
+  const S = { sound: true, calm: false, speed: 'normal', voice: true, music: true };
   const SPEED = { relaxed: { ico: '🐢', mul: 1.5 }, normal: { ico: '🐇', mul: 1 }, fast: { ico: '🚀', mul: 0.6 } };
   K.calm = () => S.calm;
   K.speed = () => SPEED[S.speed].mul;
@@ -59,6 +116,51 @@
     no: () => { tone(360, 0.12, 'sine', 0.07); setTimeout(() => tone(300, 0.14, 'sine', 0.07), 110); },
     pop: () => tone(300, 0.09, 'square', 0.06),
   };
+  // ---------- ambient music: a very soft generative loop, no audio files ----------
+  // Gentle pad chords + sparse plucks. OFF automatically in Calm Mode (sensory-
+  // friendly), OFF with mute, toggleable in settings for every kit game.
+  let mus = null;
+  function startMusic() {
+    if (mus || muted || !S.music || S.calm) return;
+    try {
+      const c = ac(), g = c.createGain();
+      g.gain.value = 0.04; g.connect(c.destination);
+      mus = { g, t1: 0, t2: 0, stop: false };
+      const CHORDS = [[262, 330, 392], [220, 262, 330], [175, 220, 262], [196, 247, 294]];
+      let ci = 0;
+      const pad = () => {
+        if (mus.stop) return;
+        for (const f of CHORDS[ci++ % 4]) {
+          const o = c.createOscillator(), og = c.createGain(), t = c.currentTime;
+          o.type = 'triangle'; o.frequency.value = f / 2;
+          og.gain.setValueAtTime(0.0001, t);
+          og.gain.linearRampToValueAtTime(0.5, t + 2.5);
+          og.gain.linearRampToValueAtTime(0.0001, t + 7.6);
+          o.connect(og).connect(g); o.start(t); o.stop(t + 8);
+        }
+        mus.t1 = setTimeout(pad, 7200);
+      };
+      const pluck = () => {
+        if (mus.stop) return;
+        const o = c.createOscillator(), og = c.createGain(), t = c.currentTime;
+        o.type = 'sine'; o.frequency.value = [523, 587, 659, 784, 880][Math.floor(Math.random() * 5)];
+        og.gain.setValueAtTime(0.0001, t);
+        og.gain.exponentialRampToValueAtTime(0.35, t + 0.03);
+        og.gain.exponentialRampToValueAtTime(0.0001, t + 1.4);
+        o.connect(og).connect(g); o.start(t); o.stop(t + 1.5);
+        mus.t2 = setTimeout(pluck, 2800 + Math.random() * 2800);
+      };
+      pad(); setTimeout(pluck, 1600);
+    } catch (e) { mus = null; }
+  }
+  function stopMusic() {
+    if (!mus) return;
+    mus.stop = true; clearTimeout(mus.t1); clearTimeout(mus.t2);
+    try { mus.g.disconnect(); } catch (e) {}
+    mus = null;
+  }
+  function refreshMusic() { stopMusic(); if ($('kTitle').style.display === 'none' && !K.paused) startMusic(); }
+
   K.say = (text) => {
     if (muted || !S.voice || !window.speechSynthesis) return;
     try {
@@ -246,10 +348,13 @@
       <p>Built for <b>Aaria and Her Friends</b> 💖 — ${cfg.tagline}</p>
       <a id="kDisclosure" href="/legal/disclosure.html" target="_blank" rel="noopener">General Disclosure</a>
       <div class="kTitleEmojis">${(cfg.emojis || []).join('')}</div>
+      <div class="kAvatars"><span class="kAvLbl">Who is playing?</span>${AVATARS.map((a) =>
+        `<button class="kAvatar" data-p="${a.id}" title="Play as ${a.emoji}">${a.emoji}</button>`).join('')}</div>
       <button class="kBig" id="kPlay" title="Start playing">▶️ Play</button>
       <div id="kTitleExtras" style="display:none;margin-top:6px">
         <button class="kBig kAlt" id="kTitleMovie" title="Watch your last adventure">▶️ My Movie</button>
         <button class="kBig kAlt" id="kTitleImport" title="Watch a friend's adventure file">📥 Friend's adventure</button>
+        <button class="kBig kAlt" id="kTitlePass" title="See your stamps from every game">🛂 Passport</button>
       </div>
       <div id="kHow" style="text-align:left;margin-top:10px"></div>
       <div class="kOrgFooter">A game from <b>Aaria's Blue Elephant</b> 🐘💙 · aariasblueelephant.org</div>
@@ -271,6 +376,45 @@
 
   function refreshMute() { $('kMute').innerHTML = muted ? '🔇<span class="kLbl">Sound</span>' : '🔊<span class="kLbl">Sound</span>'; }
 
+  function refreshAvatars() {
+    document.querySelectorAll('.kAvatar').forEach((b) => b.classList.toggle('on', b.dataset.p === prof));
+  }
+  function switchProfile(id) {
+    prof = id;
+    try { localStorage.setItem('abe.profile.current', id); } catch (e) {}
+    // this profile's own settings + saved adventure take over
+    Object.assign(S, { sound: true, calm: false, speed: 'normal', voice: true, music: true }, K.load('settings', {}));
+    const saved = K.load('replay.v1', null);
+    REC.samples = (saved && saved.samples) || []; REC.events = (saved && saved.events) || [];
+    REC.resumeAt = (REC.samples.length ? REC.samples[REC.samples.length - 1][0] : 0) + 1000;
+    $('kTitleMovie').style.display = recSpan() >= REC_MIN ? '' : 'none';
+    refreshAvatars(); K.sfx.tap();
+  }
+
+  // ---------- passport shelf (the cross-game collection that ties all games together) ----------
+  function openPassport() {
+    const p = document.createElement('div'); p.className = 'kPanel'; p.id = 'kPass';
+    const stamps = passGet();
+    const seen = CATALOG.filter((g) => stamps[g.slug] && stamps[g.slug].days > 0).length;
+    const av = AVATARS.find((a) => a.id === prof) || AVATARS[0];
+    p.innerHTML = `<div class="kPanelCard"><h2>🛂 ${av.emoji} My Game Passport</h2>
+      <p class="kPassSub">${seen} of ${CATALOG.length} games explored${seen >= CATALOG.length ? ' — you found them ALL! 🏆' : ' — collect them all!'}</p>
+      ${CATALOG.map((g) => {
+        const st = stamps[g.slug], here = g.slug === cfg.slug;
+        const days = st ? st.days : 0;
+        const stars = days ? '⭐'.repeat(Math.min(days, 5)) + (days > 5 ? ` ×${days}` : '') : '';
+        return `<div class="kPassRow ${days ? 'got' : ''}">
+          <span class="kPassEmoji">${g.emoji}</span>
+          <span class="kPassName">${g.name}${here ? ' <small>· you are here</small>' : ''}</span>
+          <span class="kPassStars">${days ? stars : '· · ·'}</span>
+          ${here ? '' : `<a class="kPassGo" href="${g.url}" title="Go play ${g.name}">▶️</a>`}
+        </div>`;
+      }).join('')}
+      <button class="kRow" id="kPassClose" title="Close the passport">✔️ Done</button></div>`;
+    document.body.appendChild(p);
+    $('kPassClose').onclick = () => p.remove();
+  }
+
   function openSettings() {
     const p = document.createElement('div'); p.className = 'kPanel'; p.id = 'kSet';
     const row = (id, txt) => `<button class="kRow" id="${id}" title="${txt.replace(/<[^>]*>/g, '')}">${txt}</button>`;
@@ -278,12 +422,16 @@
       ${row('ksCalm', `😌 Calm mode: <b>${S.calm ? 'ON' : 'off'}</b>`)}
       ${row('ksSpeed', `${SPEED[S.speed].ico} Game speed`)}
       ${row('ksVoice', `🗣️ Read aloud: <b>${S.voice ? 'ON' : 'off'}</b>`)}
+      ${row('ksMusic', `🎵 Music: <b>${S.music ? 'ON' : 'off'}</b>`)}
+      ${row('ksPass', `🛂 My Game Passport`)}
       ${row('ksImport', `📥 Watch a friend's adventure`)}
       ${row('ksHome', `🏠 More games (back to the site)`)}
       ${row('ksClose', `✔️ Done`)}</div>`;
     document.body.appendChild(p);
     const saveS = () => K.save('settings', S);
-    $('ksCalm').onclick = () => { S.calm = !S.calm; saveS(); p.remove(); openSettings(); };
+    $('ksCalm').onclick = () => { S.calm = !S.calm; saveS(); refreshMusic(); p.remove(); openSettings(); };
+    $('ksMusic').onclick = () => { S.music = !S.music; saveS(); refreshMusic(); p.remove(); openSettings(); };
+    $('ksPass').onclick = () => { p.remove(); openPassport(); };
     $('ksSpeed').onclick = () => {
       const o = ['relaxed', 'normal', 'fast']; S.speed = o[(o.indexOf(S.speed) + 1) % 3]; saveS();
       K.toast(`${SPEED[S.speed].ico} Speed: ${S.speed}`); p.remove(); openSettings();
@@ -315,15 +463,22 @@
     const begin = (then) => {
       $('kTitle').style.display = 'none';
       $('kHud').style.display = 'flex'; $('kStick').style.display = 'block'; $('kActs').style.display = 'flex';
-      ac(); ping(); cfg.onStart && cfg.onStart(); then && then();
+      ac(); ping(); startMusic();
+      if (stampToday()) setTimeout(() => { K.toast('🛂 Passport stamped! ⭐'); K.sfx.pop(); }, 1500);
+      cfg.onStart && cfg.onStart(); then && then();
     };
     $('kPlay').onclick = () => { K.sfx.yes(); begin(); };
+    $('kTitlePass').onclick = openPassport;
+    document.querySelectorAll('.kAvatar').forEach((b) => b.addEventListener('pointerdown', () => switchProfile(b.dataset.p)));
+    refreshAvatars();
+    // offline: cache this game (and every other one visited) for cars & waiting rooms
+    if ('serviceWorker' in navigator) { try { navigator.serviceWorker.register('/sw.js'); } catch (e) {} }
     $('kTitleMovie').onclick = () => { K.sfx.tap(); begin(() => startReplay({ samples: REC.samples, events: REC.events }, true)); };
     $('kTitleImport').onclick = () => { begin(); $('kImportFile').click(); };
     $('kImportFile').addEventListener('change', (e) => { if (e.target.files[0]) importAdventure(e.target.files[0]); e.target.value = ''; });
-    $('kMute').onclick = () => { muted = !muted; if (muted && window.speechSynthesis) speechSynthesis.cancel(); refreshMute(); K.toast(muted ? '🔇 Sound is off' : '🔊 Sound is on!'); };
-    $('kPauseBtn').onclick = () => setPaused(true);
-    $('kResume').onclick = () => setPaused(false);
+    $('kMute').onclick = () => { muted = !muted; if (muted && window.speechSynthesis) speechSynthesis.cancel(); refreshMute(); refreshMusic(); K.toast(muted ? '🔇 Sound is off' : '🔊 Sound is on!'); };
+    $('kPauseBtn').onclick = () => { setPaused(true); stopMusic(); };
+    $('kResume').onclick = () => { setPaused(false); refreshMusic(); };
     $('kMovie').onclick = () => { recSpan() >= REC_MIN ? startReplay({ samples: REC.samples, events: REC.events }, true) : K.toast('Play a little first, then watch your movie! ▶️'); };
     $('kShare').onclick = shareAdventure;
     $('kRShare').onclick = shareAdventure;

--- a/public/gamekit/passport.js
+++ b/public/gamekit/passport.js
@@ -1,0 +1,22 @@
+/*! © 2026 Aaria's Blue Elephant · ABE Game Passport stamp for legacy (non-kit) games.
+ * Include with:  <script src="/gamekit/passport.js" data-game="<slug>" defer></script>
+ * Stamps one passport day per game per calendar day, per profile — same storage
+ * the game kit uses, so kit games and legacy games share one passport shelf.
+ * Everything stays on-device; no identifiers, nothing transmitted. */
+(function () {
+  try {
+    var slug = (document.currentScript && document.currentScript.dataset.game) || "";
+    if (!slug || sessionStorage.getItem("abe_stamp_" + slug)) return;
+    sessionStorage.setItem("abe_stamp_" + slug, "1");
+    var prof = localStorage.getItem("abe.profile.current") || "p1";
+    var key = prof === "p1" ? "abe.passport.v1" : "abe.passport." + prof + ".v1";
+    var p = {};
+    try { p = JSON.parse(localStorage.getItem(key)) || {}; } catch (e) {}
+    var today = new Date().toISOString().slice(0, 10);
+    var entry = p[slug] || { days: 0, last: "" };
+    if (entry.last !== today) {
+      entry.days++; entry.last = today; p[slug] = entry;
+      localStorage.setItem(key, JSON.stringify(p));
+    }
+  } catch (e) {}
+})();

--- a/public/grocery/index.html
+++ b/public/grocery/index.html
@@ -313,6 +313,9 @@
       const i = Math.floor(Math.random() * pool.length);
       G.list.push(pool.splice(i, 1)[0].id);
     }
+    // food of the day — a different daily special is on every list (come back tomorrow!)
+    const special = FOODS[Math.floor(Date.now() / 864e5) % FOODS.length];
+    if (!G.list.includes(special.id)) G.list[0] = special.id;
     G.got = []; G.peeked = [];
     G.hintTimer = 0; G.hintShown = false;
     document.getElementById("gHint").style.display = "none";
@@ -327,6 +330,7 @@
     document.getElementById("gLevel").textContent = `Level ${G.level} · Remember ${size} ${size === 1 ? "thing" : "things"}!`;
     document.getElementById("gLevel").style.display = "block";
     K.say("Look and remember! " + G.list.map((id) => foodById(id).name).join(", "));
+    K.toast(`⭐ Today's special: ${special.emoji}!`, 3000);
   }
 
   function endReveal() {
@@ -560,7 +564,8 @@
     K.sfx.star(); K.recordEvent("trip", G.trips);
     K.say("Thank you for shopping! You remembered the whole list!");
     const stamps = Math.min(G.trips, 10);
-    panel(`<h2>🌟 What a memory!</h2>
+    const streak = K.streakBump();
+    panel(`${streak.n > 1 ? `<div style="font-size:20px;font-weight:900">🔥 ${streak.n} days of shopping in a row!</div>` : ""}<h2>🌟 What a memory!</h2>
       <p>You remembered your list, waited your turn, paid and bagged — a whole shopping trip!</p>
       <div class="gStamps">${"⭐".repeat(stamps)}${"☆".repeat(Math.max(0, 5 - stamps))}</div>
       <p style="font-size:14px">Shopping trips: <b>${G.trips}</b>${leveledUp ? ` · Next time: <b>${levelSize(G.level)}</b> things to remember and a <b>${DENOMS[Math.min(G.level, DENOMS.length) - 1].name}</b>! 🧠💵` : " · You know every coin and bill — now we practice them all! 🏆"}</p>

--- a/public/helpinghands/index.html
+++ b/public/helpinghands/index.html
@@ -867,5 +867,6 @@ try{
 <script src="js/content.js"></script>
 <script src="js/world.js"></script>
 <script src="js/main.js"></script>
+<script src="/gamekit/passport.js" data-game="helpinghands" defer></script>
 </body>
 </html>

--- a/public/magnetblocks/index.html
+++ b/public/magnetblocks/index.html
@@ -344,5 +344,6 @@ try{
   <script src="js/cleanup.js"></script>
   <script src="js/help.js"></script>
   <script src="js/main.js"></script>
+  <script src="/gamekit/passport.js" data-game="magnetblocks" defer></script>
 </body>
 </html>

--- a/public/roadsafety/index.html
+++ b/public/roadsafety/index.html
@@ -260,5 +260,6 @@ try{
 <script src="assets/aerial-meta.js"></script>
 <script src="assets/photos-meta.js"></script>
 <script src="game.js"></script>
+<script src="/gamekit/passport.js" data-game="roadsafety" defer></script>
 </body>
 </html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,35 @@
+/*! © 2026 Aaria's Blue Elephant · offline cache for the games ONLY.
+ * Registered by the game kit (never by the React site), so site deploys are
+ * unaffected: we only handle GET requests under the game directories below.
+ * Strategy: stale-while-revalidate — serve from cache instantly when offline
+ * or slow, refresh the cache in the background when online.
+ *
+ * NEW GAMES: add the game's folder name to GAME_RX below.
+ * (scripts/check-game-controls.mjs fails if a game folder is missing here.)
+ */
+const CACHE = "abe-games-v2";
+const GAME_RX = /^\/(gamekit|grocery|dayplanner|blockcraft|elly-tubbies|roadsafety|doughlab|magnetblocks|helpinghands|craft3d|images\/games|legal|sounds)(\/|$)/;
+
+self.addEventListener("install", () => self.skipWaiting());
+
+self.addEventListener("activate", (e) => {
+  e.waitUntil(
+    caches.keys()
+      .then((keys) => Promise.all(keys.filter((k) => k.startsWith("abe-games") && k !== CACHE).map((k) => caches.delete(k))))
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener("fetch", (e) => {
+  const url = new URL(e.request.url);
+  if (e.request.method !== "GET" || url.origin !== location.origin || !GAME_RX.test(url.pathname)) return;
+  e.respondWith(
+    caches.open(CACHE).then(async (cache) => {
+      const hit = await cache.match(e.request, { ignoreSearch: true });
+      const refresh = fetch(e.request)
+        .then((res) => { if (res && res.ok) cache.put(e.request, res.clone()); return res; })
+        .catch(() => hit);
+      return hit || refresh;
+    })
+  );
+});

--- a/scripts/check-game-controls.mjs
+++ b/scripts/check-game-controls.mjs
@@ -93,6 +93,16 @@ for (const [game, cfg] of Object.entries(GAMES)) {
   }
 }
 
+// Offline coverage: every game folder the build minifies must be cached by the
+// service worker, so no future game silently ships without offline support.
+{
+  const sw = readFileSync('public/sw.js', 'utf8');
+  const dirs = (readFileSync('scripts/minify-games.mjs', 'utf8').match(/GAME_DIRS = \[([^\]]+)\]/) || [])[1] || '';
+  for (const m of dirs.matchAll(/'([a-z0-9-]+)'/g)) {
+    if (!sw.includes(m[1])) fail('sw.js', 'R5', `game folder '${m[1]}' missing from GAME_RX in public/sw.js (no offline cache)`);
+  }
+}
+
 if (errors.length) {
   console.error('\nGame-control standard violations:\n' + errors.join('\n'));
   console.error('\nThe standard lives in scripts/check-game-controls.mjs — fix the game or (deliberately) update the rule.\n');


### PR DESCRIPTION
## Summary
- **Game Passport** — cross-game sticker shelf (one stamp/game/day, on-device only). Kit games stamp automatically; all 7 legacy games join via one passport.js script tag; Nilu's World stamps from its React boot. Shelf shows all 9 games with play links.
- **Profiles** — avatar picker on every kit title screen; per-child saves/settings/streaks/passport; profile 1 maps to legacy keys (no lost progress).
- **Offline** — games-only service worker (stale-while-revalidate), registered by the kit; checker now enforces every game folder is in the cache list.
- **Ambient music** — soft generative loop in the kit (no files); auto-off in Calm Mode; settings toggle.
- **Daily hooks** — Grocery food-of-the-day + shopping streak; Day Planner days-in-a-row; kit streakBump()/season() helpers for future games.
- **Public /games page** — shared data/games.ts registry, public route, navbar link.

## Test plan
- [x] Headless: avatars render (p1 default); playing stamps passport + toast; shelf shows 1/9; streak persists
- [x] Profile isolation: p2 starts at level 1 while p1's level 2 is untouched; separate passports
- [x] Legacy stamp: magnetblocks page writes into the active profile's passport
- [x] `npx tsc --noEmit`, `vite build`, control checker (incl. new offline-coverage rule), node --check on kit/sw/passport — all clean