### PR TITLE
App launcher self-refreshes from the live games catalog

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -18,6 +18,9 @@ const config: CapacitorConfig = {
     // serve bundled assets from a stable local origin so localStorage
     // (saves, passport, profiles) persists across app updates
     androidScheme: 'https',
+    // the launcher may open games that shipped to the website AFTER this app
+    // build (live catalog refresh) — allow the WebView to navigate there
+    allowNavigation: ['aariasblueelephant.org', 'www.aariasblueelephant.org'],
   },
 };
 

--- a/components/ParentalGate.tsx
+++ b/components/ParentalGate.tsx
@@ -24,8 +24,10 @@ const ParentalGate: React.FC = () => {
       const a = (e.target as HTMLElement)?.closest?.('a');
       if (!a) return;
       const href = a.getAttribute('href') || '';
-      // gate: external links, and the donate flow (leads to payment pages)
-      if (/^https?:\/\//i.test(href) || href === '/donate' || href.startsWith('/donate?')) {
+      // gate: external links, and the donate flow (leads to payment pages).
+      // Our own domain is exempt — live-catalog games play from there.
+      const external = /^https?:\/\//i.test(href) && !/^https?:\/\/(www\.)?aariasblueelephant\.org(\/|$)/i.test(href);
+      if (external || href === '/donate' || href.startsWith('/donate?')) {
         e.preventDefault();
         e.stopPropagation();
         newQuestion();

--- a/data/games.json
+++ b/data/games.json
@@ -1,0 +1,12 @@
+[
+    { "id": "belus-world", "title": "Nilu's World", "emoji": "🐘", "oneLiner": "Explore islands, meet friends & help Nilu grow!", "img": "/images/games/belus-world.jpg", "path": "/nelus-world" },
+    { "id": "magnetblocks", "title": "Aaria's Magnet Blocks", "emoji": "🧲", "oneLiner": "Magnetic blocks that click, stack & drive!", "img": "/images/games/magnetblocks.jpg", "view": "magnetblocks" },
+    { "id": "helpinghands", "title": "Nilu's Helping Hands", "emoji": "🖐️", "oneLiner": "Learn your world & how to get help — walk, explore, be brave!", "img": "/images/games/helpinghands.jpg", "view": "helpinghands" },
+    { "id": "doughlab", "title": "Dough Lab 3D", "emoji": "🫓", "oneLiner": "Squish, slice & sculpt real 3D dough!", "img": "/images/games/doughlab.jpg", "view": "doughlab" },
+    { "id": "blockcraft", "title": "Aaria's Block Craft 3D", "emoji": "🧱", "oneLiner": "Building, animal friends, slime & cookies!", "img": "/images/games/blockcraft.jpg", "view": "blockcraft" },
+    { "id": "elly-tubbies", "title": "Elly-Tubbies", "emoji": "☀️", "oneLiner": "Bouncy elephant friends in sunny Trunkland!", "img": "/images/games/elly-tubbies.jpg", "view": "elly-tubbies" },
+    { "id": "roadsafety", "title": "Road Safety Heroes", "emoji": "🚦", "oneLiner": "Ride & drive the REAL streets of Mountain House!", "img": "/images/games/roadsafety.jpg", "view": "roadsafety" },
+    { "id": "grocery", "title": "Aaria's Grocery Store", "emoji": "🛒", "oneLiner": "Bring your list, find the food, wait your turn, pay & bag!", "img": "/images/games/grocery.jpg", "path": "/8" },
+    { "id": "dayplanner", "title": "Aaria's Day Planner", "emoji": "📅", "oneLiner": "Plan your day with picture cards, then live it with Nilu!", "img": "/images/games/dayplanner.jpg", "path": "/9" },
+    { "id": "wheel", "title": "Wheel of Fun", "emoji": "🎡", "oneLiner": "Spin the rainbow wheel for surprises & giggles!", "img": "/images/games/wheel.jpg", "view": "wheel" }
+]

--- a/data/games.ts
+++ b/data/games.ts
@@ -1,14 +1,9 @@
+import cards from './games.json';
+
+// The games registry. data/games.json is the single source of truth: the
+// Dashboard and the public /games page import it here, and the build publishes
+// it verbatim as /games-catalog.json so the MOBILE APP's launcher can discover
+// games added after the app shipped (no store update needed).
 export type GameCard = { id: string; title: string; emoji: string; oneLiner: string; img: string; view?: string; path?: string };
 
-export const GAME_CARDS: GameCard[] = [
-    { id: 'belus-world', title: "Nilu's World", emoji: '🐘', oneLiner: 'Explore islands, meet friends & help Nilu grow!', img: '/images/games/belus-world.jpg', path: '/nelus-world' },
-    { id: 'magnetblocks', title: "Aaria's Magnet Blocks", emoji: '🧲', oneLiner: 'Magnetic blocks that click, stack & drive!', img: '/images/games/magnetblocks.jpg', view: 'magnetblocks' },
-    { id: 'helpinghands', title: "Nilu's Helping Hands", emoji: '🖐️', oneLiner: 'Learn your world & how to get help — walk, explore, be brave!', img: '/images/games/helpinghands.jpg', view: 'helpinghands' },
-    { id: 'doughlab', title: 'Dough Lab 3D', emoji: '🫓', oneLiner: 'Squish, slice & sculpt real 3D dough!', img: '/images/games/doughlab.jpg', view: 'doughlab' },
-    { id: 'blockcraft', title: "Aaria's Block Craft 3D", emoji: '🧱', oneLiner: 'Building, animal friends, slime & cookies!', img: '/images/games/blockcraft.jpg', view: 'blockcraft' },
-    { id: 'elly-tubbies', title: 'Elly-Tubbies', emoji: '☀️', oneLiner: 'Bouncy elephant friends in sunny Trunkland!', img: '/images/games/elly-tubbies.jpg', view: 'elly-tubbies' },
-    { id: 'roadsafety', title: 'Road Safety Heroes', emoji: '🚦', oneLiner: 'Ride & drive the REAL streets of Mountain House!', img: '/images/games/roadsafety.jpg', view: 'roadsafety' },
-    { id: 'grocery', title: "Aaria's Grocery Store", emoji: '🛒', oneLiner: 'Bring your list, find the food, wait your turn, pay & bag!', img: '/images/games/grocery.jpg', path: '/8' },
-    { id: 'dayplanner', title: "Aaria's Day Planner", emoji: '📅', oneLiner: 'Plan your day with picture cards, then live it with Nilu!', img: '/images/games/dayplanner.jpg', path: '/9' },
-    { id: 'wheel', title: 'Wheel of Fun', emoji: '🎡', oneLiner: 'Spin the rainbow wheel for surprises & giggles!', img: '/images/games/wheel.jpg', view: 'wheel' },
-];
+export const GAME_CARDS: GameCard[] = cards as GameCard[];

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "fetch-data": "tsx scripts/fetch-resilience-data.ts",
-    "build": "npm run check:controls && npm run fetch-data && tsc && vite build && node prerender.js && node scripts/minify-games.mjs",
+    "build": "npm run check:controls && npm run fetch-data && tsc && vite build && cp data/games.json dist/games-catalog.json && node prerender.js && node scripts/minify-games.mjs",
     "preview": "vite preview",
     "lint": "tsc --noEmit",
     "check:controls": "node scripts/check-game-controls.mjs"

--- a/pages/Games.tsx
+++ b/pages/Games.tsx
@@ -1,5 +1,50 @@
-import React from 'react';
-import { GAME_CARDS } from '../data/games';
+import React, { useEffect, useState } from 'react';
+import { GAME_CARDS, GameCard } from '../data/games';
+
+// In the NATIVE APP, the launcher refreshes itself from the live site's
+// /games-catalog.json — a game shipped to the website appears here the same
+// day, no store update. Unknown games play from the live site (the WebView is
+// allowed to navigate to aariasblueelephant.org; analytics stay app-disabled).
+// Offline, or on the website itself, the bundled list is used as-is.
+const LIVE_CATALOG = 'https://aariasblueelephant.org/games-catalog.json';
+const CACHE_KEY = 'abe.app.catalog';
+
+function useLiveCatalog(): GameCard[] {
+  const [cards, setCards] = useState<GameCard[]>(() => {
+    if (!(window as any).Capacitor) return GAME_CARDS;
+    try {
+      const cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null');
+      return Array.isArray(cached) && cached.length ? mergeCatalog(cached) : GAME_CARDS;
+    } catch { return GAME_CARDS; }
+  });
+  useEffect(() => {
+    if (!(window as any).Capacitor) return;
+    fetch(LIVE_CATALOG, { cache: 'no-store' })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((live) => {
+        if (!Array.isArray(live) || !live.length) return;
+        try { localStorage.setItem(CACHE_KEY, JSON.stringify(live)); } catch { /* full */ }
+        setCards(mergeCatalog(live));
+      })
+      .catch(() => { /* offline — bundled list is fine */ });
+  }, []);
+  return cards;
+}
+
+// bundled games keep their local (offline) entries; anything new plays from the live site
+function mergeCatalog(live: GameCard[]): GameCard[] {
+  const bundledIds = new Set(GAME_CARDS.map((g) => g.id));
+  const extras = live
+    .filter((g) => g && g.id && !bundledIds.has(g.id) && (g.path || g.view))
+    .map((g) => ({
+      ...g,
+      img: /^https?:/.test(g.img) ? g.img : `https://aariasblueelephant.org${g.img}`,
+      path: `https://aariasblueelephant.org${g.path ?? VIEW_ROUTES[g.view!] ?? ''}`,
+      view: undefined,
+    }))
+    .filter((g) => g.path !== 'https://aariasblueelephant.org');
+  return [...GAME_CARDS, ...extras];
+}
 
 // Public games catalog — no account needed. Same cards the dashboard shows,
 // so new games registered in data/games.ts appear here automatically.
@@ -13,7 +58,9 @@ const VIEW_ROUTES: Record<string, string> = {
   wheel: '/wheel',
 };
 
-const Games: React.FC = () => (
+const Games: React.FC = () => {
+  const cards = useLiveCatalog();
+  return (
   <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-16">
     <div className="text-center pt-6 pb-8">
       <h1 className="text-4xl sm:text-5xl font-extrabold text-slate-900 dark:text-white">
@@ -25,7 +72,7 @@ const Games: React.FC = () => (
       </p>
     </div>
     <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-5">
-      {GAME_CARDS.map((g) => {
+      {cards.map((g) => {
         const href = g.path ?? (g.view ? VIEW_ROUTES[g.view] : undefined);
         if (!href) return null;
         return (
@@ -54,6 +101,7 @@ const Games: React.FC = () => (
       <a href="/legal/disclosure.html" className="underline">general disclosure</a>.
     </p>
   </div>
-);
+  );
+};
 
 export default Games;

--- a/store/LISTING.md
+++ b/store/LISTING.md
@@ -58,8 +58,10 @@ In-app purchases: none · Ads: none
 Data collected: NONE.
 - No identifiers, no usage data, no diagnostics, no location, no contacts.
 - All progress is stored locally on the device (localStorage), never transmitted.
-- The app makes no network requests. (Web analytics are compile-time disabled
-  in the native app: window.Capacitor guards in the game kit and games.)
+- The app SENDS nothing. Its only network use is fetching game content from
+  our own website (aariasblueelephant.org) — the launcher's game catalog and
+  any games added after this build. Web analytics are disabled in the native
+  app (window.Capacitor guards in the game kit and games).
 Privacy policy URL: https://aariasblueelephant.org/privacy-policy
 
 ## Parental gate (Apple Kids Category note for review)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "resolveJsonModule": true,
     "target": "ES2022",
     "experimentalDecorators": true,
     "useDefineForClassFields": false,


### PR DESCRIPTION
Path-1 enhancement: the build publishes data/games.json (now the single source of truth) as /games-catalog.json; in the native app the launcher fetches it and appends games missing from the bundle, playing them from aariasblueelephant.org (allowNavigation + offline-cached catalog). Ship a game to the website → it appears in installed apps the same day, no store update. Verified headlessly: simulated app renders 10 bundled + 1 live-only game with the correct live URL. Parental gate exempts our domain; listing privacy wording updated. tsc/build/checker clean.