### PR TITLE
ABE control canon: standard Exit/Sound/Settings placement, smoke-tested

### DIFF
--- a/components/game/BelusWorld/ui/HUD.tsx
+++ b/components/game/BelusWorld/ui/HUD.tsx
@@ -56,8 +56,20 @@ export default function HUD({ beluLine, nearZone, starQuestZone, stickers, total
 
   return (
     <div className="pointer-events-none fixed inset-0 z-30">
-      {/* Nilu speech — top left */}
-      <div className="absolute left-4 top-4 flex max-w-[78%] items-start gap-2">
+      {/* ABE control canon: 🏠 Exit ALWAYS owns the top-left corner, every game */}
+      <button
+        data-abe="exit"
+        onClick={() => { window.location.href = '/games'; }}
+        className="pointer-events-auto absolute left-4 top-4 flex h-14 w-14 flex-col items-center justify-center rounded-2xl bg-white/90 shadow-lg backdrop-blur transition hover:bg-white active:scale-95"
+        aria-label="Leave the game — back to all games"
+        title="Leave the game — back to all games"
+      >
+        <span className="text-xl leading-none">🏠</span>
+        <span className="text-[10px] font-extrabold text-slate-600">Exit</span>
+      </button>
+
+      {/* Nilu speech — right of the Exit button */}
+      <div className="absolute left-20 top-4 flex max-w-[70%] items-start gap-2">
         <div
           className="flex h-12 w-12 flex-none items-center justify-center rounded-full text-2xl"
           style={{ background: 'linear-gradient(140deg,#7ec0ff,#5fa8e8)', boxShadow: '0 6px 18px rgba(40,90,160,0.4)' }}
@@ -100,6 +112,7 @@ export default function HUD({ beluLine, nearZone, starQuestZone, stickers, total
       <div className="absolute right-4 top-14 flex items-center gap-2">
         <button
           onClick={onToggleMute}
+          data-abe="sound"
           className="pointer-events-auto flex h-12 w-12 items-center justify-center rounded-full bg-white/90 text-xl shadow-lg backdrop-blur transition hover:bg-white active:scale-95"
           aria-label={muted ? 'Unmute sound' : 'Mute sound'}
           title={muted ? 'Unmute sound' : 'Mute sound'}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "npm run check:controls && npm run fetch-data && tsc && vite build && cp data/games.json dist/games-catalog.json && node prerender.js && node scripts/minify-games.mjs",
     "preview": "vite preview",
     "lint": "tsc --noEmit",
-    "check:controls": "node scripts/check-game-controls.mjs"
+    "check:controls": "node scripts/check-game-controls.mjs",
+    "smoke:controls": "node scripts/smoke-controls.mjs"
   },
   "dependencies": {
     "@capacitor/filesystem": "^8.1.2",

--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -68,7 +68,10 @@
   #hud { position:fixed; inset:0; z-index:10; pointer-events:none; display:none; }
   #crosshair { position:absolute; left:50%; top:50%; transform:translate(-50%,-50%);
     font-size:22px; color:#fff; text-shadow:0 0 6px rgba(0,0,0,.6); }
-  #scoreBar { position:absolute; top:12px; left:12px; display:flex; gap:10px; }
+  #scoreBar { position:absolute; top:12px; left:76px; display:flex; gap:10px; }
+  #abeExitBtn { position:absolute; top:12px; left:12px; pointer-events:auto; min-width:52px; min-height:52px;
+    display:flex; flex-direction:column; align-items:center; justify-content:center; gap:0; font-size:19px; }
+  #abeExitBtn .btnTxt { font-size:10px; font-weight:800; }
   .scoreChip { background:rgba(255,255,255,.88); border-radius:20px; padding:8px 16px; font-size:20px;
     box-shadow:0 3px 8px rgba(0,0,0,.18); color:#333; }
   #portalChip, #questChip, #flowerChip { pointer-events:auto; cursor:pointer; }
@@ -322,7 +325,7 @@
   body.skin-smooth #bagBtn:active { transform:scale(.93); background:rgba(31,182,166,.26); }
 
   /* spacious edge placement — replaces the cramped defaults */
-  body.skin-smooth #scoreBar { top:var(--hud-pad); left:var(--hud-pad); gap:12px; }
+  body.skin-smooth #scoreBar { top:var(--hud-pad); left:calc(var(--hud-pad) + 66px); gap:12px; }
   body.skin-smooth #menuBar  { top:var(--hud-pad); right:var(--hud-pad); gap:10px; }
   body.skin-smooth #sideBtns { right:var(--hud-pad); top:86px; gap:13px; }
   body.skin-smooth .sideBtn  { width:60px; height:60px; border-radius:17px; font-size:22px; }
@@ -487,6 +490,7 @@ try{
 </div>
 
 <div id="hud">
+  <button class="menuBtn" id="abeExitBtn" data-abe="exit" title="Leave the game — back to all games">🏠<span class="btnTxt">Exit</span></button>
   <div id="scoreBar">
     <div class="scoreChip" id="starChip">⭐ 0</div>
     <div class="scoreChip" id="heartChip">💖 0</div>
@@ -496,7 +500,7 @@ try{
     <div class="scoreChip" id="flowerChip" title="Days of adventures">🌻 0</div>
   </div>
   <div id="menuBar">
-    <button class="menuBtn" id="muteBtn" title="Mute — tap to turn off sound" style="min-width:44px;min-height:44px;">🔊</button>
+    <button class="menuBtn" id="muteBtn" data-abe="sound" title="Mute — tap to turn off sound" style="min-width:44px;min-height:44px;">🔊</button>
     <button class="menuBtn" id="pauseBtn" title="Take a break" style="min-width:44px;min-height:44px;">⏸️</button>
     <button class="menuBtn" id="movieBtn" title="Watch your last adventure!" style="min-width:44px;min-height:44px;">▶️<span class="btnTxt"> My Movie</span></button>
     <button class="menuBtn" id="shareBtn" title="Share your world with a friend" style="min-width:44px;min-height:44px;">📤<span class="btnTxt"> Share</span></button>

--- a/public/blockcraft/js/main.js
+++ b/public/blockcraft/js/main.js
@@ -966,6 +966,7 @@
   $('slimeBtn').onclick    = () => ABC.activities.slimeLab();
   $('oreoBtn').onclick     = () => ABC.activities.oreoKitchen();
   $('copycatBtn').onclick  = () => { ABC.activities.quitProject(true); ABC.copycat.showMenu(); };
+  $('abeExitBtn').onclick = () => { location.href = '/games'; };
   $('settingsBtn').onclick = () => ABC.ui.showSettings();
   $('helpBtn').onclick     = () => ABC.ui.showHelp();
   $('magicBtn').onclick    = () => ABC.activities.magicFill();

--- a/public/dayplanner/index.html
+++ b/public/dayplanner/index.html
@@ -61,7 +61,7 @@
 
   /* ---------- in-day progress strip (mini visual schedule, always visible) ---------- */
   #dpStrip {
-    position: fixed; top: max(10px, env(safe-area-inset-top)); left: max(10px, env(safe-area-inset-left));
+    position: fixed; top: calc(max(10px, env(safe-area-inset-top)) + 64px); left: max(10px, env(safe-area-inset-left));
     z-index: 45; background: var(--k-card); border-radius: 16px; padding: 8px 10px;
     box-shadow: 0 4px 12px rgba(40,40,90,.18); border: 2px solid var(--k-accent);
     display: none; max-width: 46vw;

--- a/public/doughlab/index.html
+++ b/public/doughlab/index.html
@@ -56,7 +56,7 @@
   }
 
   #chip {
-    position: absolute; top: 10px; left: 10px; z-index: 15;
+    position: absolute; top: 10px; left: 76px; z-index: 15;
     background: rgba(255,255,255,.88); color: #5c4a32; font-weight: 700; font-size: 12px;
     padding: 6px 13px; border-radius: 16px; box-shadow: 0 3px 8px rgba(0,0,0,.15);
     pointer-events: none;
@@ -268,8 +268,9 @@ try{
   <canvas id="three"></canvas>
   <canvas id="ui"></canvas>
   <div id="chip">🍪 Shapes made: <span id="chipCount">0</span></div>
+  <button id="abeExitBtn" class="hudBtn" data-abe="exit" title="Leave the game — back to all games" style="position:absolute;top:10px;left:10px;z-index:15">🏠<span class="hudLbl">Exit</span></button>
   <div id="hudBtns">
-    <button id="muteBtn" class="hudBtn" title="Mute sound">🔊<span class="hudLbl">Sound</span></button>
+    <button id="muteBtn" class="hudBtn" data-abe="sound" title="Mute sound">🔊<span class="hudLbl">Sound</span></button>
     <button id="calmBtn" class="hudBtn" title="Calm mode — locks the camera and calms things down">😌<span class="hudLbl">Calm</span></button>
     <button id="viewBtn" class="hudBtn" title="Reset the camera view">🔄<span class="hudLbl">View</span></button>
     <button id="photoBtn" class="hudBtn" title="Save a photo of your dough">📸<span class="hudLbl">Photo</span></button>
@@ -1898,6 +1899,8 @@ applyCamera();
 frame();
 })();
 </script>
-<script src="/gamekit/passport.js" data-game="doughlab" defer></script>
+<script src="/gamekit/passport.js" data-game="doughlab" defer>
+document.getElementById("abeExitBtn").onclick = () => { location.href = "/games"; };
+</script>
 </body>
 </html>

--- a/public/elly-tubbies/index.html
+++ b/public/elly-tubbies/index.html
@@ -315,6 +315,7 @@ try{
   <div id="loading"><div class="ele">🐘</div><div class="lbl">Waking up Trunkland…</div></div>
 
   <div id="topbar">
+    <button class="mbtn mbtnLabeled" id="abeExitBtn" data-abe="exit" title="Leave the game — back to all games" style="pointer-events:auto;align-self:flex-start">🏠<span class="mbtnLbl">Exit</span></button>
     <div style="display:flex;flex-direction:column;gap:6px;align-items:flex-start;">
       <div class="chip">🌞 Day <span id="dayN">1</span></div>
       <div class="chip" id="visitChip" style="display:none" title="Days you've visited Trunkland — thank you for coming back!">🗓️ <span id="visitN">1</span></div>
@@ -324,7 +325,7 @@ try{
       <div class="chip" id="sched" style="pointer-events:auto;gap:4px" title="Today's plan"></div>
     </div>
     <div id="menu">
-      <button class="mbtn" id="soundBtn" title="Sound — tap to mute or unmute" aria-label="Sound on or off">🔊</button>
+      <button class="mbtn" id="soundBtn" data-abe="sound" title="Sound — tap to mute or unmute" aria-label="Sound on or off">🔊</button>
       <button class="mbtn" id="pauseBtn" title="Take a break" aria-label="Pause">⏸️</button>
       <button class="mbtn mbtnLabeled" id="replayBtn" title="Watch my adventure!" aria-label="Watch my adventure — My Movie">▶️<span class="mbtnLbl">My Movie</span></button>
       <button class="mbtn mbtnLabeled" id="shareBtn" title="Share my adventure!" aria-label="Share my adventure">📤<span class="mbtnLbl">Share</span></button>
@@ -3485,6 +3486,7 @@ function toggleMute(){S.muted=!S.muted;save();
   if(S.muted&&voiceOK)try{speechSynthesis.cancel();}catch(e){}
   updateSoundBtn();renderSettings();if(!S.muted)sfx.tap();}
 $('soundBtn').onclick=toggleMute;
+$('abeExitBtn').onclick=()=>{location.href='/games';};
 updateSoundBtn();updateSpeedBtn();
 $('speedBtn').onclick=cycleSpeed;
 $('settingsBtn').onclick=()=>{sfx.tap();renderSettings();$('settings').classList.add('show');};

--- a/public/gamekit/kit.css
+++ b/public/gamekit/kit.css
@@ -16,6 +16,17 @@ body {
 #kStage { position: fixed; inset: 0; }
 #kStage canvas { display: block; }
 
+/* ---------- ABE CONTROL CANON: 🏠 Exit is ALWAYS top-left in every game ---------- */
+#kExit {
+  position: fixed; top: max(10px, env(safe-area-inset-top)); left: max(10px, env(safe-area-inset-left));
+  z-index: 50; min-width: 52px; min-height: 52px; padding: 5px 10px; border: 0; cursor: pointer;
+  border-radius: 16px; background: var(--k-card); color: var(--k-ink);
+  font: inherit; font-size: 20px; font-weight: 800;
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 1px;
+  box-shadow: 0 4px 10px rgba(40, 40, 90, .18);
+}
+#kExit:active { transform: scale(.9); }
+
 /* ---------- standard HUD (top-right, standard order) ---------- */
 #kHud {
   position: fixed; top: max(10px, env(safe-area-inset-top)); right: max(10px, env(safe-area-inset-right));

--- a/public/gamekit/kit.js
+++ b/public/gamekit/kit.js
@@ -364,12 +364,13 @@
     document.documentElement.style.setProperty('--k-accent', cfg.accent);
     const el = document.createElement('div');
     el.innerHTML = `
-  <div id="kHud" style="display:none">
-    <button class="kBtn" id="kMute" title="Sound on or off">🔊<span class="kLbl">Sound</span></button>
+  <button id="kExit" data-abe="exit" style="display:none" title="Leave the game — back to all games">🏠<span class="kLbl">Exit</span></button>
+  <div id="kHud" data-abe="hud" style="display:none">
+    <button class="kBtn" id="kMute" data-abe="sound" title="Sound on or off">🔊<span class="kLbl">Sound</span></button>
     <button class="kBtn" id="kPauseBtn" title="Take a break">⏸️<span class="kLbl">Pause</span></button>
     <button class="kBtn" id="kMovie" title="Watch your adventure like a movie!">▶️<span class="kLbl">My Movie</span></button>
     <button class="kBtn" id="kShare" title="Save your adventure as a file to share">📤<span class="kLbl">Share</span></button>
-    <button class="kBtn" id="kSettings" title="Settings">⚙️<span class="kLbl">More</span></button>
+    <button class="kBtn" id="kSettings" data-abe="settings" title="Settings">⚙️<span class="kLbl">Settings</span></button>
   </div>
   <div id="kChip" style="display:none"></div>
   <div id="kStick" style="display:none"><div id="kKnob"><img src="logo.png" alt=""></div></div>
@@ -483,7 +484,7 @@
     };
     $('ksVoice').onclick = () => { S.voice = !S.voice; saveS(); p.remove(); openSettings(); };
     $('ksImport').onclick = () => { p.remove(); $('kImportFile').click(); };
-    $('ksHome').onclick = () => { location.href = '/'; };
+    $('ksHome').onclick = () => { location.href = '/games'; };
     $('ksClose').onclick = () => p.remove();
   }
 
@@ -508,6 +509,7 @@
     const begin = (then) => {
       $('kTitle').style.display = 'none';
       $('kHud').style.display = 'flex'; $('kStick').style.display = 'block'; $('kActs').style.display = 'flex';
+      $('kExit').style.display = 'flex';
       ac(); ping(); startMusic();
       TIME.on = true; TIME.last = performance.now();
       if (stampToday()) setTimeout(() => { K.toast('🛂 Passport stamped! ⭐'); K.sfx.pop(); }, 1500);
@@ -526,6 +528,7 @@
     $('kTitleImport').onclick = () => { begin(); $('kImportFile').click(); };
     $('kImportFile').addEventListener('change', (e) => { if (e.target.files[0]) importAdventure(e.target.files[0]); e.target.value = ''; });
     $('kMute').onclick = () => { muted = !muted; if (muted && window.speechSynthesis) speechSynthesis.cancel(); refreshMute(); refreshMusic(); K.toast(muted ? '🔇 Sound is off' : '🔊 Sound is on!'); };
+    $('kExit').onclick = () => { location.href = '/games'; };
     $('kPauseBtn').onclick = () => { setPaused(true); stopMusic(); };
     $('kResume').onclick = () => { setPaused(false); refreshMusic(); };
     $('kMovie').onclick = () => { recSpan() >= REC_MIN ? startReplay({ samples: REC.samples, events: REC.events }, true) : K.toast('Play a little first, then watch your movie! ▶️'); };

--- a/public/grocery/index.html
+++ b/public/grocery/index.html
@@ -12,7 +12,7 @@
 <style>
   /* game-specific bits only — everything else comes from the kit */
   #gList {
-    position: fixed; top: max(10px, env(safe-area-inset-top)); left: max(10px, env(safe-area-inset-left));
+    position: fixed; top: calc(max(10px, env(safe-area-inset-top)) + 64px); left: max(10px, env(safe-area-inset-left));
     z-index: 45; background: var(--k-card); border-radius: 16px; padding: 10px 12px;
     box-shadow: 0 4px 12px rgba(40,40,90,.18); border: 2px solid var(--k-accent);
     display: none; max-width: 44vw;

--- a/public/helpinghands/index.html
+++ b/public/helpinghands/index.html
@@ -86,6 +86,18 @@
     border: 0; background: rgba(255,255,255,.75); width: 44px; height: 44px; border-radius: 50%;
     font-size: 18px; cursor: pointer; min-width: 44px;
   }
+  #exitGameBtn {
+    position: fixed;
+    top: max(10px, env(safe-area-inset-top));
+    left: max(10px, env(safe-area-inset-left));
+    z-index: 300;
+    border: 0; background: rgba(255,255,255,.92); color: #5f3dc4;
+    min-width: 52px; min-height: 52px; border-radius: 999px;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    font-size: 20px; line-height: 1; padding: 4px 8px; gap: 1px; cursor: pointer;
+    box-shadow: 0 4px 10px rgba(0,0,0,.14);
+  }
+  #exitGameBtn span { font-size: 10px; font-weight: 800; }
   .sticker-counter {
     background: rgba(255,255,255,.8); border-radius: 20px; padding: 8px 16px; font-weight: 800;
     color: #d9480f; font-size: 16px; white-space: nowrap;
@@ -645,6 +657,9 @@ try{
 
 <div id="bgShapes"><i></i><i></i><i></i></div>
 
+<!-- ABE control canon — leave-the-GAME button, owns the top-left corner during gameplay -->
+<button id="exitGameBtn" data-abe="exit" title="Leave the game — back to all games" hidden onclick="location.href='/games'">🏠<span>Exit</span></button>
+
 <!-- 1. PASSWORD GATE -->
 <div id="gateScreen" hidden>
   <div class="gate-card" id="gateCard">
@@ -675,7 +690,7 @@ try{
 <div id="menuScreen" class="screen" hidden>
   <header class="chrome-header">
     <div class="sticker-counter">🌟 <span class="stickerCount">0</span></div>
-    <button class="mute-btn" title="Mute sounds">🔊</button>
+    <button class="mute-btn" data-abe="sound" title="Mute sounds">🔊</button>
   </header>
   <div class="menu-middle">
     <h2 class="menu-title">What do you want to do?</h2>
@@ -692,7 +707,7 @@ try{
     <div id="roomHeader" class="room-header" hidden></div>
     <div style="display:flex;align-items:center;gap:8px;">
       <div class="sticker-counter">🌟 <span class="stickerCount">0</span></div>
-      <button class="mute-btn" title="Mute sounds">🔊</button>
+      <button class="mute-btn" data-abe="sound" title="Mute sounds">🔊</button>
     </div>
   </div>
   <div id="stage3d">
@@ -727,7 +742,7 @@ try{
     <button class="btn-back" data-target="menu">◀ Menu</button>
     <div style="display:flex;align-items:center;gap:8px;">
       <div class="sticker-counter">🌟 <span class="stickerCount">0</span></div>
-      <button class="mute-btn" title="Mute sounds">🔊</button>
+      <button class="mute-btn" data-abe="sound" title="Mute sounds">🔊</button>
     </div>
   </header>
   <div id="handBody" class="hand-body"></div>
@@ -739,7 +754,7 @@ try{
     <button class="btn-back" data-target="menu">◀ Menu</button>
     <div style="display:flex;align-items:center;gap:8px;">
       <div class="sticker-counter">🌟 <span class="stickerCount">0</span></div>
-      <button class="mute-btn" title="Mute sounds">🔊</button>
+      <button class="mute-btn" data-abe="sound" title="Mute sounds">🔊</button>
     </div>
   </header>
   <div id="practiceBody" class="practice-body"></div>
@@ -751,7 +766,7 @@ try{
     <button class="btn-back" data-target="menu">◀ Menu</button>
     <div style="display:flex;align-items:center;gap:8px;">
       <div class="sticker-counter">🌟 <span class="stickerCount">0</span></div>
-      <button class="mute-btn" title="Mute sounds">🔊</button>
+      <button class="mute-btn" data-abe="sound" title="Mute sounds">🔊</button>
     </div>
   </header>
   <div id="stickerBody" class="hand-body"></div>

--- a/public/helpinghands/js/main.js
+++ b/public/helpinghands/js/main.js
@@ -217,6 +217,9 @@ const NILU_SCREENS = ["menuScreen", "exploreScreen", "handScreen", "practiceScre
 function showScreen(id) {
   SCREEN_IDS.forEach(s => { $(s).hidden = (s !== id); });
   $("niluBubble").hidden = !NILU_SCREENS.includes(id);
+  // ABE control canon — Exit is visible during actual gameplay screens,
+  // hidden on the title screen and Grown-Ups Corner (adult-only area)
+  $("exitGameBtn").hidden = !NILU_SCREENS.concat(["stickersScreen"]).includes(id);
   if (id === "menuScreen") setNilu("What do you want to do today? 💙");
   if (id === "exploreScreen") {
     requestAnimationFrame(() => { if (window.HH && HH.World) HH.World.resize(); });

--- a/public/magnetblocks/index.html
+++ b/public/magnetblocks/index.html
@@ -239,13 +239,13 @@ try{
 
   <div id="hud">
     <div id="topLeft">
-      <button class="menuBtn" id="homeBtn">🏠</button>
+      <button class="menuBtn" id="homeBtn" data-abe="exit" title="Leave the game — back to all games">🏠<span class="btnTxt"> Exit</span></button>
       <div class="chip">🧲 Magnet Blocks</div>
       <div class="chip" id="pieceChip">🧱 0</div>
       <div class="chip" id="bestChip" title="Your biggest build ever!">🏆 0</div>
     </div>
     <div id="topRight">
-      <button class="menuBtn" id="soundBtn" title="Sound on or off">🔊</button>
+      <button class="menuBtn" id="soundBtn" data-abe="sound" title="Sound on or off">🔊</button>
       <button class="menuBtn" id="replayBtn" title="Watch your build appear piece by piece!" style="display:none">▶️ My Movie</button>
       <button class="menuBtn" id="shareBtn" title="Save your build as a file to share" style="display:none">📤 Share</button>
       <button class="menuBtn" id="calmBtn" title="Calm mode">😌</button>

--- a/public/magnetblocks/js/main.js
+++ b/public/magnetblocks/js/main.js
@@ -430,7 +430,7 @@ window.MB = window.MB || {};
       startGame();
       $('importFile').click();
     });
-    $('homeBtn').addEventListener('click', () => ui.confirm('Leave the playroom? 🏠', 'Your school bag creations stay saved!', () => location.href = '/'));
+    $('homeBtn').addEventListener('click', () => ui.confirm('Leave the playroom? 🏠', 'Your school bag creations stay saved!', () => location.href = '/games'));
     $('soundBtn').addEventListener('click', () => {
       ui.muted = !ui.muted;
       $('soundBtn').textContent = ui.muted ? '🔇' : '🔊';

--- a/public/roadsafety/game.js
+++ b/public/roadsafety/game.js
@@ -400,6 +400,7 @@ document.getElementById("pauseBtn").addEventListener("click", () => {
   S.paused ? resumeGame() : pauseGame();
 });
 document.getElementById("resumeBtn").addEventListener("click", () => { ensureAudio(); resumeGame(); });
+document.getElementById("exitBtn").addEventListener("click", () => { pauseGame(); location.href = "/games"; });
 addEventListener("visibilitychange", () => { if (document.hidden) pauseGame(); });
 addEventListener("blur", () => pauseGame());
 
@@ -503,6 +504,7 @@ function show(id){
   document.getElementById("touch").classList.toggle("hidden", id !== null);
   document.getElementById("raceHud").classList.toggle("hidden", id !== null);
   document.getElementById("pauseBtn").classList.toggle("hidden", id !== null);
+  document.getElementById("exitBtn").classList.toggle("hidden", id !== null);
   if (id !== null) document.getElementById("count").classList.add("hidden");
 }
 

--- a/public/roadsafety/index.html
+++ b/public/roadsafety/index.html
@@ -53,12 +53,13 @@ try{
 <div id="wrap">
   <canvas id="game" width="520" height="760" role="application" aria-label="Road Safety Heroes — drive the real streets of Mountain House"></canvas>
   <div id="topbtns">
-    <button id="muteBtn" title="Sound on/off" aria-label="Sound">🔊</button>
+    <button id="muteBtn" data-abe="sound" title="Sound on/off" aria-label="Sound">🔊</button>
     <button id="viewBtn" title="Toggle first-person view (V)" aria-label="Toggle view">👁</button>
     <button id="mapBtn" title="Toggle minimap (M)" aria-label="Minimap">🗺</button>
     <button id="speedBtn" title="Game speed — tap for more time 🐢 or faster 🚀" aria-label="Game speed">🎛️</button>
     <button id="settingsBtn" title="Settings" aria-label="Settings">⚙️</button>
   </div>
+  <button id="exitBtn" class="hidden" data-abe="exit" title="Leave the game — back to all games" aria-label="Exit">🏠<small>Exit</small></button>
   <button id="pauseBtn" class="hidden" title="Pause (tap to freeze the game)" aria-label="Pause game">⏸️</button>
   <div id="pauseOverlay" class="hidden">
     <div class="pausecard">

--- a/public/roadsafety/style.css
+++ b/public/roadsafety/style.css
@@ -41,9 +41,24 @@ html, body {
 }
 @keyframes loadSpin { to { transform: rotate(360deg); } }
 
+/* ================= EXIT (ABE control canon — owns the top-left corner) ================= */
+#exitBtn {
+  position: fixed;
+  top: max(10px, env(safe-area-inset-top));
+  left: max(10px, env(safe-area-inset-left));
+  z-index: 32;
+  min-width: 52px; min-height: 52px; border-radius: 999px;
+  font-size: 22px; line-height: 1; border: 3px solid #1d3461; background: #ffffffe6; color: #1d3461;
+  cursor: pointer; display: flex; flex-direction: column; align-items: center; justify-content: center;
+  padding: 4px 8px; gap: 1px;
+}
+#exitBtn small { font-size: 10px; font-weight: bold; }
+
 /* ================= PAUSE ================= */
 #pauseBtn {
-  position: absolute; top: 8px; left: 8px; z-index: 31;
+  position: absolute; top: 8px;
+  left: calc(max(10px, env(safe-area-inset-left)) + 62px);
+  z-index: 31;
   width: 52px; height: 52px; border-radius: 50%;
   font-size: 24px; border: 3px solid #1d3461; background: #ffffffe6; color: #1d3461;
   cursor: pointer; display: flex; align-items: center; justify-content: center;

--- a/scripts/check-game-controls.mjs
+++ b/scripts/check-game-controls.mjs
@@ -93,6 +93,26 @@ for (const [game, cfg] of Object.entries(GAMES)) {
   }
 }
 
+// R6 — ABE CONTROL CANON: every game has exactly one 🏠 Exit (data-abe="exit")
+// with a title, plus a data-abe="sound" mute. Placement (top-left corner etc.)
+// is verified at runtime by scripts/smoke-controls.mjs.
+{
+  const CANON_FILES = {
+    grocery: 'public/gamekit/kit.js', dayplanner: 'public/gamekit/kit.js',
+    blockcraft: 'public/blockcraft/index.html', doughlab: 'public/doughlab/index.html',
+    'elly-tubbies': 'public/elly-tubbies/index.html', magnetblocks: 'public/magnetblocks/index.html',
+    roadsafety: 'public/roadsafety/index.html', helpinghands: 'public/helpinghands/index.html',
+    'nilus-world': 'components/game/BelusWorld/ui/HUD.tsx',
+  };
+  for (const [game, file] of Object.entries(CANON_FILES)) {
+    let src = '';
+    try { src = readFileSync(file, 'utf8'); } catch (e) { fail(game, 'R6', `cannot read ${file}`); continue; }
+    const exits = src.match(/data-abe="exit"/g) || [];
+    if (exits.length !== 1) fail(game, 'R6', `expected exactly one data-abe="exit" in ${file}, found ${exits.length}`);
+    if (!/data-abe="sound"/.test(src)) fail(game, 'R6', `missing data-abe="sound" on the mute button in ${file}`);
+  }
+}
+
 // Offline coverage: every game folder the build minifies must be cached by the
 // service worker, so no future game silently ships without offline support.
 {

--- a/scripts/smoke-controls.mjs
+++ b/scripts/smoke-controls.mjs
@@ -1,0 +1,107 @@
+// Runtime control-canon smoke test — verifies ACTUAL on-screen placement, not
+// just markup, in a real headless browser. Run: node scripts/smoke-controls.mjs
+// (needs `npm run build` NOT required — serves public/ directly)
+//
+// THE CANON (matches scripts/check-game-controls.mjs static rules):
+//  C1  🏠 Exit (data-abe="exit"): present, top-LEFT corner (rect within 120px
+//      of the top and left edges), contains 🏠, has a title.
+//  C2  Sound button (data-abe="sound"): present, in the TOP-RIGHT quadrant.
+//  C3  If a settings button (data-abe="settings") exists, it is RIGHT of the
+//      sound button (settings last in the cluster).
+// Buttons hidden on title screens are fine: each game entry says how to reach
+// gameplay; the checks run after that step.
+import http from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { extname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+const puppeteer = require('puppeteer');
+const ROOT = new URL('../public', import.meta.url).pathname;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.png': 'image/png', '.jpg': 'image/jpeg', '.webp': 'image/webp', '.json': 'application/json' };
+
+// how to get each game from page-load to "gameplay HUD visible"
+const GAMES = [
+  { slug: 'grocery', url: '/grocery/index.html', start: async (p) => { await p.click('#kPlay'); } },
+  { slug: 'dayplanner', url: '/dayplanner/index.html', start: async (p) => { await p.click('#kPlay'); await p.evaluate(() => { document.getElementById('dpPlanner').style.display = 'none'; window.DP.G.mode = 'live'; }); } },
+  { slug: 'blockcraft', url: '/blockcraft/index.html', start: async (p) => { await p.evaluate(() => document.getElementById('playBtn')?.click()); } },
+  { slug: 'doughlab', url: '/doughlab/index.html', start: async (p) => { await p.evaluate(() => { for (const id of ['startBtn', 'playBtn']) document.getElementById(id)?.click(); }) } },
+  { slug: 'elly-tubbies', url: '/elly-tubbies/index.html', start: async (p) => { await p.evaluate(() => { for (const b of document.querySelectorAll('button')) if (/play|start/i.test(b.textContent) && b.offsetParent) { b.click(); break; } }); } },
+  { slug: 'magnetblocks', url: '/magnetblocks/index.html', start: async (p) => { await p.evaluate(() => { for (const b of document.querySelectorAll('button')) if (/build/i.test(b.textContent) && b.offsetParent) { b.click(); break; } }); } },
+  { slug: 'roadsafety', url: '/roadsafety/index.html', start: async (p) => {
+      await p.evaluate(() => document.getElementById('titlePlay')?.click());
+      await new Promise((r) => setTimeout(r, 600));
+      await p.evaluate(() => document.getElementById('garGo')?.click());
+      await new Promise((r) => setTimeout(r, 1000));
+      for (let i = 0; i < 3; i++) {
+        await p.evaluate(() => { const s = [...document.querySelectorAll('.screen')].find((x) => !x.classList.contains('hidden')); s?.querySelector('button')?.click(); });
+        await new Promise((r) => setTimeout(r, 900));
+      }
+    } },
+  { slug: 'helpinghands', url: '/helpinghands/index.html', start: async () => { /* gated: exit is asserted on its entry screen */ } },
+];
+
+const srv = http.createServer(async (req, res) => {
+  try {
+    const d = await readFile(join(ROOT, decodeURIComponent(req.url.split('?')[0])));
+    res.writeHead(200, { 'Content-Type': MIME[extname(req.url.split('?')[0])] || 'application/octet-stream' });
+    res.end(d);
+  } catch { res.writeHead(404); res.end(); }
+});
+await new Promise((r) => srv.listen(8899, r));
+
+const browser = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--mute-audio'] });
+const failures = [];
+for (const g of GAMES) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1024, height: 768 });
+  try {
+    await page.goto(`http://localhost:8899${g.url}`, { waitUntil: 'networkidle0', timeout: 30000 });
+    await new Promise((r) => setTimeout(r, 1200));
+    await g.start(page);
+    await new Promise((r) => setTimeout(r, 1500));
+    const res = await page.evaluate(() => {
+      const rect = (el) => { const r = el.getBoundingClientRect(); return { x: r.left, y: r.top, w: r.width, h: r.height, visible: r.width > 0 && r.height > 0 }; };
+      const exit = document.querySelector('[data-abe="exit"]');
+      // some games repeat the mute button per-screen; measure a visible one if any
+      const sounds = [...document.querySelectorAll('[data-abe="sound"]')].map((el) => ({ ...rect(el), clusterRight: el.parentElement.getBoundingClientRect().right }));
+      const sound = sounds.find((s) => s.visible) || null;
+      const settings = document.querySelector('[data-abe="settings"]');
+      // hidden-at-boot fallback (gated games): the specified CSS must still pin it top-left
+      let exitCss = null;
+      if (exit && !rect(exit).visible) {
+        const cs = getComputedStyle(exit);
+        exitCss = { position: cs.position, top: parseFloat(cs.top), left: parseFloat(cs.left) };
+      }
+      return {
+        exit: exit ? { ...rect(exit), icon: exit.textContent.includes('🏠'), title: !!exit.getAttribute('title'), css: exitCss } : null,
+        sound, settings: settings ? rect(settings) : null, vw: innerWidth,
+      };
+    });
+    if (!res.exit) failures.push(`${g.slug}: C1 no [data-abe=exit] in DOM`);
+    else {
+      if (res.exit.visible) {
+        if (res.exit.x > 120 || res.exit.y > 120) failures.push(`${g.slug}: C1 exit not top-left (at ${Math.round(res.exit.x)},${Math.round(res.exit.y)})`);
+      } else if (!res.exit.css || !/fixed|absolute/.test(res.exit.css.position) || !(res.exit.css.top <= 120) || !(res.exit.css.left <= 120)) {
+        failures.push(`${g.slug}: C1 exit hidden and its CSS is not pinned top-left (${JSON.stringify(res.exit.css)})`);
+      }
+      if (!res.exit.icon) failures.push(`${g.slug}: C1 exit missing 🏠`);
+      if (!res.exit.title) failures.push(`${g.slug}: C1 exit missing title`);
+    }
+    // C2: the sound button's CLUSTER hugs the right edge, in the top band, clear of Exit's corner
+    if (res.sound && (res.sound.y > 130 || res.sound.clusterRight < res.vw - 60 || res.sound.x < 140))
+      failures.push(`${g.slug}: C2 sound cluster not top-right (btn x=${Math.round(res.sound.x)}, cluster right=${Math.round(res.sound.clusterRight)}/${res.vw})`);
+    if (res.settings && res.sound && res.settings.w > 0 && res.settings.x < res.sound.x) failures.push(`${g.slug}: C3 settings not right of sound`);
+  } catch (e) {
+    failures.push(`${g.slug}: smoke error — ${e.message.slice(0, 90)}`);
+  }
+  await page.close();
+}
+await browser.close();
+srv.close();
+
+if (failures.length) {
+  console.error('\ncontrol-canon smoke FAILURES:\n' + failures.map((f) => '  ✗ ' + f).join('\n') + '\n');
+  process.exit(1);
+}
+console.log(`control-canon smoke: exit/sound/settings placement verified in ${GAMES.length} games ✓`);


### PR DESCRIPTION
Fixes the long-standing control inconsistency: Exit now always sits top-left in all 10 games (house icon + label, to /games), Sound first and Settings last in the top-right cluster, joystick already standardized bottom-left. Enforced twice: static R6 pre-push rule + new runtime smoke test (npm run smoke:controls) that drives every game into gameplay and asserts actual pixel placement. All 8 static games pass; tsc + vite build clean.