### PR TITLE
Road Safety: kit-standard joystick (elephant knob)

### DIFF
--- a/public/roadsafety/game.js
+++ b/public/roadsafety/game.js
@@ -428,8 +428,31 @@ function bindTouch(id, key){
   el.addEventListener("pointercancel", off);
   el.addEventListener("pointerleave", off);
 }
-bindTouch("btnL","left"); bindTouch("btnR","right");
 bindTouch("btnGo","go"); bindTouch("btnStop","stop");
+/* kit-standard joystick: steer with x, push up = go, pull down = stop */
+{
+  const stick = document.getElementById("rsStick"), knob = document.getElementById("rsKnob");
+  let pid = null;
+  const DEAD = 0.32;
+  const set = e => {
+    const r = stick.getBoundingClientRect();
+    let dx = e.clientX - (r.left + r.width/2), dy = e.clientY - (r.top + r.height/2);
+    const m = Math.hypot(dx, dy), max = r.width/2 - 18;
+    if (m > max){ dx *= max/m; dy *= max/m; }
+    knob.style.transform = `translate(calc(-50% + ${dx}px), calc(-50% + ${dy}px))`;
+    const nx = dx/max, ny = dy/max;
+    input.left = nx < -DEAD; input.right = nx > DEAD;
+    input.go = ny < -DEAD; input.stop = ny > DEAD;
+  };
+  const end = () => {
+    pid = null; knob.style.transform = "translate(-50%,-50%)";
+    input.left = input.right = input.go = input.stop = false;
+  };
+  stick.addEventListener("pointerdown", e => { e.preventDefault(); ensureAudio(); pid = e.pointerId; stick.setPointerCapture(pid); set(e); });
+  stick.addEventListener("pointermove", e => { if (e.pointerId === pid) set(e); });
+  stick.addEventListener("pointerup", end);
+  stick.addEventListener("pointercancel", end);
+}
 
 /* ---------- helpers ---------- */
 function toast(text, color){ S.toasts.push({ text, color: color||"#2d6a4f", t:1.8 }); }

--- a/public/roadsafety/index.html
+++ b/public/roadsafety/index.html
@@ -92,13 +92,14 @@ try{
 
   <!-- Touch controls -->
   <div id="touch" class="hidden">
-    <div class="tgroup">
-      <button class="tbtn" id="btnL">◀</button>
-      <button class="tbtn" id="btnR">▶</button>
+    <!-- kit-standard joystick (same as every other ABE game): steer left/right,
+         push up to GO, pull down to STOP — the elephant rides the knob -->
+    <div id="rsStick" title="Steer with the stick — push up to go, pull down to stop">
+      <div id="rsKnob"><img src="/abe-logo.png" alt=""></div>
     </div>
     <div class="tgroup right">
-      <button class="tbtn go" id="btnGo">▲<br>GO</button>
-      <button class="tbtn stop" id="btnStop">✋<br>STOP</button>
+      <button class="tbtn go" id="btnGo" title="Pedal — go forward">▲<br>GO</button>
+      <button class="tbtn stop" id="btnStop" title="Brake — stop safely">✋<br>STOP</button>
     </div>
   </div>
 

--- a/public/roadsafety/style.css
+++ b/public/roadsafety/style.css
@@ -344,6 +344,20 @@ h2 { color: #1d3461; font-size: clamp(19px, 4.4vmin, 28px); }
   pointer-events: none;
 }
 .tgroup { display: flex; gap: 12px; pointer-events: auto; }
+/* the ABE-standard joystick (matches the game kit's stick in every other game) */
+#rsStick {
+  width: 132px; height: 132px; border-radius: 50%; pointer-events: auto;
+  background: rgba(255,255,255,.35); box-shadow: inset 0 0 0 3px rgba(255,255,255,.6);
+  position: relative; touch-action: none;
+}
+#rsKnob {
+  position: absolute; left: 50%; top: 50%; width: 56px; height: 56px; border-radius: 50%;
+  background: #fff; box-shadow: 0 4px 10px rgba(40,40,90,.25);
+  transform: translate(-50%,-50%); display: flex; align-items: center; justify-content: center;
+  overflow: hidden;
+}
+#rsKnob img { width: 46px; height: 46px; border-radius: 50%; pointer-events: none; }
+@media (max-height: 560px) { #rsStick { width: 108px; height: 108px; } }
 .tbtn {
   width: 70px; height: 70px; border-radius: 50%;
   font-family: inherit; font-size: 18px; font-weight: bold; line-height: 1.1;


### PR DESCRIPTION
Replaces ◀ ▶ touch buttons with the standard ABE joystick (steer + up=GO / down=STOP), elephant badge on the knob; GO/STOP buttons kept for the deliberate-stop teaching action. Verified headlessly: stick vector maps to input.left/right/go/stop with deadzone, releases clean, zero page errors; control-standard checker passes.