### PR TITLE
Control canon polish: joystick arrows in all games, overlap fixes

### DIFF
--- a/public/elly-tubbies/index.html
+++ b/public/elly-tubbies/index.html
@@ -271,6 +271,7 @@
     flex-direction:column;gap:14px;background:linear-gradient(160deg,#6cbcff,#9fd4ff,#d6f0ff);color:#fff;}
   #loading .lbl{font-weight:900;font-size:clamp(20px,6vw,30px);text-shadow:0 3px 10px rgba(58,58,90,.3);}
   #loading .ele{font-size:clamp(52px,16vw,90px);animation:bob 1.2s ease-in-out infinite;}
+.abeJoyArrow{position:absolute;font-size:13px;font-weight:900;color:#fff;text-shadow:0 2px 5px rgba(58,58,90,.5);pointer-events:none;z-index:1;}
 </style>
 </head>
 <body>
@@ -419,7 +420,7 @@ try{
     <button class="big" id="resumeBtn" style="font-size:22px">Keep playing ▶️</button>
   </div></div>
 
-  <div id="stick" role="application" aria-label="Movement joystick — drag to walk Nilu"><div id="knob"><img src="logo.png" alt=""></div>
+  <div id="stick" role="application" aria-label="Movement joystick — drag to walk Nilu"><span class="abeJoyArrow" style="top:6px;left:50%;transform:translateX(-50%)">▲</span><span class="abeJoyArrow" style="bottom:6px;left:50%;transform:translateX(-50%)">▼</span><span class="abeJoyArrow" style="left:8px;top:50%;transform:translateY(-50%)">◀</span><span class="abeJoyArrow" style="right:8px;top:50%;transform:translateY(-50%)">▶</span><div id="knob"><img src="logo.png" alt=""></div>
     <span class="stickArrow sa-u">▲</span><span class="stickArrow sa-d">▼</span>
     <span class="stickArrow sa-l">◀</span><span class="stickArrow sa-r">▶</span>
   </div>

--- a/public/gamekit/kit.css
+++ b/public/gamekit/kit.css
@@ -50,6 +50,7 @@ body {
   width: 132px; height: 132px; border-radius: 50%; z-index: 40;
   background: rgba(255,255,255,.35); box-shadow: inset 0 0 0 3px rgba(255,255,255,.6);
 }
+.abeJoyArrow{position:absolute;font-size:13px;font-weight:900;color:#fff;text-shadow:0 2px 5px rgba(58,58,90,.5);pointer-events:none;z-index:1;}
 #kKnob {
   position: absolute; left: 50%; top: 50%; width: 56px; height: 56px; border-radius: 50%;
   background: var(--k-card); box-shadow: 0 4px 10px rgba(40,40,90,.25);

--- a/public/gamekit/kit.js
+++ b/public/gamekit/kit.js
@@ -373,7 +373,7 @@
     <button class="kBtn" id="kSettings" data-abe="settings" title="Settings">⚙️<span class="kLbl">Settings</span></button>
   </div>
   <div id="kChip" style="display:none"></div>
-  <div id="kStick" style="display:none"><div id="kKnob"><img src="logo.png" alt=""></div></div>
+  <div id="kStick" style="display:none"><span class="abeJoyArrow" style="top:6px;left:50%;transform:translateX(-50%)">▲</span><span class="abeJoyArrow" style="bottom:6px;left:50%;transform:translateX(-50%)">▼</span><span class="abeJoyArrow" style="left:8px;top:50%;transform:translateY(-50%)">◀</span><span class="abeJoyArrow" style="right:8px;top:50%;transform:translateY(-50%)">▶</span><div id="kKnob"><img src="logo.png" alt=""></div></div>
   <div id="kActs" style="display:none"></div>
   <div id="kToast"></div>
   <div id="kReplayBar" style="display:none">

--- a/public/helpinghands/index.html
+++ b/public/helpinghands/index.html
@@ -104,7 +104,7 @@
   }
   .chrome-header {
     display: flex; align-items: center; justify-content: space-between; gap: 10px;
-    padding: 12px 14px; flex-wrap: wrap;
+    padding: 12px 14px 12px 74px; flex-wrap: wrap;
   }
   .speak-btn {
     border: 0; background: rgba(255,255,255,.85); width: 40px; height: 40px; border-radius: 50%;

--- a/public/helpinghands/js/world.js
+++ b/public/helpinghands/js/world.js
@@ -2907,6 +2907,7 @@
     knobImg.style.borderRadius = '50%';
     knobImg.style.pointerEvents = 'none';
     knob.appendChild(knobImg);
+    (function(){var dirs=[['▲','top:6px;left:50%;transform:translateX(-50%)'],['▼','bottom:6px;left:50%;transform:translateX(-50%)'],['◀','left:8px;top:50%;transform:translateY(-50%)'],['▶','right:8px;top:50%;transform:translateY(-50%)']];for(var i=0;i<dirs.length;i++){var a=document.createElement('span');a.textContent=dirs[i][0];a.style.cssText='position:absolute;font-size:13px;font-weight:900;color:#fff;text-shadow:0 2px 5px rgba(58,58,90,.5);pointer-events:none;'+dirs[i][1].replace(/;/g,';');a.style.cssText+=';'+dirs[i][1];joystickEl.appendChild(a);}})();
     joystickEl.appendChild(knob);
     if (container) container.appendChild(joystickEl);
     joystickKnob = knob;

--- a/public/magnetblocks/index.html
+++ b/public/magnetblocks/index.html
@@ -180,6 +180,7 @@
   /* HUD chip pop — plays when the "biggest build" record grows */
   #bestChip.chipPop { animation:chipPop .5s ease; }
   @keyframes chipPop { 0%{transform:scale(1)} 40%{transform:scale(1.3)} 100%{transform:scale(1)} }
+.abeJoyArrow{position:absolute;font-size:13px;font-weight:900;color:#fff;text-shadow:0 2px 5px rgba(58,58,90,.5);pointer-events:none;z-index:1;}
 </style>
 </head>
 <body>
@@ -288,7 +289,7 @@ try{
       </button>
     </div>
 
-    <div id="joy"><div id="joyKnob"><img src="logo.png" alt=""></div></div>
+    <div id="joy"><span class="abeJoyArrow" style="top:6px;left:50%;transform:translateX(-50%)">▲</span><span class="abeJoyArrow" style="bottom:6px;left:50%;transform:translateX(-50%)">▼</span><span class="abeJoyArrow" style="left:8px;top:50%;transform:translateY(-50%)">◀</span><span class="abeJoyArrow" style="right:8px;top:50%;transform:translateY(-50%)">▶</span><div id="joyKnob"><img src="logo.png" alt=""></div></div>
   </div>
 
   <div id="tidyBanner">🧹 Tidy-up time! Tap the flashing blocks! 🏡<button id="tidyForMeBtn">🪄 Tidy for me!</button></div>

--- a/public/roadsafety/game.js
+++ b/public/roadsafety/game.js
@@ -2156,17 +2156,18 @@ function drawHUD(){
   drawSpeedStreaks();
   const sc = Math.round(S.score), lim = currentLimit();
 
-  // glass top bar
+  // glass top bar — starts right of the Exit + Pause buttons (ABE canon corner)
+  const BARX = 132;
   ctx.fillStyle = "rgba(13,27,42,.78)";
-  rounded(8, 8, W - 16, 48, 12); ctx.fill();
+  rounded(BARX, 8, W - BARX - 8, 48, 12); ctx.fill();
   ctx.textAlign = "left"; ctx.font = "bold 17px sans-serif";
   ctx.fillStyle = sc >= 70 ? "#7ae582" : sc >= 40 ? "#ffd23f" : "#ff6b6b";
-  ctx.fillText(`🛡 ${sc}`, 20, 30);
+  ctx.fillText(`🛡 ${sc}`, BARX + 12, 30);
   ctx.font = "9px sans-serif"; ctx.fillStyle = "#9fb3c8";
-  ctx.fillText("SAFETY SCORE", 20, 46);
+  ctx.fillText("SAFETY SCORE", BARX + 12, 46);
 
   // progress
-  const bx = 116, bw = W - 240;
+  const bx = BARX + 124, bw = W - 124 - bx;
   ctx.fillStyle = "rgba(255,255,255,.18)"; rounded(bx, 20, bw, 10, 5); ctx.fill();
   ctx.fillStyle = "#4ea8de"; rounded(bx, 20, Math.max(8, bw * clamp(S.t / S.rt.len, 0, 1)), 10, 5); ctx.fill();
   for (const ev of S.events){

--- a/public/roadsafety/index.html
+++ b/public/roadsafety/index.html
@@ -95,7 +95,7 @@ try{
   <div id="touch" class="hidden">
     <!-- kit-standard joystick (same as every other ABE game): steer left/right,
          push up to GO, pull down to STOP — the elephant rides the knob -->
-    <div id="rsStick" title="Steer with the stick — push up to go, pull down to stop">
+    <div id="rsStick" title="Steer with the stick — push up to go, pull down to stop"><span class="abeJoyArrow" style="top:6px;left:50%;transform:translateX(-50%)">▲</span><span class="abeJoyArrow" style="bottom:6px;left:50%;transform:translateX(-50%)">✋</span><span class="abeJoyArrow" style="left:8px;top:50%;transform:translateY(-50%)">◀</span><span class="abeJoyArrow" style="right:8px;top:50%;transform:translateY(-50%)">▶</span>
       <div id="rsKnob"><img src="/abe-logo.png" alt=""></div>
     </div>
     <div class="tgroup right">

--- a/public/roadsafety/style.css
+++ b/public/roadsafety/style.css
@@ -366,6 +366,7 @@ h2 { color: #1d3461; font-size: clamp(19px, 4.4vmin, 28px); }
   background: rgba(255,255,255,.35); box-shadow: inset 0 0 0 3px rgba(255,255,255,.6);
   position: relative; touch-action: none;
 }
+.abeJoyArrow{position:absolute;font-size:13px;font-weight:900;color:#fff;text-shadow:0 2px 5px rgba(58,58,90,.5);pointer-events:none;z-index:1;}
 #rsKnob {
   position: absolute; left: 50%; top: 50%; width: 56px; height: 56px; border-radius: 50%;
   background: #fff; box-shadow: 0 4px 10px rgba(40,40,90,.25);


### PR DESCRIPTION
Re-lands the lost canon polish: joystick direction arrows in every game (kit, Elly, Magnet Blocks, Helping Hands, Road Safety with hand-for-stop); Road Safety's canvas banner starts beside Exit/Pause; Helping Hands headers clear the Exit. The CI workflow edit is excluded (needs the web-UI paste). All checks green: tsc, control checker, placement/click smoke × 8.