### PR TITLE
Portability: remove Elly-Tubbies' Google Fonts CDN dependency

### DIFF
--- a/public/elly-tubbies/index.html
+++ b/public/elly-tubbies/index.html
@@ -6,9 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
 <title>Elly-Tubbies 🐘 — Aaria's Blue Elephant</title>
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🐘</text></svg>" />
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@600;800&display=swap" rel="stylesheet">
 <style>
   :root{--nilu:#2563eb; --ink:#3a3a5a; --sun:#ffd23f; --glow:#fff3b0; --pink:#ff8fb1;}
   *{box-sizing:border-box;-webkit-tap-highlight-color:transparent;}


### PR DESCRIPTION
Mobile-app portability audit result: this was the single external asset dependency across all 10 games. Font stack falls back to the same handwriting fonts the other games use. Full audit findings in PR discussion below — everything else is app-phase work (blob downloads → share sheet, disclosure links → parental gate), not web fixes.