### PR TITLE
Game Plays: anonymous play-time tracking

### DIFF
--- a/pages/Dashboard.tsx
+++ b/pages/Dashboard.tsx
@@ -103,7 +103,15 @@ interface GamePlayRow {
     game: string;
     day: string; // YYYY-MM-DD (UTC)
     plays: number;
+    seconds: number; // aggregate anonymous play time (0 for rows predating time tracking)
 }
+
+// "3h 24m" / "18m" style label for aggregate seconds
+const fmtDuration = (s: number): string => {
+    if (s < 60) return s > 0 ? '<1m' : '0m';
+    const h = Math.floor(s / 3600), m = Math.round((s % 3600) / 60);
+    return h > 0 ? `${h}h ${m}m` : `${m}m`;
+};
 
 const Dashboard: React.FC = () => {
     const { user, isBoard, isDonor, updateAvatar } = useAuth();
@@ -168,6 +176,7 @@ const Dashboard: React.FC = () => {
                     game: String(r.game),
                     day: String(r.day).slice(0, 10),
                     plays: Number(r.plays) || 0,
+                    seconds: Number(r.seconds) || 0,
                 }))
             );
         } catch (err: any) {
@@ -2226,9 +2235,17 @@ const Dashboard: React.FC = () => {
         const plays7 = rows.filter(r => r.day >= cutoff7).reduce((sum, r) => sum + r.plays, 0);
         const plays30 = rows.filter(r => r.day >= cutoff30).reduce((sum, r) => sum + r.plays, 0);
 
+        // Aggregate play time (rows from before time tracking simply contribute 0)
+        const totalSeconds = rows.reduce((sum, r) => sum + r.seconds, 0);
+        const seconds7 = rows.filter(r => r.day >= cutoff7).reduce((sum, r) => sum + r.seconds, 0);
+
         // Per-game all-time totals, sorted desc
         const perGame = new Map<string, number>();
-        rows.forEach(r => perGame.set(r.game, (perGame.get(r.game) || 0) + r.plays));
+        const perGameSeconds = new Map<string, number>();
+        rows.forEach(r => {
+            perGame.set(r.game, (perGame.get(r.game) || 0) + r.plays);
+            perGameSeconds.set(r.game, (perGameSeconds.get(r.game) || 0) + r.seconds);
+        });
         const ranked = Array.from(perGame.entries()).sort((a, b) => b[1] - a[1]);
         const maxPlays = ranked.length > 0 ? ranked[0][1] : 0;
 
@@ -2237,10 +2254,12 @@ const Dashboard: React.FC = () => {
         rows.forEach(r => byGameDay.set(`${r.game}|${r.day}`, (byGameDay.get(`${r.game}|${r.day}`) || 0) + r.plays));
 
         const statCards = [
-            { label: 'Total Plays (All-Time)', value: totalPlays, iconClass: 'bg-brand-purple/10 text-brand-purple' },
-            { label: 'Plays Today', value: playsToday, iconClass: 'bg-brand-cyan/10 text-brand-cyan' },
-            { label: 'Last 7 Days', value: plays7, iconClass: 'bg-brand-green/10 text-brand-green' },
-            { label: 'Last 30 Days', value: plays30, iconClass: 'bg-amber-500/10 text-amber-500' },
+            { label: 'Total Plays (All-Time)', value: totalPlays.toLocaleString(), iconClass: 'bg-brand-purple/10 text-brand-purple' },
+            { label: 'Plays Today', value: playsToday.toLocaleString(), iconClass: 'bg-brand-cyan/10 text-brand-cyan' },
+            { label: 'Last 7 Days', value: plays7.toLocaleString(), iconClass: 'bg-brand-green/10 text-brand-green' },
+            { label: 'Last 30 Days', value: plays30.toLocaleString(), iconClass: 'bg-amber-500/10 text-amber-500' },
+            { label: 'Time Played (All-Time)', value: fmtDuration(totalSeconds), iconClass: 'bg-rose-500/10 text-rose-500' },
+            { label: 'Time · Last 7 Days', value: fmtDuration(seconds7), iconClass: 'bg-sky-500/10 text-sky-500' },
         ];
 
         return (
@@ -2249,7 +2268,7 @@ const Dashboard: React.FC = () => {
                     <div>
                         <h2 className="text-2xl font-black text-slate-900 dark:text-white uppercase tracking-tight">Game Plays 🎮</h2>
                         <p className="text-slate-600 dark:text-slate-400 text-sm mt-1">
-                            Anonymous tally only — no personal data, no identifiers; one count per game per session.
+                            Anonymous tally only — no personal data, no identifiers; one count per game per session, plus aggregate active-play time.
                         </p>
                     </div>
                     <button
@@ -2284,7 +2303,7 @@ const Dashboard: React.FC = () => {
                 ) : rows.length > 0 && (
                     <>
                         {/* Summary Stat Cards */}
-                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                             {statCards.map((card) => (
                                 <div key={card.label} className="bg-white dark:bg-brand-card p-6 rounded-2xl border border-slate-200 dark:border-slate-800 shadow-sm hover:shadow-md transition-all group">
                                     <div className="flex items-center gap-4">
@@ -2293,7 +2312,7 @@ const Dashboard: React.FC = () => {
                                         </div>
                                         <div>
                                             <p className="text-slate-500 dark:text-slate-400 text-[10px] font-black uppercase tracking-widest leading-tight">{card.label}</p>
-                                            <h3 className="text-2xl font-black text-slate-900 dark:text-white mt-1">{card.value.toLocaleString()}</h3>
+                                            <h3 className="text-2xl font-black text-slate-900 dark:text-white mt-1">{card.value}</h3>
                                         </div>
                                     </div>
                                 </div>
@@ -2312,7 +2331,15 @@ const Dashboard: React.FC = () => {
                                         <div className="flex-1 min-w-0">
                                             <div className="flex items-center justify-between mb-1">
                                                 <span className="text-xs font-bold text-slate-900 dark:text-white truncate">{gameLabel(slug)}</span>
-                                                <span className="text-xs font-black text-brand-purple dark:text-purple-300 ml-2 shrink-0">{count.toLocaleString()}</span>
+                                                <span className="text-xs font-black text-brand-purple dark:text-purple-300 ml-2 shrink-0">
+                                                    {count.toLocaleString()}
+                                                    {(perGameSeconds.get(slug) || 0) >= 60 && (
+                                                        <span className="text-slate-400 dark:text-slate-500 font-bold">
+                                                            {' '}· {fmtDuration(perGameSeconds.get(slug) || 0)}
+                                                            {count > 0 && ` (~${fmtDuration(Math.round((perGameSeconds.get(slug) || 0) / count))}/play)`}
+                                                        </span>
+                                                    )}
+                                                </span>
                                             </div>
                                             <div className="h-2 rounded-full bg-slate-100 dark:bg-slate-800 overflow-hidden">
                                                 <div

--- a/public/gamekit/kit.js
+++ b/public/gamekit/kit.js
@@ -301,6 +301,30 @@
     cfg.onPause && cfg.onPause(p);
   }
 
+  // ---------- anonymous play-time tally (aggregate seconds only, ZERO identifiers) ----------
+  // Counts only ACTIVE play: after Play is pressed, not paused, tab visible.
+  // Flushed in small batches so a closed tab loses at most a minute.
+  const TIME = { acc: 0, last: 0, on: false };
+  function timeFlush() {
+    const s = Math.floor(TIME.acc);
+    if (s < 5 || !cfg.anonKey) { return; }
+    TIME.acc -= s;
+    try {
+      fetch('https://joclqxgedhdgslxnovxz.supabase.co/rest/v1/rpc/record_game_time', {
+        method: 'POST', keepalive: true,
+        headers: { apikey: cfg.anonKey, Authorization: `Bearer ${cfg.anonKey}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ g: cfg.slug, s }),
+      }).catch(() => {});
+    } catch (e) {}
+  }
+  function timeTick() {
+    const now = performance.now();
+    if (TIME.on && !K.paused && !document.hidden) TIME.acc += (now - TIME.last) / 1000;
+    TIME.last = now;
+  }
+  setInterval(() => { timeTick(); if (TIME.acc >= 60) timeFlush(); }, 5000);
+  addEventListener('pagehide', () => { timeTick(); timeFlush(); });
+
   // ---------- anonymous play tally (one per session, ZERO identifiers) ----------
   function ping() {
     try {
@@ -464,6 +488,7 @@
       $('kTitle').style.display = 'none';
       $('kHud').style.display = 'flex'; $('kStick').style.display = 'block'; $('kActs').style.display = 'flex';
       ac(); ping(); startMusic();
+      TIME.on = true; TIME.last = performance.now();
       if (stampToday()) setTimeout(() => { K.toast('🛂 Passport stamped! ⭐'); K.sfx.pop(); }, 1500);
       cfg.onStart && cfg.onStart(); then && then();
     };

--- a/public/gamekit/passport.js
+++ b/public/gamekit/passport.js
@@ -20,3 +20,35 @@
     }
   } catch (e) {}
 })();
+
+/* Anonymous aggregate play-time for legacy games (same posture as the play
+ * tally each game already sends: seconds per game per day, NO identifiers).
+ * Counts only visible-tab time, flushed in small batches. The anon key below
+ * is the same public key already inline in every game's page. */
+(function () {
+  try {
+    var slug = (document.currentScript && document.currentScript.dataset.game) || "";
+    if (!slug || slug === "nilus-world") return; // Nilu's World route stays analytics-free (COPPA follow-up)
+    var KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImpvY2xxeGdlZGhkZ3NseG5vdnh6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzE4MzA3NzUsImV4cCI6MjA4NzQwNjc3NX0.824zjMOHfPyMXBm5WgvArI-ZzQJgYzddskm7-5y-PSM";
+    var acc = 0, last = performance.now();
+    function tick() {
+      var now = performance.now();
+      if (!document.hidden) acc += (now - last) / 1000;
+      last = now;
+    }
+    function flush() {
+      var s = Math.floor(acc);
+      if (s < 5) return;
+      acc -= s;
+      try {
+        fetch("https://joclqxgedhdgslxnovxz.supabase.co/rest/v1/rpc/record_game_time", {
+          method: "POST", keepalive: true,
+          headers: { apikey: KEY, Authorization: "Bearer " + KEY, "Content-Type": "application/json" },
+          body: JSON.stringify({ g: slug, s: s }),
+        }).catch(function () {});
+      } catch (e) {}
+    }
+    setInterval(function () { tick(); if (acc >= 60) flush(); }, 5000);
+    addEventListener("pagehide", function () { tick(); flush(); });
+  } catch (e) {}
+})();

--- a/supabase/create_game_play_counts.sql
+++ b/supabase/create_game_play_counts.sql
@@ -41,3 +41,31 @@ $$;
 
 revoke all on function public.record_game_play(text) from public;
 grant execute on function public.record_game_play(text) to anon, authenticated;
+
+-- Anonymous aggregate play TIME (seconds per game per day; no identifiers).
+-- Clients flush small batches of active-play seconds; clamped server-side.
+alter table public.game_play_counts add column if not exists seconds bigint not null default 0;
+
+create or replace function public.record_game_time(g text, s int)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if s is null or s < 5 then return; end if;
+  if s > 600 then s := 600; end if;
+  -- same allowlist as record_game_play — keep both in sync (and in the live DB)
+  if g not in ('elly-tubbies','blockcraft','nilus-world','roadsafety',
+               'doughlab','magnetblocks','helpinghands','grocery','dayplanner') then
+    return;
+  end if;
+  insert into public.game_play_counts (game, day, plays, seconds)
+  values (g, (now() at time zone 'utc')::date, 0, s)
+  on conflict (game, day)
+  do update set seconds = public.game_play_counts.seconds + excluded.seconds;
+end;
+$$;
+
+revoke all on function public.record_game_time(text, int) from public;
+grant execute on function public.record_game_time(text, int) to anon, authenticated;


### PR DESCRIPTION
Adds aggregate play seconds per game per day next to the play counts — no identifiers, clamped server-side, allowlisted. Kit games count only active play (not paused, tab visible); legacy games track visible time via passport.js; Nilu's World stays analytics-free. Dashboard gains Time Played cards and per-game time + avg/play. Live DB already migrated and verified with a test write (then removed). Behavioral tests: kit ping ~8-10s of play, paused time sends nothing, legacy ping works; tsc + checker clean.