### PR TITLE
Road Safety: show joystick on every device

### DIFF
--- a/public/roadsafety/game.js
+++ b/public/roadsafety/game.js
@@ -498,8 +498,9 @@ function updateBoostCharge(){
 const SCREENS = ["title","menu","intro","tip","quiz","cert","retry","results","settings","buckle"];
 function show(id){
   for (const s of SCREENS) document.getElementById(s).classList.toggle("hidden", s !== id);
-  document.getElementById("touch").classList.toggle("hidden",
-    !(id === null && ("ontouchstart" in window)));
+  // on-screen controls show on EVERY device while driving (kit standard —
+  // the joystick works with a mouse too, not just touch)
+  document.getElementById("touch").classList.toggle("hidden", id !== null);
   document.getElementById("raceHud").classList.toggle("hidden", id !== null);
   document.getElementById("pauseBtn").classList.toggle("hidden", id !== null);
   if (id !== null) document.getElementById("count").classList.add("hidden");


### PR DESCRIPTION
The touch-control panel (now the kit joystick) was hidden unless the device reported a touchscreen, so desktops/laptops never saw it. Now it shows during driving on every device, matching the kit games. Verified headlessly on a no-touch desktop viewport: level 1 drive shows the stick + GO/STOP, zero page errors.