### PR TITLE
Game Plays: allowlist grocery + dayplanner

### DIFF
--- a/supabase/create_game_play_counts.sql
+++ b/supabase/create_game_play_counts.sql
@@ -26,8 +26,10 @@ set search_path = public
 as $$
 begin
   -- allowlist keeps junk out of the table
+  -- NEW GAMES: add the slug here AND re-run this function block in the
+  -- Supabase SQL editor (the allowlist lives in the DB, not just this file).
   if g not in ('elly-tubbies','blockcraft','nilus-world','roadsafety',
-               'doughlab','magnetblocks','helpinghands') then
+               'doughlab','magnetblocks','helpinghands','grocery','dayplanner') then
     return;
   end if;
   insert into public.game_play_counts (game, day, plays)


### PR DESCRIPTION
The record_game_play DB function silently dropped pings from the two new games (server-side allowlist). Live DB already patched via management API and verified with a test ping (then removed); this syncs the repo SQL and documents the two-place registration for future games.