### PR TITLE
Spanish: AI-translation disclaimer + Floating Islands quest content

### DIFF
--- a/components/game/BelusWorld/three/quest/advancedQuests.ts
+++ b/components/game/BelusWorld/three/quest/advancedQuests.ts
@@ -17,6 +17,7 @@
 import type { Quest, Orb } from './quests';
 import type { Mood } from './QuestNPC';
 import type { ActivityZone } from '../../belu/progress';
+import { isEs } from '../../../../../lib/lang';
 
 /** The four advanced zone ids — a subset of ActivityZone. */
 export type AdvancedZone = Extract<ActivityZone, 'garden' | 'deepforest' | 'lagoon' | 'bay'>;
@@ -34,7 +35,7 @@ function opt(emoji: string, caption: string, correct = false): Orb {
 // FEELINGS GARDEN 🌷 — Advanced Feelings (sister island of meadow)
 // ===========================================================================
 
-const GARDEN: AdvancedQuest[] = [
+const GARDEN_EN: AdvancedQuest[] = [
   {
     zone: 'garden', level: 1, goal: 'Two feelings at once',
     intro: "Welcome to my garden! Sometimes we feel TWO feelings at the same time. Both are okay.",
@@ -175,11 +176,154 @@ const GARDEN: AdvancedQuest[] = [
   },
 ];
 
+const GARDEN_ES: AdvancedQuest[] = [
+  {
+    zone: 'garden', level: 1, goal: 'Dos sentimientos a la vez',
+    intro: '¡Bienvenido a mi jardín! A veces sentimos DOS sentimientos al mismo tiempo. Los dos están bien.',
+    outro: 'Ya sabes que dos sentimientos pueden pasar juntos. ¡Eso lo sabe un niño grande!',
+    moment: 'leyó sentimientos mezclados en el jardín',
+    rounds: [
+      { kind: 'choice', say: 'Es el primer día de Bea en una clase nueva. Se siente feliz Y nerviosa. ¿Pueden ser verdad las dos cosas?',
+        npc: { face: '🐛', mood: MOOD('neutral'), thought: { emoji: '🏫' } },
+        options: [
+          opt('✅', 'Sí, las dos a la vez', true),
+          opt('❌', 'No, solo un sentimiento'),
+        ], doneLine: '¡Sí! Feliz y nerviosa pueden estar las dos. Las dos están bien.' },
+      { kind: 'multiPick', say: 'Camina hacia LOS DOS sentimientos que Bea podría tener en su primer día.', picks: 2,
+        npc: { face: '🐛', mood: MOOD('neutral'), thought: { emoji: '🏫' } },
+        options: [
+          opt('🤩', 'emocionada', true),
+          opt('😟', 'un poco nerviosa', true),
+          opt('😡', 'enojada'),
+          opt('😴', 'aburrida'),
+        ], doneLine: 'Emocionada Y un poco nerviosa — las dos a la vez. Eso le pasa a todos.' },
+      { kind: 'choice', say: 'Sol va de viaje divertido, pero va a extrañar a su perro. ¿Qué dos sentimientos van mejor?',
+        npc: { face: '🦋', mood: MOOD('neutral'), thought: { emoji: '🧳' } },
+        options: [
+          opt('🥹', 'emocionado y un poco triste', true),
+          opt('😡', 'solo enojado'),
+          opt('😐', 'solo aburrido'),
+        ], doneLine: 'Emocionado por el viaje, y un poco triste por extrañar a su perro — las dos son verdad.' },
+    ],
+  },
+  {
+    zone: 'garden', level: 2, goal: 'La cara no siempre dice el sentimiento',
+    intro: 'Una cara no siempre muestra el sentimiento verdadero de adentro. Vamos a mirar más de cerca.',
+    outro: '¡Miraste más allá de la cara y encontraste el sentimiento verdadero. Eso es notar muy bien!',
+    moment: 'miró más allá de las caras en el jardín',
+    rounds: [
+      { kind: 'choice', say: 'Milo está sonriendo, pero bosteza y sus ojos se ven pesados. ¿Cómo podría sentirse Milo en verdad?',
+        npc: { face: '🦋', mood: MOOD('happy'), thought: { emoji: '😪' } },
+        options: [
+          opt('😴', 'cansado, aunque sonría', true),
+          opt('😡', 'enojado'),
+          opt('😨', 'asustado'),
+        ], doneLine: 'Una sonrisa puede esconder un sentimiento de cansancio adentro. Buena observación.' },
+      { kind: 'choice', say: 'Pip dice "estoy bien" pero su voz es bajita y mira al piso. ¿Qué podría ser verdad?',
+        npc: { face: '🐛', mood: MOOD('neutral'), thought: { emoji: '🤔' } },
+        options: [
+          opt('😞', 'Podría sentirse triste por dentro', true),
+          opt('🤩', 'Está muy emocionada'),
+          opt('😤', 'Está muy enojada'),
+        ], doneLine: 'A veces "estoy bien" esconde un sentimiento. Es amable preguntarle cómo está.' },
+      { kind: 'choice', say: '¿Qué es amable decir si crees que la cara de un amigo no coincide con cómo se siente?',
+        npc: { face: '🦋', mood: MOOD('calm') },
+        options: [
+          opt('💬', '¿De verdad estás bien?', true),
+          opt('🙉', 'Nada, solo adivina'),
+          opt('😏', 'Te ves bien'),
+        ], doneLine: '"¿De verdad estás bien?" le da a un amigo la oportunidad de contarte.' },
+    ],
+  },
+  {
+    zone: 'garden', level: 3, goal: 'Notar los sentimientos de un amigo por lo que pasó',
+    intro: 'Podemos adivinar el sentimiento de un amigo recordando lo que le acaba de pasar.',
+    outro: '¡Notaste los sentimientos por lo que pasó — eso es empatía de verdad!',
+    moment: 'notó los sentimientos de un amigo en el jardín',
+    rounds: [
+      { kind: 'choice', say: 'La torre de bloques de Sam se acaba de caer con un golpe fuerte. ¿Cómo se siente Sam ahora mismo?',
+        npc: { face: '🐛', mood: MOOD('sad'), thought: { emoji: '🧱' } },
+        options: [
+          opt('😞', 'triste o frustrado', true),
+          opt('🤩', 'emocionado'),
+          opt('😴', 'aburrido'),
+        ], doneLine: 'A la mayoría de nosotros una torre que se cae también nos haría sentir tristes o frustrados.' },
+      { kind: 'choice', say: 'El globo de Lulu se acaba de volar hacia el cielo. ¿Cómo se siente Lulu?',
+        npc: { face: '🦋', mood: MOOD('disappointed'), thought: { emoji: '🎈' } },
+        options: [
+          opt('😞', 'decepcionada', true),
+          opt('😌', 'tranquila'),
+          opt('🏆', 'orgullosa'),
+        ], doneLine: 'Perder un globo da decepción — eso tiene sentido.' },
+      { kind: 'choice', say: 'El amigo de Otto se tuvo que mudar a un pueblo nuevo. ¿Cómo podría sentirse Otto?',
+        npc: { face: '🐛', mood: MOOD('sad'), thought: { emoji: '📦' } },
+        options: [
+          opt('😢', 'triste, extrañando a su amigo', true),
+          opt('😄', 'feliz'),
+          opt('😲', 'sorprendido'),
+        ], doneLine: 'Extrañar a un amigo que se mudó es un sentimiento real y triste.' },
+    ],
+  },
+  {
+    zone: 'garden', level: 4, goal: 'Ayudar a un amigo triste',
+    intro: 'Cuando un amigo se siente triste, hay maneras suaves de ayudar. Vamos a practicar.',
+    outro: 'Sabes justo cómo ayudar a un amigo triste. Eso es bondad de verdad.',
+    moment: 'ayudó a un amigo triste en el jardín',
+    rounds: [
+      { kind: 'choice', say: 'La torre de Sam se cayó y se ve triste. ¿Cuál es un buen primer paso amable?',
+        npc: { face: '🐛', mood: MOOD('sad'), thought: { emoji: '🧱' } },
+        options: [
+          opt('🧎', 'Sentarte con él', true),
+          opt('😆', 'Reírte'),
+          opt('🚶', 'Irte caminando'),
+        ], doneLine: 'Sentarte con un amigo triste le muestra que no está solo.' },
+      { kind: 'choice', say: 'Sam sigue triste por la torre. ¿Qué le puedes ofrecer después?',
+        npc: { face: '🐛', mood: MOOD('sad'), thought: { emoji: '🧱' } },
+        options: [
+          opt('🤝', 'Ofrecerte a ayudar a reconstruirla', true),
+          opt('🙅', 'Decirle que deje de estar triste'),
+          opt('🏃', 'Irte a jugar a otro lado'),
+        ], doneLine: 'Ofrecerte a ayudar es una manera hermosa de mostrar que te importa.' },
+      { kind: 'choice', say: 'Sam TODAVÍA está muy triste, aunque te sentaste y ayudaste. ¿Cuál es un buen siguiente paso?',
+        npc: { face: '🐛', mood: MOOD('sad'), thought: { emoji: '💭' } },
+        options: [
+          opt('🙋', 'Buscar a una persona adulta', true),
+          opt('🤐', 'No decir nada'),
+          opt('😤', 'Alterarte también'),
+        ], doneLine: 'Cuando un sentimiento es grande, buscar a una persona adulta es una gran idea.' },
+    ],
+  },
+  {
+    zone: 'garden', level: 5, goal: 'Mis sentimientos cambian como las nubes',
+    intro: 'Los sentimientos se mueven y cambian, como las nubes que pasan. Un sentimiento grande ahora no dura para siempre.',
+    outro: 'Aprendiste que los sentimientos pasan, como las nubes en el cielo. Siempre volverás a sentirte tranquilo.',
+    moment: 'aprendió que los sentimientos pasan en el jardín',
+    rounds: [
+      { kind: 'choice', say: 'Bea se sintió muy enojada cuando pausaron su juego. Un rato después, ¿cómo podría sentirse?',
+        npc: { face: '🦋', mood: MOOD('angry'), thought: { emoji: '⏸️' } },
+        options: [
+          opt('😌', 'tranquila otra vez, después de un rato', true),
+          opt('😡', 'enojada para siempre'),
+        ], doneLine: 'Sí — hasta los sentimientos de mucho enojo pasan, como una nube que sigue su camino.' },
+      { kind: 'breathe', say: 'Vamos a ayudar a que un sentimiento grande pase, como una nube. Respira conmigo.',
+        npc: { face: '🦋', mood: MOOD('calm') }, cycles: 3,
+        doneLine: 'El sentimiento grande flotó y se fue, como una nube. Ahora te sientes más tranquilo.' },
+      { kind: 'steps', say: 'Camina el sendero de las nubes — mira cómo cada sentimiento pasa flotando, un paso a la vez.',
+        npc: { face: '🐛', mood: MOOD('calm') },
+        count: 4,
+        labels: ['Enojado ☁️', 'Un poco más tranquilo ⛅', 'Más tranquilo aún 🌤️', 'Tranquilo otra vez ☀️'],
+        doneLine: 'De enojado, a tranquilo — los sentimientos de verdad cambian, como las nubes que pasan.' },
+    ],
+  },
+];
+
+const GARDEN = isEs() ? GARDEN_EN.map((item, i) => GARDEN_ES[i] ?? item) : GARDEN_EN;
+
 // ===========================================================================
 // DEEP FOREST 🌲 — Advanced Friendship & Words (sister island of forest)
 // ===========================================================================
 
-const DEEPFOREST: AdvancedQuest[] = [
+const DEEPFOREST_EN: AdvancedQuest[] = [
   {
     zone: 'deepforest', level: 1, goal: 'Joining kids already playing',
     intro: "Some friends are already playing deep in the forest. Let's learn how to join in.",
@@ -319,11 +463,153 @@ const DEEPFOREST: AdvancedQuest[] = [
   },
 ];
 
+const DEEPFOREST_ES: AdvancedQuest[] = [
+  {
+    zone: 'deepforest', level: 1, goal: 'Unirse a niños que ya están jugando',
+    intro: 'Algunos amigos ya están jugando en lo profundo del bosque. Vamos a aprender cómo unirnos.',
+    outro: '¡Aprendiste cómo pedir unirte a un juego. Eso toma mucho valor!',
+    moment: 'aprendió a unirse a un juego en el bosque profundo',
+    rounds: [
+      { kind: 'choice', say: 'Zorro y Conejita están jugando a las atrapadas sin ti. ¿Qué puedes decir?',
+        npc: { face: '🦌', mood: MOOD('happy'), thought: { emoji: '🏃' } },
+        options: [
+          opt('🙋', '¿Puedo jugar también?', true),
+          opt('🤐', 'No decir nada y solo mirar'),
+          opt('😤', 'Agarrar la pelota y correr'),
+        ], doneLine: '"¿Puedo jugar también?" es una gran manera de preguntar.' },
+      { kind: 'choice', say: 'Preguntaste "¿Puedo jugar también?" — ¿ahora qué haces?',
+        npc: { face: '🦊', mood: MOOD('happy'), thought: { emoji: '❓' } },
+        options: [
+          opt('⏳', 'Esperar su respuesta', true),
+          opt('🏃', 'Empezar a jugar de una vez sin esperar'),
+        ], doneLine: 'Esperar la respuesta es amable y educado.' },
+      { kind: 'choice', say: 'Zorro dice "¡Sí, ven a jugar!" ¿Qué haces?',
+        npc: { face: '🦊', mood: MOOD('happy'), thought: { emoji: '✅' } },
+        options: [
+          opt('🎉', 'Unirte feliz', true),
+          opt('🙅', 'Decir que no gracias'),
+        ], doneLine: '¡Te uniste al juego. Muy bien preguntado!' },
+    ],
+  },
+  {
+    zone: 'deepforest', level: 2, goal: 'Cuando un amigo dice que no',
+    intro: 'A veces un amigo dice que no, y eso también está bien. Vamos a aprender qué hacer.',
+    outro: "Aprendiste que 'no' está bien, y siempre hay otro juego. Muy bien hecho.",
+    moment: 'aprendió qué hacer cuando un amigo dice que no en el bosque profundo',
+    rounds: [
+      { kind: 'choice', say: 'Preguntas "¿Puedo jugar también?" y Oso dice "Ahora no." ¿Cómo te sientes primero?',
+        npc: { face: '🐻', mood: MOOD('neutral'), thought: { emoji: '🙅' } },
+        options: [
+          opt('😞', 'Un poco decepcionado — y eso está bien', true),
+          opt('😡', 'Tengo que gritar'),
+        ], doneLine: 'Está bien sentirse un poco decepcionado. Ese sentimiento pasa.' },
+      { kind: 'choice', say: 'Oso dijo ahora no. ¿Qué puedes hacer después?',
+        npc: { face: '🐻', mood: MOOD('neutral') },
+        options: [
+          opt('🔍', 'Buscar otro juego para jugar', true),
+          opt('😤', 'Meterte de todos modos'),
+          opt('😭', 'Llorar fuerte frente a Oso'),
+        ], doneLine: 'Buscar otro juego mantiene tu día divertido.' },
+      { kind: 'choice', say: 'Tal vez más tarde todavía quieras jugar con Oso. ¿Qué puedes intentar?',
+        npc: { face: '🐻', mood: MOOD('happy') },
+        options: [
+          opt('🙋', 'Preguntar de nuevo más tarde', true),
+          opt('🙅', 'Nunca más preguntarle a Oso'),
+        ], doneLine: 'Preguntar de nuevo más tarde es una gran idea. "Ahora no" no es "nunca."' },
+    ],
+  },
+  {
+    zone: 'deepforest', level: 3, goal: 'Perder un juego con buena actitud',
+    intro: 'A veces no ganamos. Hay una manera amigable de perder un juego.',
+    outro: '¡Perdiste un juego con corazón amigable. Eso te hace divertido para jugar!',
+    moment: 'perdió un juego con buena actitud en el bosque profundo',
+    rounds: [
+      { kind: 'choice', say: 'Venado ganó la carrera y tú llegaste segundo. ¿Qué le dices a Venado?',
+        npc: { face: '🦌', mood: MOOD('proud'), thought: { emoji: '🏁' } },
+        options: [
+          opt('👏', '¡Buen juego!', true),
+          opt('😤', 'Eso no fue justo'),
+          opt('🙄', 'Ni siquiera intenté'),
+        ], doneLine: '"¡Buen juego!" muestra que puedes ser un amigo generoso.' },
+      { kind: 'choice', say: 'Te sientes un poco decepcionado por no haber ganado. ¿Qué puedes hacer con ese sentimiento?',
+        npc: { face: '🦌', mood: MOOD('neutral') },
+        options: [
+          opt('🌬️', 'Respirar hondo, está bien', true),
+          opt('😡', 'Patear el suelo'),
+        ], doneLine: 'Una respiración ayuda a que pase el sentimiento de decepción.' },
+      { kind: 'choice', say: '¿Cuál es un buen siguiente paso después de perder un juego?',
+        npc: { face: '🦌', mood: MOOD('happy') },
+        options: [
+          opt('🔁', 'Intentarlo de nuevo', true),
+          opt('🚪', 'Nunca jugar otra vez'),
+        ], doneLine: 'Intentarlo de nuevo es cómo mejoramos y nos divertimos más.' },
+    ],
+  },
+  {
+    zone: 'deepforest', level: 4, goal: 'No estar de acuerdo con amabilidad',
+    intro: 'Los amigos no siempre quieren lo mismo. Vamos a aprender a no estar de acuerdo con amabilidad.',
+    outro: '¡No estuviste de acuerdo con amabilidad y encontraste una respuesta justa. Eso es una gran habilidad de amistad!',
+    moment: 'no estuvo de acuerdo con amabilidad en el bosque profundo',
+    rounds: [
+      { kind: 'choice', say: 'Tú y Conejita quieren el bloque rojo. ¿Qué puedes decir?',
+        npc: { face: '🐰', mood: MOOD('neutral'), thought: { emoji: '🟥' } },
+        options: [
+          opt('💬', 'Yo quiero el rojo', true),
+          opt('😤', 'Agarrarlo y correr'),
+          opt('🤐', 'No decir nada y sentirte mal'),
+        ], doneLine: 'Decir lo que quieres con claridad es un buen primer paso.' },
+      { kind: 'choice', say: 'Conejita también quiere el bloque rojo. ¿Qué pueden intentar los dos?',
+        npc: { face: '🐰', mood: MOOD('neutral') },
+        options: [
+          opt('🔄', '¿Podemos turnarnos?', true),
+          opt('😡', 'Es mío, no hay turnos'),
+        ], doneLine: '"¿Podemos turnarnos?" es una manera justa y amable de resolverlo.' },
+      { kind: 'choice', say: 'Los dos aceptan turnarse. ¿Quién va primero se puede decidir con...?',
+        npc: { face: '🐰', mood: MOOD('happy') },
+        options: [
+          opt('🪙', 'Una elección justa, como una moneda al aire', true),
+          opt('😤', 'Quien lo agarre primero'),
+        ], doneLine: 'Una elección justa mantiene todo amigable para todos.' },
+    ],
+  },
+  {
+    zone: 'deepforest', level: 5, goal: 'Dar y recibir cumplidos',
+    intro: 'Las palabras amables sobre el trabajo de un amigo se llaman cumplidos. Vamos a practicar darlos y recibirlos.',
+    outro: '¡Diste y recibiste cumplidos con tanta amabilidad. Así crecen las amistades!',
+    moment: 'compartió cumplidos en el bosque profundo',
+    rounds: [
+      { kind: 'choice', say: 'Búho construyó una torre muy alta. ¿Qué cosa amable puedes decir?',
+        npc: { face: '🦉', mood: MOOD('proud'), thought: { emoji: '🗼' } },
+        options: [
+          opt('👏', '¡Wow, qué torre tan buena!', true),
+          opt('😐', 'Eso es aburrido'),
+          opt('🤐', 'No decir nada'),
+        ], doneLine: 'Un cumplido amable puede alegrarle todo el día a un amigo.' },
+      { kind: 'choice', say: 'Venado dice "¡Me encanta tu dibujo!" ¿Qué le dices de vuelta?',
+        npc: { face: '🦌', mood: MOOD('happy'), thought: { emoji: '🎨' } },
+        options: [
+          opt('😊', '¡Gracias!', true),
+          opt('🙅', 'No está bueno'),
+        ], doneLine: '"¡Gracias!" es la manera perfecta de recibir un cumplido.' },
+      { kind: 'multiPick', say: 'Camina hacia dos cosas amables que podrías decir sobre el trabajo de un amigo.', picks: 2,
+        npc: { face: '🦌', mood: MOOD('happy') },
+        options: [
+          opt('🌈', '¡Me encantan los colores!', true),
+          opt('💪', '¡Trabajaste tan duro!', true),
+          opt('😒', 'Podría estar mejor'),
+          opt('🥱', 'Eso es aburrido'),
+        ], doneLine: 'Esos son cumplidos maravillosos — a los amigos les encanta escucharlos.' },
+    ],
+  },
+];
+
+const DEEPFOREST = isEs() ? DEEPFOREST_EN.map((item, i) => DEEPFOREST_ES[i] ?? item) : DEEPFOREST_EN;
+
 // ===========================================================================
 // QUIET LAGOON 🪷 — Advanced Calm (sister island of cove)
 // ===========================================================================
 
-const LAGOON: AdvancedQuest[] = [
+const LAGOON_EN: AdvancedQuest[] = [
   {
     zone: 'lagoon', level: 1, goal: 'Noticing early body signals',
     intro: "Our body sends little signals before a big feeling grows. Let's learn to notice them early.",
@@ -445,11 +731,135 @@ const LAGOON: AdvancedQuest[] = [
   },
 ];
 
+const LAGOON_ES: AdvancedQuest[] = [
+  {
+    zone: 'lagoon', level: 1, goal: 'Notar señales tempranas del cuerpo',
+    intro: 'Nuestro cuerpo manda pequeñas señales antes de que crezca un sentimiento grande. Vamos a aprender a notarlas temprano.',
+    outro: '¡Notaste las señales tempranas en tu cuerpo. Eso es un superpoder para mantenerte tranquilo!',
+    moment: 'notó señales tempranas del cuerpo en la laguna',
+    rounds: [
+      { kind: 'choice', say: 'Antes de que crezca un sentimiento grande, tus manos podrían sentirse...',
+        npc: { face: '🐬', mood: MOOD('neutral'), thought: { emoji: '✊' } },
+        options: [
+          opt('✊', 'apretadas o tensas', true),
+          opt('🖐️', 'sueltas y flojas'),
+        ], doneLine: '¡Las manos apretadas pueden ser una señal temprana — buena observación!' },
+      { kind: 'choice', say: 'Tu corazón podría empezar a sentirse...',
+        npc: { face: '🐬', mood: MOOD('neutral'), thought: { emoji: '💓' } },
+        options: [
+          opt('💓', 'rápido, latiendo deprisa', true),
+          opt('💤', 'somnoliento y lento'),
+        ], doneLine: 'Un corazón rápido también puede ser una señal temprana.' },
+      { kind: 'choice', say: 'Cuando notas una señal como manos apretadas o corazón rápido, ¿cuál es un buen primer paso?',
+        npc: { face: '🐬', mood: MOOD('calm') },
+        options: [
+          opt('🌬️', 'Respirar con calma', true),
+          opt('🙈', 'Ignorarlo y seguir'),
+        ], doneLine: 'Notar temprano y respirar ayuda a que los sentimientos se mantengan pequeños y manejables.' },
+    ],
+  },
+  {
+    zone: 'lagoon', level: 2, goal: 'Una escalera de respiración más larga',
+    intro: 'Vamos a subir las piedras de calma — cinco respiraciones, una piedra a la vez.',
+    outro: '¡Subiste las cinco piedras de calma. Qué escalera de respiraciones tan tranquila!',
+    moment: 'subió la escalera de respiración en la laguna',
+    rounds: [
+      { kind: 'steps', say: 'Sube las piedras de calma conmigo — una respiración lenta en cada piedra.',
+        npc: { face: '🐬', mood: MOOD('calm') },
+        count: 5,
+        labels: ['Respira 1 🌊', 'Respira 2 🌊', 'Respira 3 🌊', 'Respira 4 🌊', 'Respira 5 🌊'],
+        doneLine: 'Cinco respiraciones lentas, cinco piedras de calma — ahora te sientes en paz.' },
+      { kind: 'breathe', say: 'Una respiración más juntos, solo porque se siente bien.',
+        npc: { face: '🐬', mood: MOOD('calm') }, cycles: 2,
+        doneLine: 'Tan tranquilo y en calma, como la laguna misma.' },
+    ],
+  },
+  {
+    zone: 'lagoon', level: 3, goal: 'Hacer un plan para lugares ruidosos',
+    intro: 'Los lugares ruidosos pueden sentirse abrumadores. Vamos a separar las ideas que ayudan de las que no.',
+    outro: '¡Armaste un plan inteligente para lugares ruidosos. Ya estás listo para cualquier lugar!',
+    moment: 'hizo un plan para lugares ruidosos en la laguna',
+    rounds: [
+      { kind: 'sort', say: '¡Vamos a separar ideas para lugares ruidosos! Lleva cada una a útil o no útil.',
+        npc: { face: '🐬', mood: MOOD('neutral'), thought: { emoji: '🔊' } },
+        tables: [
+          opt('✅', 'Útil'),
+          opt('❌', 'No útil'),
+        ],
+        items: [
+          { emoji: '🙉', caption: 'Taparte los oídos', table: 0 },
+          { emoji: '🙋', caption: 'Pedir un rincón tranquilo', table: 0 },
+          { emoji: '🌬️', caption: 'Respirar hondo', table: 0 },
+          { emoji: '😡', caption: 'Gritar más fuerte', table: 1 },
+          { emoji: '🏃', caption: 'Correr solo', table: 1 },
+        ],
+        doneLine: '¡Taparte los oídos, pedir tranquilidad, y respirar — eso sí ayuda!' },
+      { kind: 'choice', say: 'Un cuarto ruidoso se siente abrumador ahora mismo. ¿Qué intentas primero?',
+        npc: { face: '🐬', mood: MOOD('neutral'), thought: { emoji: '🔊' } },
+        options: [
+          opt('🙉', 'Taparme los oídos', true),
+          opt('😡', 'Gritar más fuerte'),
+        ], doneLine: 'Taparte los oídos es un gran primer plan.' },
+    ],
+  },
+  {
+    zone: 'lagoon', level: 4, goal: 'Esperar con calma',
+    intro: 'Esperar puede sentirse largo. Vamos a practicar formas divertidas de esperar con calma.',
+    outro: '¡Esperaste con tanta calma con tus propios juegos de espera. Qué paciencia tan maravillosa!',
+    moment: 'practicó esperar con calma en la laguna',
+    rounds: [
+      { kind: 'multiPick', say: 'Camina hacia DOS juegos de espera que ayudan a que el tiempo pase con calma.', picks: 2,
+        npc: { face: '🐬', mood: MOOD('calm'), thought: { emoji: '⏳' } },
+        options: [
+          opt('🔢', 'Contar despacio', true),
+          opt('✊', 'Apretar mis manos', true),
+          opt('😡', 'Gritar "¡apúrate!"'),
+          opt('🏃', 'Correr por todos lados haciendo ruido'),
+        ], doneLine: 'Contar y apretar las manos son grandes maneras de esperar con calma.' },
+      { kind: 'steps', say: 'Vamos a contar despacio juntos mientras esperamos, un número a la vez.',
+        npc: { face: '🐬', mood: MOOD('calm') },
+        count: 5,
+        doneLine: 'Uno, dos, tres, cuatro, cinco — se acabó la espera, ¡y te mantuviste tan tranquilo!' },
+      { kind: 'choice', say: 'Mientras esperas, pensar en tu cosa favorita puede ayudar. ¿Cuál es una buena favorita para pensar?',
+        npc: { face: '🐬', mood: MOOD('calm'), thought: { emoji: '💭' } },
+        options: [
+          opt('🌟', 'Mi cosa favorita', true),
+          opt('😤', 'Qué lento va esto'),
+        ], doneLine: 'Pensar en una cosa favorita hace que la espera se sienta más corta.' },
+    ],
+  },
+  {
+    zone: 'lagoon', level: 5, goal: 'Cuando los planes cambian',
+    intro: 'A veces los planes cambian sin avisar. Vamos a practicar pensar en una idea nueva.',
+    outro: '¡Encontraste un plan nuevo cuando el viejo cambió. Eso es pensamiento flexible — qué fuerte!',
+    moment: 'manejó un plan que cambió en la laguna',
+    rounds: [
+      { kind: 'choice', say: 'El parque está cerrado hoy, y ese era el plan. ¿Cómo podrías sentirte primero?',
+        npc: { face: '🐬', mood: MOOD('disappointed'), thought: { emoji: '🚫' } },
+        options: [
+          opt('😞', 'Un poco decepcionado — y eso está bien', true),
+          opt('😡', 'Tengo que gritar por eso'),
+        ], doneLine: 'Sentirte decepcionado cuando un plan cambia está bien.' },
+      { kind: 'breathe', say: 'Vamos a respirar juntos para pasar la sorpresa.',
+        npc: { face: '🐬', mood: MOOD('calm') }, cycles: 2,
+        doneLine: 'Una respiración con calma abre espacio para una idea nueva.' },
+      { kind: 'choice', say: 'El parque está cerrado. ¿Qué podemos hacer en su lugar?',
+        npc: { face: '🐬', mood: MOOD('calm'), thought: { emoji: '❓' } },
+        options: [
+          opt('🏠', 'Pensar en algo divertido para hacer en casa', true),
+          opt('😤', 'Quedarte molesto todo el día'),
+        ], doneLine: 'Encontrar un plan nuevo convierte un momento difícil en uno bueno.' },
+    ],
+  },
+];
+
+const LAGOON = isEs() ? LAGOON_EN.map((item, i) => LAGOON_ES[i] ?? item) : LAGOON_EN;
+
 // ===========================================================================
 // TREASURE BAY ⛵ — Advanced Sharing & Cooperation (sister island of shore)
 // ===========================================================================
 
-const BAY: AdvancedQuest[] = [
+const BAY_EN: AdvancedQuest[] = [
   {
     zone: 'bay', level: 1, goal: 'Borrowing and returning',
     intro: "Sometimes we borrow a friend's thing. Let's practice asking, and giving it back.",
@@ -584,6 +994,143 @@ const BAY: AdvancedQuest[] = [
   },
 ];
 
+const BAY_ES: AdvancedQuest[] = [
+  {
+    zone: 'bay', level: 1, goal: 'Pedir prestado y devolver',
+    intro: 'A veces le pedimos algo prestado a un amigo. Vamos a practicar pedirlo, y devolverlo.',
+    outro: '¡Pediste prestado y devolviste con tanta amabilidad. Eso construye confianza entre amigos!',
+    moment: 'practicó pedir prestado y devolver en la bahía',
+    rounds: [
+      { kind: 'choice', say: 'Perico tiene una pala que quieres usar. ¿Qué le dices?',
+        npc: { face: '🦜', mood: MOOD('happy'), thought: { emoji: '🪏' } },
+        options: [
+          opt('🙋', '¿Me la prestas?', true),
+          opt('🤚', 'Tomarla sin preguntar'),
+        ], doneLine: '"¿Me la prestas?" es la manera amable de preguntar.' },
+      { kind: 'choice', say: 'Ya terminaste de usar la pala. ¿Qué haces ahora?',
+        npc: { face: '🦜', mood: MOOD('happy') },
+        options: [
+          opt('🔙', 'Devolverla y decir gracias', true),
+          opt('🙅', 'Quedártela'),
+        ], doneLine: '"Aquí la tienes de vuelta — ¡gracias!" Así funciona pedir prestado.' },
+      { kind: 'choice', say: 'Perico dice "¡Gracias por traerla de vuelta!" ¿Cómo te sientes?',
+        npc: { face: '🦜', mood: MOOD('happy') },
+        options: [
+          opt('😊', 'Feliz — fui un buen amigo', true),
+          opt('😐', 'No importa'),
+        ], doneLine: 'Que confíen en ti con cosas prestadas se siente muy bien.' },
+    ],
+  },
+  {
+    zone: 'bay', level: 2, goal: 'Intercambiar y llegar a un acuerdo',
+    intro: 'A veces dos amigos quieren cosas diferentes. Un intercambio puede hacer felices a los dos.',
+    outro: '¡Hiciste un intercambio justo. Llegar a un acuerdo hace que todos ganen!',
+    moment: 'hizo un intercambio justo en la bahía',
+    rounds: [
+      { kind: 'choice', say: 'Tú tienes una concha azul, Tortuga tiene una rosada. A los dos les gusta la del otro. ¿Qué pueden intentar?',
+        npc: { face: '🐢', mood: MOOD('neutral'), thought: { emoji: '🐚' } },
+        options: [
+          opt('🔄', 'Intercambiar las conchas', true),
+          opt('🙅', 'Quedarte con la tuya y tomar la de ella también'),
+        ], doneLine: '¡Un intercambio significa que los dos se quedan con algo que les gusta!' },
+      { kind: 'choice', say: 'Los dos quieren elegir el juego primero. ¿Cuál es una manera justa de decidir?',
+        npc: { face: '🦜', mood: MOOD('neutral') },
+        options: [
+          opt('🥇', 'Tú eliges primero esta vez, yo elijo la próxima', true),
+          opt('😤', 'Yo siempre elijo primero'),
+        ], doneLine: 'Turnarse para elegir es un acuerdo justo.' },
+      { kind: 'choice', say: 'Salió justo para los dos. ¿Cómo se sienten ambos?',
+        npc: { face: '🐢', mood: MOOD('happy') },
+        options: [
+          opt('😊', 'Felices, se sintió justo', true),
+          opt('😤', 'Todavía molestos'),
+        ], doneLine: 'Un intercambio justo deja a todos sintiéndose bien.' },
+    ],
+  },
+  {
+    zone: 'bay', level: 3, goal: 'Construir juntos',
+    intro: 'Vamos a construir un castillo de arena juntos, una pieza a la vez — turnándonos para agregar.',
+    outro: '¡Construyeron todo el castillo juntos, turno por turno. Se ve aún mejor hecho en equipo!',
+    moment: 'construyó un castillo de arena junto a otro en la bahía',
+    rounds: [
+      { kind: 'choice', say: 'Un montón de arena, dos constructores. ¿Cómo deberían empezar?',
+        npc: { face: '🦜', mood: MOOD('excited'), thought: { emoji: '🏰' } },
+        options: [
+          opt('🤝', 'Turnarse para agregar piezas', true),
+          opt('🙅', 'Construir por separado sin turnos'),
+        ], doneLine: 'Turnarse significa que el castillo se construye de verdad en equipo.' },
+      { kind: 'carry', say: '¡Vamos a construirlo! Lleva cada pieza al castillo, un turno a la vez — tu pieza, mi pieza, tu pieza.',
+        npc: { face: '🦜', mood: MOOD('happy') },
+        items: [
+          { emoji: '🧱', caption: 'mi pieza' },
+          { emoji: '🐚', caption: 'la pieza de Perico' },
+          { emoji: '🚩', caption: 'mi pieza' },
+        ],
+        doneLine: '¡Pieza por pieza, turno por turno — el castillo creció alto!' },
+      { kind: 'choice', say: '¡El castillo está terminado! ¿Cómo te sientes por haberlo construido juntos?',
+        npc: { face: '🦜', mood: MOOD('proud'), thought: { emoji: '🏰' } },
+        options: [
+          opt('🎉', '¡Orgulloso — lo construimos juntos!', true),
+          opt('😤', 'Deseo haberlo construido solo'),
+        ], doneLine: '"¡Lo construimos juntos!" — el mejor tipo de orgullo.' },
+    ],
+  },
+  {
+    zone: 'bay', level: 4, goal: 'Cuando solo hay uno',
+    intro: 'Solo un bote, y dos amigos que quieren pasear. Vamos a encontrar maneras justas de compartirlo.',
+    outro: '¡Encontraste maneras justas de compartir una sola cosa. Eso toma verdadero trabajo en equipo!',
+    moment: 'compartió algo con justicia en la bahía',
+    rounds: [
+      { kind: 'choice', say: 'Solo hay un bote, y tanto tú como Tortuga quieren pasear. ¿Cuál es una idea justa?',
+        npc: { face: '🐢', mood: MOOD('neutral'), thought: { emoji: '⛵' } },
+        options: [
+          opt('⏱️', 'Turnarse con un cronómetro', true),
+          opt('😤', 'Quien llegue primero se lo queda'),
+        ], doneLine: 'Un cronómetro hace que los turnos sean justos para todos.' },
+      { kind: 'choice', say: 'El bote es suficientemente grande para dos. ¿Qué más podrían intentar?',
+        npc: { face: '🐢', mood: MOOD('happy') },
+        options: [
+          opt('🤝', 'Pasear juntos', true),
+          opt('🙅', 'Empujar a Tortuga fuera'),
+        ], doneLine: '¡Pasear juntos significa que nadie tiene que esperar nada!' },
+      { kind: 'choice', say: 'Si no pueden pasear juntos ni usar un cronómetro, ¿cuál es otra idea justa?',
+        npc: { face: '🦜', mood: MOOD('neutral') },
+        options: [
+          opt('🎲', 'Elegir juntos, con algo justo', true),
+          opt('😡', 'Discutir hasta que alguien se rinda'),
+        ], doneLine: 'Elegir juntos, con justicia, mantiene a todos como amigos.' },
+    ],
+  },
+  {
+    zone: 'bay', level: 5, goal: 'Celebrar la victoria de un amigo',
+    intro: 'Cuando un amigo gana o hace algo genial, podemos celebrar CON él.',
+    outro: '¡Celebraste la victoria de un amigo con todo tu corazón. Eso es amistad de verdad!',
+    moment: 'celebró la victoria de un amigo en la bahía',
+    rounds: [
+      { kind: 'choice', say: '¡Tortuga acaba de ganar la carrera de natación! ¿Qué puedes hacer?',
+        npc: { face: '🐢', mood: MOOD('proud'), thought: { emoji: '🏆' } },
+        options: [
+          opt('👏', 'Aplaudir para Tortuga', true),
+          opt('😤', 'Mirar hacia otro lado, molesto'),
+        ], doneLine: 'Aplaudir por un amigo muestra que estás feliz por él.' },
+      { kind: 'choice', say: '¿Qué palabras amables le puedes decir a Tortuga?',
+        npc: { face: '🐢', mood: MOOD('proud') },
+        options: [
+          opt('🎉', '¡Felicidades, gran trabajo!', true),
+          opt('😒', 'Solo tuviste suerte'),
+        ], doneLine: '"¡Felicidades, gran trabajo!" hace que quien gana se sienta visto de verdad.' },
+      { kind: 'choice', say: 'No ganaste esta vez, pero animaste a Tortuga. ¿Cómo se puede sentir eso?',
+        npc: { face: '🦜', mood: MOOD('happy') },
+        options: [
+          opt('💖', 'Bien — estar feliz por otros también se siente bonito', true),
+          opt('😡', 'Solo mal'),
+        ], doneLine: 'Estar feliz por un amigo es su propio tipo de victoria.' },
+    ],
+  },
+];
+
+const BAY = isEs() ? BAY_EN.map((item, i) => BAY_ES[i] ?? item) : BAY_EN;
+
 // ===========================================================================
 
 export const ADVANCED_QUESTS: Record<AdvancedZone, AdvancedQuest[]> = {
@@ -601,7 +1148,7 @@ export function getAdvancedQuest(zone: AdvancedZone, level: number): AdvancedQue
 }
 
 /** Suggested Day Book sticker entries for each advanced level, 'garden-1'..'bay-5'. */
-export const ADVANCED_STICKERS: Record<string, { emoji: string; label: string }> = {
+const ADVANCED_STICKERS_EN: Record<string, { emoji: string; label: string }> = {
   'garden-1': { emoji: '🌦️', label: 'Mixed feelings are okay! 🌦️' },
   'garden-2': { emoji: '🎭', label: 'A face doesn\'t always tell it all! 🎭' },
   'garden-3': { emoji: '🧠', label: 'I can guess how a friend feels! 🧠' },
@@ -623,3 +1170,30 @@ export const ADVANCED_STICKERS: Record<string, { emoji: string; label: string }>
   'bay-4': { emoji: '⛵', label: 'When there is only one, we share it fairly! ⛵' },
   'bay-5': { emoji: '🎉', label: 'I celebrate my friend\'s win! 🎉' },
 };
+
+const ADVANCED_STICKERS_ES: Record<string, { emoji: string; label: string }> = {
+  'garden-1': { emoji: '🌦️', label: '¡Los sentimientos mezclados están bien! 🌦️' },
+  'garden-2': { emoji: '🎭', label: '¡Una cara no siempre lo dice todo! 🎭' },
+  'garden-3': { emoji: '🧠', label: '¡Puedo adivinar cómo se siente un amigo! 🧠' },
+  'garden-4': { emoji: '🤗', label: '¡Sé cómo ayudar a un amigo triste! 🤗' },
+  'garden-5': { emoji: '☁️', label: '¡Los sentimientos pasan, como las nubes! ☁️' },
+  'deepforest-1': { emoji: '🙋', label: '¿Puedo jugar también? ¡Sé cómo preguntar! 🙋' },
+  'deepforest-2': { emoji: '🔍', label: '¡Cuando un amigo dice que no, busco otro juego! 🔍' },
+  'deepforest-3': { emoji: '👏', label: '¡Buen juego! ¡Puedo perder con una sonrisa! 👏' },
+  'deepforest-4': { emoji: '🔄', label: '¿Podemos turnarnos? ¡No estoy de acuerdo con amabilidad! 🔄' },
+  'deepforest-5': { emoji: '💛', label: '¡Doy y recibo cumplidos! 💛' },
+  'lagoon-1': { emoji: '✊', label: '¡Noto temprano las manos apretadas y el corazón rápido! ✊' },
+  'lagoon-2': { emoji: '🪨', label: '¡Cinco respiraciones de calma, cinco piedras de calma! 🪨' },
+  'lagoon-3': { emoji: '🔊', label: '¡Tengo un plan para lugares ruidosos! 🔊' },
+  'lagoon-4': { emoji: '⏳', label: '¡Puedo esperar con calma con mis propios juegos! ⏳' },
+  'lagoon-5': { emoji: '🔀', label: '¡Cuando los planes cambian, pienso en algo nuevo! 🔀' },
+  'bay-1': { emoji: '🔙', label: '¡Pido prestado con amabilidad y lo devuelvo! 🔙' },
+  'bay-2': { emoji: '🔄', label: '¡Puedo intercambiar y llegar a un acuerdo! 🔄' },
+  'bay-3': { emoji: '🏰', label: '¡Lo construimos juntos, turno por turno! 🏰' },
+  'bay-4': { emoji: '⛵', label: '¡Cuando solo hay uno, lo compartimos con justicia! ⛵' },
+  'bay-5': { emoji: '🎉', label: '¡Celebro la victoria de mi amigo! 🎉' },
+};
+
+export const ADVANCED_STICKERS = isEs()
+  ? Object.fromEntries(Object.entries(ADVANCED_STICKERS_EN).map(([k, v]) => [k, ADVANCED_STICKERS_ES[k] ?? v]))
+  : ADVANCED_STICKERS_EN;

--- a/components/game/BelusWorld/three/quest/coveContent.ts
+++ b/components/game/BelusWorld/three/quest/coveContent.ts
@@ -14,6 +14,8 @@
 //   L5: build a calm plan — walk to 3 strategy totems in a row, then 1 breath.
 // ---------------------------------------------------------------------------
 
+import { isEs } from '../../../../../lib/lang';
+
 /** A totem the child walks Nilu into (or taps) — a body spot or a calm strategy. */
 export interface CoveTotem {
   emoji: string;
@@ -65,13 +67,25 @@ export interface CovePose {
   cue: string;
 }
 
-export const POSES: Record<string, CovePose> = {
+const POSES_EN: Record<string, CovePose> = {
   crisscross: { emoji: '🧘', name: 'Criss-cross sit', cue: 'Sit crossed and tall, just like me.' },
   tree: { emoji: '🌳', name: 'Tree pose', cue: 'Stand tall like a tree — arms up like branches!' },
   butterfly: { emoji: '🦋', name: 'Butterfly wings', cue: 'Flap your arms slowly, like soft butterfly wings.' },
   star: { emoji: '⭐', name: 'Star pose', cue: 'Arms and legs wide, like a bright star!' },
   turtle: { emoji: '🐢', name: 'Turtle curl', cue: 'Curl up small and hug your knees.' },
 };
+
+const POSES_ES: Record<string, CovePose> = {
+  crisscross: { emoji: '🧘', name: 'Sentado con piernas cruzadas', cue: 'Siéntate con las piernas cruzadas y la espalda recta, igual que yo.' },
+  tree: { emoji: '🌳', name: 'Postura del árbol', cue: '¡Ponte de pie bien alto, como un árbol — brazos arriba como ramas!' },
+  butterfly: { emoji: '🦋', name: 'Alas de mariposa', cue: 'Mueve tus brazos despacio, como suaves alas de mariposa.' },
+  star: { emoji: '⭐', name: 'Postura de estrella', cue: '¡Brazos y piernas bien abiertos, como una estrella brillante!' },
+  turtle: { emoji: '🐢', name: 'Tortuga enroscada', cue: 'Enróllate pequeñito y abraza tus rodillas.' },
+};
+
+export const POSES: Record<string, CovePose> = isEs()
+  ? Object.fromEntries(Object.keys(POSES_EN).map((k) => [k, POSES_ES[k] ?? POSES_EN[k]]))
+  : POSES_EN;
 
 /** One step of the five-senses grounding round: "find something you can ___". */
 export interface CoveSenseStep {
@@ -82,7 +96,7 @@ export interface CoveSenseStep {
 }
 
 /** Kind, gentle lines Nilu says as the child finds hidden shells (cycled). */
-export const SHELL_FINDS: string[] = [
+const SHELL_FINDS_EN: string[] = [
   'Ooh, a shiny shell! Hold it up to your ear — can you hear the sea? 🐚',
   'A sparkly treasure! You have good finding eyes. ✨',
   'Another one! The calm sea likes to leave us little gifts. 💙',
@@ -90,15 +104,37 @@ export const SHELL_FINDS: string[] = [
   'You found one more! What a collector you are. 🌟',
 ];
 
+const SHELL_FINDS_ES: string[] = [
+  '¡Uy, una concha brillante! Ponla junto a tu oreja — ¿puedes oír el mar? 🐚',
+  '¡Un tesoro brillante! Tienes buenos ojos para encontrar cosas. ✨',
+  '¡Otra más! Al mar tranquilo le gusta dejarnos regalitos. 💙',
+  '¡Una estrella de mar! Guárdala en tu bolsa de tesoros. ⭐',
+  '¡Encontraste una más! Qué buen coleccionista eres. 🌟',
+];
+
+export const SHELL_FINDS: string[] = isEs()
+  ? SHELL_FINDS_EN.map((item, i) => SHELL_FINDS_ES[i] ?? item)
+  : SHELL_FINDS_EN;
+
 /** Tiny gentle dolphin jokes for replay variety (chosen by a seed, never random). */
-export const DOLPHIN_JOKES: string[] = [
+const DOLPHIN_JOKES_EN: string[] = [
   'The dolphin squeaks: "What did the sea say to the shore? Nothing — it just waved!" 🌊',
   'The dolphin giggles: "I love calm days. They are just my-sea-tea!" 🫧',
   'The dolphin grins: "You breathe better than a whale, and they have HUGE lungs!" 🐳',
 ];
 
+const DOLPHIN_JOKES_ES: string[] = [
+  'El delfín chilla: "¿Qué le dijo el mar a la orilla? ¡Nada — solo la saludó con una ola!" 🌊',
+  'El delfín se ríe: "Me encantan los días tranquilos. ¡Son pura mar-avilla!" 🫧',
+  'El delfín sonríe: "¡Respiras mejor que una ballena, y eso que tienen pulmones ENORMES!" 🐳',
+];
+
+export const DOLPHIN_JOKES: string[] = isEs()
+  ? DOLPHIN_JOKES_EN.map((item, i) => DOLPHIN_JOKES_ES[i] ?? item)
+  : DOLPHIN_JOKES_EN;
+
 // Reused calm strategies (matches quests.ts CALM_STRATEGIES pedagogy).
-const STRATEGIES: CoveTotem[] = [
+const STRATEGIES_EN: CoveTotem[] = [
   { emoji: '🌬️', label: 'Deep breaths' },
   { emoji: '🤫', label: 'Quiet spot' },
   { emoji: '✊', label: 'Squeeze hands' },
@@ -107,15 +143,31 @@ const STRATEGIES: CoveTotem[] = [
   { emoji: '🤗', label: 'Get a big hug' },
 ];
 
+const STRATEGIES_ES: CoveTotem[] = [
+  { emoji: '🌬️', label: 'Respiraciones profundas' },
+  { emoji: '🤫', label: 'Lugar tranquilo' },
+  { emoji: '✊', label: 'Apretar las manos' },
+  { emoji: '✋', label: 'Pedir un descanso' },
+  { emoji: '🖐️', label: 'Contar hasta cinco' },
+  { emoji: '🤗', label: 'Un abrazo grande' },
+];
+
 // Body spots for the level-3 body scan (matches quests.ts L3 options).
-const BODY_SPOTS: CoveTotem[] = [
+const BODY_SPOTS_EN: CoveTotem[] = [
   { emoji: '🫄', label: 'Tummy' },
   { emoji: '🫁', label: 'Chest' },
   { emoji: '💪', label: 'Shoulders' },
   { emoji: '🤲', label: 'Hands' },
 ];
 
-export const COVE_LEVELS: CoveLevel[] = [
+const BODY_SPOTS_ES: CoveTotem[] = [
+  { emoji: '🫄', label: 'Pancita' },
+  { emoji: '🫁', label: 'Pecho' },
+  { emoji: '💪', label: 'Hombros' },
+  { emoji: '🤲', label: 'Manos' },
+];
+
+const COVE_LEVELS_EN: CoveLevel[] = [
   {
     goal: 'Calm the sea with 2 breaths',
     intro: "The cove is stormy today. Let's calm the sea together — follow the bubble and breathe with me.",
@@ -137,7 +189,7 @@ export const COVE_LEVELS: CoveLevel[] = [
     breatheCue: "Let's count 3 butterfly breaths together — follow the bubble.",
     shells: 4,
     dolphin: 'Splash! The dolphin leaps for joy because YOU made the sea so calm. 🐬',
-    pose: POSES.tree,
+    pose: POSES_EN.tree,
     counting: true,
   },
   {
@@ -146,11 +198,11 @@ export const COVE_LEVELS: CoveLevel[] = [
     outro: 'Calm in your body, calm in the sea. Beautiful! 🌈',
     moment: 'did a calm body check at the cove',
     cycles: 2,
-    pre: { kind: 'bodySpot', totems: BODY_SPOTS },
+    pre: { kind: 'bodySpot', totems: BODY_SPOTS_EN },
     breatheCue: 'Now breathe with me, sending calm to that spot — and watch the sea settle.',
     shells: 4,
     dolphin: 'A dolphin surfaces and nods, as if to say "well done, calm friend." 🐬',
-    pose: POSES.butterfly,
+    pose: POSES_EN.butterfly,
   },
   {
     goal: 'Pick a calm strategy, then breathe',
@@ -158,7 +210,7 @@ export const COVE_LEVELS: CoveLevel[] = [
     outro: 'Great choice — that really helps. The sea is calm and bright. 🌈',
     moment: 'chose a calm strategy at the cove',
     cycles: 1,
-    pre: { kind: 'pickOne', totems: STRATEGIES.slice(0, 4) },
+    pre: { kind: 'pickOne', totems: STRATEGIES_EN.slice(0, 4) },
     breatheCue: 'Now one calm breath together — let the sea grow calm.',
     shells: 5,
     dolphin: 'The dolphin spins a happy loop above the bright, calm water! 🐬',
@@ -174,9 +226,79 @@ export const COVE_LEVELS: CoveLevel[] = [
     outro: 'A wonderful calm plan — and a calm, sparkling sea! 🌈',
     moment: 'built my own calm plan at the cove',
     cycles: 1,
-    pre: { kind: 'plan', need: 3, totems: STRATEGIES },
+    pre: { kind: 'plan', need: 3, totems: STRATEGIES_EN },
     breatheCue: 'A wonderful plan! One calm breath to finish — and the sea is calm.',
     shells: 5,
     dolphin: 'A whole family of dolphins leaps in a happy line — your calm plan worked! 🐬',
   },
 ];
+
+const COVE_LEVELS_ES: CoveLevel[] = [
+  {
+    goal: 'Calma el mar con 2 respiraciones',
+    intro: 'El mar está agitado hoy. Vamos a calmar el mar juntos — sigue la burbuja y respira conmigo.',
+    outro: '¡Mira — el mar está calmado y brillante! Gracias por respirar conmigo. 🌈',
+    moment: 'calmó el mar agitado de la cala',
+    cycles: 2,
+    pre: { kind: 'none' },
+    breatheCue: 'Inhala mientras la burbuja crece, exhala mientras se encoge. Observa cómo se calma el mar.',
+    shells: 3,
+    dolphin: '¡Iii-iii! ¡Un delfín asoma para saludar y da una voltereta feliz! 🐬',
+  },
+  {
+    goal: 'Calma el mar con 3 respiraciones',
+    intro: 'La tormenta es un poco más grande ahora. Podemos lograrlo — una calma más larga juntos.',
+    outro: '¡Toda la cala brilla de color cian ahora. Calmaste el mar! 🌈',
+    moment: 'calmó el mar agitado de la cala',
+    cycles: 3,
+    pre: { kind: 'none' },
+    breatheCue: 'Contemos 3 respiraciones de mariposa juntos — sigue la burbuja.',
+    shells: 4,
+    dolphin: '¡Splash! El delfín salta de alegría porque TÚ calmaste tanto el mar. 🐬',
+    pose: POSES_ES.tree,
+    counting: true,
+  },
+  {
+    goal: 'Envía calma a tu cuerpo, luego respira',
+    intro: 'Antes de respirar, notemos nuestro cuerpo. Camina hasta un lugar para enviarle tu calma.',
+    outro: 'Calma en tu cuerpo, calma en el mar. ¡Hermoso! 🌈',
+    moment: 'hizo un chequeo de calma corporal en la cala',
+    cycles: 2,
+    pre: { kind: 'bodySpot', totems: BODY_SPOTS_ES },
+    breatheCue: 'Ahora respira conmigo, enviando calma a ese lugar — y observa cómo se calma el mar.',
+    shells: 4,
+    dolphin: 'Un delfín asoma y asiente, como diciendo "bien hecho, amigo tranquilo." 🐬',
+    pose: POSES_ES.butterfly,
+  },
+  {
+    goal: 'Elige una estrategia de calma, luego respira',
+    intro: 'Se siente ruidoso y agitado aquí. Camina hasta algo que te ayude a sentirte tranquilo.',
+    outro: 'Excelente elección — eso realmente ayuda. El mar está calmado y brillante. 🌈',
+    moment: 'eligió una estrategia de calma en la cala',
+    cycles: 1,
+    pre: { kind: 'pickOne', totems: STRATEGIES_ES.slice(0, 4) },
+    breatheCue: 'Ahora una respiración de calma juntos — deja que el mar se calme.',
+    shells: 5,
+    dolphin: '¡El delfín da una vuelta feliz sobre el agua brillante y calmada! 🐬',
+    senses: [
+      { senseEmoji: '👀', senseLabel: 'VER', targetEmoji: '🌸', targetLabel: 'la flor' },
+      { senseEmoji: '👂', senseLabel: 'OÍR', targetEmoji: '🌊', targetLabel: 'la ola' },
+      { senseEmoji: '🤲', senseLabel: 'SENTIR', targetEmoji: '🌬️', targetLabel: 'la brisa' },
+    ],
+  },
+  {
+    goal: 'Construye tu plan de calma, luego respira',
+    intro: 'Vamos a construir TU plan de calma. Camina hasta tres cosas que más te ayuden.',
+    outro: '¡Un plan de calma maravilloso — y un mar tranquilo y brillante! 🌈',
+    moment: 'construyó su propio plan de calma en la cala',
+    cycles: 1,
+    pre: { kind: 'plan', need: 3, totems: STRATEGIES_ES },
+    breatheCue: '¡Un plan maravilloso! Una respiración de calma para terminar — y el mar está tranquilo.',
+    shells: 5,
+    dolphin: '¡Toda una familia de delfines salta en una fila feliz — tu plan de calma funcionó! 🐬',
+  },
+];
+
+export const COVE_LEVELS: CoveLevel[] = isEs()
+  ? COVE_LEVELS_EN.map((lvl, i) => COVE_LEVELS_ES[i] ?? lvl)
+  : COVE_LEVELS_EN;

--- a/components/game/BelusWorld/three/quest/forestContent.ts
+++ b/components/game/BelusWorld/three/quest/forestContent.ts
@@ -12,6 +12,7 @@
 // ---------------------------------------------------------------------------
 
 import type { AnimalSpecies } from './Animal3D';
+import { isEs } from '../../../../../lib/lang';
 
 export interface SpellWord {
   /** the word painted on the bubble (also what the child "says") */
@@ -58,7 +59,7 @@ function w(word: string, emoji: string): SpellWord {
 // FRIENDSHIP FOREST — Expressive Language (5 levels, 2..5 friends each)
 // ===========================================================================
 
-export const FOREST_STORY: ForestLevel[] = [
+const FOREST_STORY_EN: ForestLevel[] = [
   // L1 — single mands: "apple" / "ball" / "book". One word = the whole spell.
   {
     goal: 'Say the magic word',
@@ -230,6 +231,182 @@ export const FOREST_STORY: ForestLevel[] = [
   },
 ];
 
+const FOREST_STORY_ES: ForestLevel[] = [
+  // L1 — single mands
+  {
+    goal: 'Di la palabra mágica',
+    intro:
+      '¡Mis amigos del bosque están deseando cosas! Acércate, mira qué quieren, y luego camina hacia la PALABRA mágica para hacerla aparecer.',
+    outro: '¡Dijiste cada palabra mágica tan bien! Tus palabras hacen que las cosas sucedan. 🌳',
+    moment: 'dije mis primeras palabras mágicas en el bosque',
+    twinkles: [
+      { emoji: '✨', pos: [-5.5, -4] },
+      { emoji: '⭐', pos: [5.5, -4.5] },
+      { emoji: '🐝', pos: [0, 5.5] },
+    ],
+    friends: [
+      {
+        species: 'fox', thought: '🍎',
+        spell: [w('manzana', '🍎')], decoys: [w('pelota', '⚽')],
+        reward: '🍎', cheer: '¡Manzana! ¡La dijiste — aquí viene! 🍎',
+        pos: [-3, 0],
+      },
+      {
+        species: 'bunny', thought: '⚽',
+        spell: [w('pelota', '⚽')], decoys: [w('libro', '📖')],
+        reward: '⚽', cheer: '¡Pelota! ¡Tu palabra la hizo aparecer! ⚽',
+        pos: [3, 1],
+      },
+      {
+        species: 'bear', thought: '📖',
+        spell: [w('libro', '📖')], decoys: [w('manzana', '🍎')],
+        reward: '📖', cheer: '¡Libro! ¡Las palabras mágicas sí funcionan! 📖',
+        pos: [0, -3],
+      },
+    ],
+  },
+
+  // L2 — action verbs
+  {
+    goal: 'Di la palabra de acción',
+    intro:
+      '¡Mira lo que están haciendo mis amigos! Acércate, y luego camina hacia la palabra de ACCIÓN para animarlos.',
+    outro: '¡Nombraste cada acción! Las palabras de acción son poderosas. 🏃',
+    moment: 'usé palabras de acción en el bosque',
+    friends: [
+      {
+        species: 'fox', thought: '💨',
+        spell: [w('corriendo', '🏃')], decoys: [w('durmiendo', '😴'), w('comiendo', '🍽️')],
+        reward: '🏃', cheer: '¡Corriendo! ¡Mira cómo va Zorro! 🏃',
+        pos: [-4, -1],
+      },
+      {
+        species: 'bird', thought: '☁️',
+        spell: [w('volando', '🕊️')], decoys: [w('saltando', '🦘'), w('comiendo', '🍽️')],
+        reward: '🕊️', cheer: '¡Volando! ¡Arriba va Pájaro! 🕊️',
+        pos: [4, -1],
+      },
+      {
+        species: 'bear', thought: '🍯',
+        spell: [w('comiendo', '🍽️')], decoys: [w('corriendo', '🏃'), w('volando', '🕊️')],
+        reward: '🍯', cheer: '¡Comiendo! ¡Rica miel! 🍯',
+        pos: [-2, 3],
+      },
+      {
+        species: 'bunny', thought: '⬆️',
+        spell: [w('saltando', '🦘')], decoys: [w('durmiendo', '😴'), w('volando', '🕊️')],
+        reward: '🦘', cheer: '¡Saltando! ¡Salta, salta, salta! 🦘',
+        pos: [3, 3],
+      },
+    ],
+  },
+
+  // L3 — two-word combos
+  {
+    goal: 'Lanza un hechizo de dos palabras',
+    intro:
+      '¡Ahora vamos a juntar DOS palabras! Camina hacia las palabras en orden para lanzar todo el hechizo.',
+    outro: '¡Juntaste las palabras tan bien! Dos palabras, gran magia. ✨',
+    moment: 'hice hechizos de dos palabras en el bosque',
+    friends: [
+      {
+        species: 'bunny', thought: '⚽',
+        spell: [w('quiero', '🙋'), w('pelota', '⚽')], decoys: [w('libro', '📖')],
+        reward: '⚽', cheer: '"quiero pelota" — ¡perfecto! ¡Aquí está! ⚽',
+        pos: [-3, 1],
+      },
+      {
+        species: 'fox', thought: '🍎',
+        spell: [w('quiero', '🙋'), w('manzana', '🍎')], decoys: [w('bebida', '🥤')],
+        reward: '🍎', cheer: '"quiero manzana" — ¡sí! 🍎',
+        pos: [3, 1],
+      },
+      {
+        species: 'bear', thought: '🤗',
+        spell: [w('gran', '🫅'), w('abrazo', '🤗')], decoys: [w('pelota', '⚽')],
+        reward: '🤗', cheer: '"gran abrazo" — aww, ¡el mejor tipo! 🤗',
+        pos: [0, -3],
+      },
+    ],
+  },
+
+  // L4 — "yo veo X"
+  {
+    goal: 'Di "Veo un/a…"',
+    intro:
+      '¡Cuando notamos algo podemos contárselo a un amigo! Camina hacia "yo" luego "veo" y luego lo que VES.',
+    outro: '¡Me contaste todo lo que viste! Compartir lo que notamos es maravilloso. 👀',
+    moment: 'les conté a mis amigos lo que vi en el bosque',
+    friends: [
+      {
+        species: 'fox', thought: '🐶',
+        spell: [w('yo', '🙋'), w('veo', '👀'), w('perro', '🐶')],
+        decoys: [w('gato', '🐱')],
+        reward: '🐶', cheer: '"¡Yo veo un perro!" ¡Muy buena observación! 🐶',
+        pos: [-4, 0],
+      },
+      {
+        species: 'bird', thought: '🌳',
+        spell: [w('yo', '🙋'), w('veo', '👀'), w('árbol', '🌳')],
+        decoys: [w('roca', '🪨')],
+        reward: '🌳', cheer: '"¡Yo veo un árbol!" 🌳',
+        pos: [4, 0],
+      },
+      {
+        species: 'bunny', thought: '⭐',
+        spell: [w('yo', '🙋'), w('veo', '👀'), w('estrella', '⭐')],
+        decoys: [w('luna', '🌙')],
+        reward: '⭐', cheer: '"¡Yo veo una estrella!" ¡Muy alto en el cielo! ⭐',
+        pos: [0, 3],
+      },
+      {
+        species: 'bear', thought: '🦋',
+        spell: [w('yo', '🙋'), w('veo', '👀'), w('mariposa', '🦋')],
+        decoys: [w('abeja', '🐝')],
+        reward: '🦋', cheer: '"¡Yo veo una mariposa!" ¡Qué bonita! 🦋',
+        pos: [0, -3],
+      },
+    ],
+  },
+
+  // L5 — whole sentences + turn-taking
+  {
+    goal: 'Oraciones completas y turnos',
+    intro:
+      '¡Vamos a formar oraciones COMPLETAS, y luego a conversar como buenos amigos — turnándonos para hablar!',
+    outro: 'Nos turnamos para hablar tan bien. Eso es lo que hacen los amigos. 💜',
+    moment: 'hice oraciones y me turné para hablar en el bosque',
+    friends: [
+      {
+        species: 'fox', thought: '🍎',
+        spell: [w('me', '🙋'), w('gustan', '💗'), w('las manzanas', '🍎')],
+        decoys: [w('correr', '🏃')],
+        reward: '🍎', cheer: '"Me gustan las manzanas." ¡Qué buena oración! 🍎',
+        pos: [-4, 1],
+      },
+      {
+        species: 'bunny', thought: '🫵',
+        spell: [w('yo', '🙋'), w('veo', '👀'), w('a ti', '🫵')],
+        decoys: [w('grande', '🫅')],
+        reward: '💜', cheer: '"Yo veo a ti." ¡Yo también te veo, amigo! 💜',
+        pos: [4, 1],
+      },
+      // a friendly turn-take: say it back and forth like a real little chat
+      {
+        species: 'bear', thought: '💬',
+        spell: [w('mi turno', '💬'), w('tu turno', '🗨️'), w('mi turno', '💬'), w('tu turno', '🗨️')],
+        decoys: [],
+        reward: '💜', cheer: '¡Nos turnamos tan bien! Eso es lo que hacen los amigos. 💜',
+        pos: [0, -3],
+      },
+    ],
+  },
+];
+
+export const FOREST_STORY: ForestLevel[] = isEs()
+  ? FOREST_STORY_EN.map((lvl, i) => FOREST_STORY_ES[i] ?? lvl)
+  : FOREST_STORY_EN;
+
 // Default scatter of hidden twinkles for any level that doesn't specify its own.
 // Kept deterministic (fixed positions) — kids can hunt these down between
 // friends for a little sparkle + chime, with no pressure to find them all.
@@ -242,16 +419,37 @@ export const FOREST_TWINKLES: { emoji: string; pos: [number, number] }[] = [
 
 // Warm one-liners Nilu says when a hidden twinkle is found — the firefly guide
 // celebrating discovery. Rotated by a seed so it doesn't feel repetitive.
-export const TWINKLE_FINDS: string[] = [
+const TWINKLE_FINDS_EN: string[] = [
   'Ooh, a hidden sparkle! You found it! ✨',
   'A little firefly was hiding there — well spotted! 🐝',
   'You have sharp eyes! Another shiny one! ⭐',
   'The forest left a sparkle just for you! 🍄',
 ];
 
+const TWINKLE_FINDS_ES: string[] = [
+  '¡Ooh, un brillo escondido! ¡Lo encontraste! ✨',
+  'Una lucecita se escondía ahí — ¡bien visto! 🐝',
+  '¡Tienes ojos muy agudos! ¡Otro brillito! ⭐',
+  '¡El bosque dejó un brillo solo para ti! 🍄',
+];
+
+export const TWINKLE_FINDS: string[] = isEs()
+  ? TWINKLE_FINDS_EN.map((line, i) => TWINKLE_FINDS_ES[i] ?? line)
+  : TWINKLE_FINDS_EN;
+
 // Nilu's gentle nudges while exploring the forest (idle personality).
-export const FOREST_NUDGES: string[] = [
+const FOREST_NUDGES_EN: string[] = [
   'The forest feels happier the more friends we help. 🌳',
   'Listen — the fireflies are dancing! 🐝',
   'Your words are magic here. Try walking into one! 💜',
 ];
+
+const FOREST_NUDGES_ES: string[] = [
+  'El bosque se siente más feliz mientras más amigos ayudamos. 🌳',
+  '¡Escucha — las luciérnagas están bailando! 🐝',
+  'Tus palabras son mágicas aquí. ¡Intenta caminar hacia una! 💜',
+];
+
+export const FOREST_NUDGES: string[] = isEs()
+  ? FOREST_NUDGES_EN.map((line, i) => FOREST_NUDGES_ES[i] ?? line)
+  : FOREST_NUDGES_EN;

--- a/components/game/BelusWorld/three/quest/mountainContent.ts
+++ b/components/game/BelusWorld/three/quest/mountainContent.ts
@@ -12,6 +12,8 @@
 //   L4 safety (walk to the SAFE marker of two)  • L5 independent self-check (any order)
 // ---------------------------------------------------------------------------
 
+import { isEs } from '../../../../../lib/lang';
+
 /** How a station behaves once Nilu reaches it. */
 export type StationKind =
   | 'ordered' // must be visited in sequence order (L1-L3, the routine)
@@ -57,13 +59,23 @@ const STARS: [number, number][][] = [
 
 // Cheery lines Nimbus the cloud-buddy says as the morning gets going. Picked by
 // step index so they stay deterministic (no random at render).
-export const NIMBUS_LINES = [
+const NIMBUS_LINES_EN = [
   'Yawwwn… oh! Good morning, Nilu! Let us get ready together!',
   'Way to go! The sun is peeking out!',
   'Look — it is getting brighter! Keep going!',
   'You are SO good at this. Almost there!',
   'Wow, what a morning! The sun is way up high!',
 ];
+
+const NIMBUS_LINES_ES = [
+  '¡Bostezo… oh! ¡Buenos días, Nilu! ¡Vamos a alistarnos juntos!',
+  '¡Muy bien! ¡El sol ya está asomando!',
+  '¡Mira — está aclarando! ¡Sigue así!',
+  'Eres MUY bueno en esto. ¡Ya casi!',
+  '¡Vaya, qué mañana! ¡El sol ya está bien arriba!',
+];
+
+export const NIMBUS_LINES = isEs() ? NIMBUS_LINES_ES : NIMBUS_LINES_EN;
 
 function st(
   emoji: string,
@@ -95,7 +107,7 @@ export const RING: [number, number][] = [
 export const SAFE_SPOTS: [number, number][] = [[-2.6, -4], [2.6, -4], [-2.6, 4], [2.6, 4]];
 export const TWIN_DX = 2.4;
 
-export const MOUNTAIN_ROUTINE: MountainLevel[] = [
+const MOUNTAIN_ROUTINE_EN: MountainLevel[] = [
   {
     goal: 'Do each self-care job, in order',
     intro: "Let's get ready for the day! Walk to the bed 🛏️ first, to wake up. Then visit each job in order.",
@@ -174,3 +186,82 @@ export const MOUNTAIN_ROUTINE: MountainLevel[] = [
     stars: STARS[4],
   },
 ];
+
+const MOUNTAIN_ROUTINE_ES: MountainLevel[] = [
+  {
+    goal: 'Haz cada tarea de cuidado personal, en orden',
+    intro: '¡Vamos a alistarnos para el día! Camina hasta la cama 🛏️ primero, para despertar. Luego visita cada tarea en orden.',
+    outro: '¡Lo hiciste todo tú solo — estás muy listo!',
+    moment: 'practicó tareas de vida en la montaña',
+    stations: [
+      st('🛏️', 'Despertar', 'ordered', RING[0][0], RING[0][1], { done: '¡Buenos días! A levantarse.' }),
+      st('🧼', 'Lavarse las manos', 'ordered', RING[1][0], RING[1][1], { done: '¡Manos bien limpias!' }),
+      st('🪥', 'Cepillarse los dientes', 'ordered', RING[2][0], RING[2][1], { done: '¡Dientes bien limpios!' }),
+      st('👟', 'Ponerse los zapatos', 'ordered', RING[3][0], RING[3][1], { done: '¡Zapatos puestos — listos para salir!' }),
+    ],
+    stars: STARS[0],
+  },
+  {
+    goal: 'Haz los pasos en orden',
+    intro: 'Algunas tareas tienen pasos en orden. Camina hasta la cama 🛏️ primero, para despertar. Luego visita cada siguiente paso en orden.',
+    outro: '¡Lo hiciste todo tú solo — estás muy listo!',
+    moment: 'practicó tareas de vida en la montaña',
+    stations: [
+      st('😴', 'Despertar', 'ordered', RING[0][0], RING[0][1], { done: '¡Arriba y a moverse!' }),
+      st('🪥', 'Cepillarse los dientes', 'ordered', RING[1][0], RING[1][1], { done: '¡Así se cepilla!' }),
+      st('👕', 'Vestirse', 'ordered', RING[3][0], RING[3][1], { done: '¡Ya vestido!' }),
+      st('🥣', 'Desayunar', 'ordered', RING[4][0], RING[4][1], { done: '¡Rico — buena energía!' }),
+    ],
+    stars: STARS[1],
+  },
+  {
+    goal: 'Toda la mañana',
+    intro: '¡Vamos a hacer TODA la mañana, paso a paso! Camina hasta la cama 🛏️ primero, para despertar. Luego visita cada siguiente paso en orden.',
+    outro: '¡Una mañana perfecta, de principio a fin!',
+    moment: 'practicó tareas de vida en la montaña',
+    stations: [
+      st('😴', 'Despertar', 'ordered', RING[0][0], RING[0][1], { done: '¡Buenos días!' }),
+      st('🪥', 'Cepillarse los dientes', 'ordered', RING[1][0], RING[1][1], { done: '¡Dientes bien limpios!' }),
+      st('👕', 'Vestirse', 'ordered', RING[2][0], RING[2][1], { done: '¡Qué elegante!' }),
+      st('🥣', 'Desayunar', 'ordered', RING[3][0], RING[3][1], { done: '¡Desayuno delicioso!' }),
+      st('🎒', 'Empacar la mochila', 'ordered', RING[4][0], RING[4][1], { done: '¡Mochila lista!' }),
+      st('🚪', 'Despedirse', 'ordered', RING[5][0], RING[5][1], { done: '¡Adiós — que tengas un gran día!' }),
+    ],
+    stars: STARS[2],
+  },
+  {
+    goal: 'Mantente seguro',
+    intro: '¡Estar seguro es una habilidad de niño grande! Cada lugar tiene dos opciones. Camina hasta la SEGURA — como Mirar a los dos lados 👀 — para estar seguros.',
+    outro: '¡Hiciste cada elección segura — muy bien!',
+    moment: 'practicó estar seguro en la montaña',
+    stations: [
+      st('👀', 'Mirar a los dos lados', 'safe', SAFE_SPOTS[0][0], SAFE_SPOTS[0][1], { pair: 0, done: '¡Sí — esa es la opción segura!' }),
+      st('🏃', 'Cruzar corriendo rápido', 'unsafe', SAFE_SPOTS[0][0] + TWIN_DX, SAFE_SPOTS[0][1], { pair: 0 }),
+      st('🙅', 'Mantenerse lejos de la estufa caliente', 'safe', SAFE_SPOTS[1][0], SAFE_SPOTS[1][1], { pair: 1, done: 'Mantenerse lejos nos mantiene seguros.' }),
+      st('✋', 'Tocar la estufa caliente', 'unsafe', SAFE_SPOTS[1][0] + TWIN_DX, SAFE_SPOTS[1][1], { pair: 1 }),
+      st('🙋', 'Buscar a un adulto de confianza', 'safe', SAFE_SPOTS[2][0], SAFE_SPOTS[2][1], { pair: 2, done: 'Siempre busca a un adulto de confianza.' }),
+      st('🚶', 'Irse con un desconocido', 'unsafe', SAFE_SPOTS[2][0] + TWIN_DX, SAFE_SPOTS[2][1], { pair: 2 }),
+      st('🔒', 'Abrocharse el cinturón', 'safe', SAFE_SPOTS[3][0], SAFE_SPOTS[3][1], { pair: 3, done: '¡Clic! Seguro y listo.' }),
+      st('🎮', 'Ponerse de pie en el carro', 'unsafe', SAFE_SPOTS[3][0] + TWIN_DX, SAFE_SPOTS[3][1], { pair: 3 }),
+    ],
+    stars: STARS[3],
+  },
+  {
+    goal: 'Todo yo solo',
+    intro: '¿Puedes alistarte tú solo? Camina hasta cada tarea que veas — la cama 🛏️, el cepillo de dientes 🪥, y las demás — ¡en el orden que quieras!',
+    outro: '¡Todo listo — te alistaste tú solo! 🌟',
+    moment: 'se alistó todo solo',
+    stations: [
+      st('🛏️', 'Hacer la cama', 'any', RING[0][0], RING[0][1], { done: '¡Cama hecha!' }),
+      st('🪥', 'Cepillarse los dientes', 'any', RING[1][0], RING[1][1], { done: '¡Dientes bien limpios!' }),
+      st('👕', 'Vestirse', 'any', RING[2][0], RING[2][1], { done: '¡Ya vestido!' }),
+      st('🥣', 'Desayunar', 'any', RING[4][0], RING[4][1], { done: '¡Desayuno delicioso!' }),
+      st('🎒', 'Empacar mi mochila', 'any', RING[5][0], RING[5][1], { done: '¡Mochila lista!' }),
+    ],
+    stars: STARS[4],
+  },
+];
+
+export const MOUNTAIN_ROUTINE: MountainLevel[] = isEs()
+  ? MOUNTAIN_ROUTINE_EN.map((lvl, i) => MOUNTAIN_ROUTINE_ES[i] ?? lvl)
+  : MOUNTAIN_ROUTINE_EN;

--- a/components/game/BelusWorld/three/quest/quests.ts
+++ b/components/game/BelusWorld/three/quest/quests.ts
@@ -10,6 +10,7 @@
 import type { ActivityZone } from '../../belu/progress';
 import type { Mood } from './QuestNPC';
 import { ADVANCED_QUESTS } from './advancedQuests';
+import { isEs } from '../../../../../lib/lang';
 
 export interface Orb {
   emoji: string;
@@ -79,7 +80,7 @@ const MOOD = (m: Mood): Mood => m;
 // FEELINGS MEADOW — Reading Emotions
 // ===========================================================================
 
-const MEADOW: Quest[] = [
+const MEADOW_EN: Quest[] = [
   {
     zone: 'meadow', level: 1, goal: 'Match feeling faces',
     intro: "Hi! My meadow friends are showing their feelings. Can you read each one?",
@@ -200,6 +201,129 @@ const MEADOW: Quest[] = [
   },
 ];
 
+const MEADOW_ES: Quest[] = [
+  {
+    zone: 'meadow', level: 1, goal: 'Reconoce caras con sentimientos',
+    intro: "¡Hola! Mis amigos del prado están mostrando sus sentimientos. ¿Puedes reconocer cada uno?",
+    outro: "Reconociste cada sentimiento tan bien. ¡Gracias por enseñarme!",
+    moment: 'reconoció sentimientos en el prado',
+    rounds: [
+      { kind: 'choice', say: 'Pip está poniendo una cara. ¿Qué sentimiento es este?',
+        npc: { face: '😊', mood: MOOD('happy') },
+        options: [feel('happy', true), feel('sad')] },
+      { kind: 'choice', say: '¿Y Milo? ¿Qué sentimiento es este?',
+        npc: { face: '😢', mood: MOOD('sad') },
+        options: [feel('sad', true), feel('happy'), feel('angry')] },
+      { kind: 'choice', say: 'Mira a Bea. ¿Qué sentimiento es este?',
+        npc: { face: '😡', mood: MOOD('angry') },
+        options: [feel('angry', true), feel('calm'), feel('happy')] },
+      { kind: 'choice', say: 'Y Otto — ¿qué sentimiento es este?',
+        npc: { face: '😨', mood: MOOD('scared') },
+        options: [feel('scared', true), feel('excited'), feel('sad')] },
+    ],
+  },
+  {
+    zone: 'meadow', level: 2, goal: 'Lee las señales del cuerpo',
+    intro: "Ahora mira cómo mis amigos mueven su cuerpo. ¡Su cuerpo también muestra sentimientos!",
+    outro: "Reconociste cada sentimiento tan bien. ¡Gracias por enseñarme!",
+    moment: 'reconoció sentimientos en el prado',
+    rounds: [
+      { kind: 'choice', say: 'Milo tiene los hombros caídos y mira hacia abajo. ¿Cómo se siente Milo?',
+        npc: { face: '😔', mood: MOOD('sad') },
+        options: [feel('sad', true), feel('excited'), feel('angry')] },
+      { kind: 'choice', say: 'Lulu está saltando y aplaudiendo rápido. ¿Cómo se siente Lulu?',
+        npc: { face: '🤩', mood: MOOD('excited') },
+        options: [feel('excited', true), feel('scared'), feel('sad')] },
+      { kind: 'choice', say: 'Otto se esconde detrás de un árbol, temblando un poco. ¿Cómo se siente Otto?',
+        npc: { face: '😨', mood: MOOD('scared') },
+        options: [feel('scared', true), feel('happy'), feel('proud')] },
+      { kind: 'choice', say: 'Bea tiene los brazos cruzados fuerte y golpea el piso con el pie. ¿Cómo se siente Bea?',
+        npc: { face: '😤', mood: MOOD('angry') },
+        options: [feel('angry', true), feel('calm'), feel('surprised')] },
+    ],
+  },
+  {
+    zone: 'meadow', level: 3, goal: 'Sentimientos según lo que pasa',
+    intro: "A veces sabemos un sentimiento por lo que acaba de pasar. ¡Vamos a intentarlo!",
+    outro: "Reconociste cada sentimiento tan bien. ¡Gracias por enseñarme!",
+    moment: 'reconoció sentimientos en el prado',
+    rounds: [
+      { kind: 'choice', say: '¡Pip recibió un regalo sorpresa de cumpleaños! ¿Cómo se siente Pip?',
+        npc: { face: '🙂', mood: MOOD('happy'), thought: { emoji: '🎁' } },
+        options: [feel('happy', true), feel('sad'), feel('angry'), feel('scared')] },
+      { kind: 'choice', say: 'El helado de Sol se cayó al suelo. ¿Cómo se siente Sol?',
+        npc: { face: '🙂', mood: MOOD('sad'), thought: { emoji: '🍦' } },
+        options: [feel('sad', true), feel('excited'), feel('proud')] },
+      { kind: 'choice', say: 'Empieza una tormenta con truenos muy fuertes. ¿Cómo se siente Otto?',
+        npc: { face: '🙂', mood: MOOD('scared'), thought: { emoji: '⛈️' } },
+        options: [feel('scared', true), feel('happy'), feel('calm')] },
+      { kind: 'choice', say: 'Lulu terminó un rompecabezas difícil ella sola. ¿Cómo se siente Lulu?',
+        npc: { face: '🙂', mood: MOOD('proud'), thought: { emoji: '🏆' } },
+        options: [feel('proud', true), feel('angry'), feel('sad')] },
+    ],
+  },
+  {
+    zone: 'meadow', level: 4, goal: 'Lo que ellos querían',
+    intro: "Los sentimientos dependen de lo que esperábamos. Piensa en lo que quería cada amigo.",
+    outro: "Reconociste cada sentimiento tan bien. ¡Gracias por enseñarme!",
+    moment: 'reconoció sentimientos en el prado',
+    rounds: [
+      { kind: 'choice', say: 'Mona quería la pelota roja, pero le dieron la azul. ¿Cómo se siente Mona?',
+        npc: { face: '😞', mood: MOOD('disappointed'), thought: { emoji: '🔵' } },
+        options: [feel('disappointed', true), feel('happy'), feel('surprised')] },
+      { kind: 'choice', say: '¡Pip esperaba panqueques — y los panqueques ya están listos! ¿Cómo se siente Pip?',
+        npc: { face: '😄', mood: MOOD('happy'), thought: { emoji: '🥞' } },
+        options: [feel('happy', true), feel('sad'), feel('scared')] },
+      { kind: 'choice', say: '¡Bea esperaba un amigo, pero llegaron DIEZ amigos! ¿Cómo se siente Bea?',
+        npc: { face: '😲', mood: MOOD('surprised'), thought: { emoji: '🎉' } },
+        options: [feel('surprised', true), feel('angry'), feel('bored')] },
+      { kind: 'choice', say: 'Sol quería jugar afuera, pero está lloviendo. ¿Cómo se siente Sol?',
+        npc: { face: '😟', mood: MOOD('disappointed'), thought: { emoji: '🌧️' } },
+        options: [feel('disappointed', true), feel('excited'), feel('proud')] },
+    ],
+  },
+  {
+    zone: 'meadow', level: 5, goal: 'Ayuda a un amigo',
+    intro: "Lo más bondadoso es ayudar. Encuentra el sentimiento y luego elige una forma amable de ayudar.",
+    outro: "Reconociste cada sentimiento tan bien. ¡Gracias por enseñarme!",
+    moment: 'ayudó a sus amigos en el prado',
+    rounds: [
+      { kind: 'choice', say: 'Sam no sabe que su torre de bloques se cayó. Cuando la vea, ¿cómo se sentirá?',
+        npc: { face: '🙂', mood: MOOD('neutral'), thought: { emoji: '🧱' } },
+        options: [feel('sad', true), feel('happy'), feel('proud')] },
+      { kind: 'choice', say: 'Ahora — ¿cuál es una forma amable de ayudar a Sam?',
+        npc: { face: '😢', mood: MOOD('sad') },
+        options: [
+          { emoji: '🤗', caption: 'Abrazar y ayudar a reconstruir', correct: true },
+          { emoji: '😆', caption: 'Reírse de él' },
+          { emoji: '🚶', caption: 'Irse caminando' },
+        ], doneLine: 'Eso es muy amable. Eres un buen amigo.' },
+      { kind: 'choice', say: 'Lulu está atascada en un rompecabezas y se está frustrando. ¿Cómo se siente Lulu?',
+        npc: { face: '😤', mood: MOOD('frustrated'), thought: { emoji: '🧩' } },
+        options: [feel('frustrated', true), feel('excited'), feel('calm')] },
+      { kind: 'choice', say: '¿Cómo puedes ayudar a Lulu?',
+        npc: { face: '😤', mood: MOOD('frustrated') },
+        options: [
+          { emoji: '🙋', caption: 'Preguntarle si quiere ayuda', correct: true },
+          { emoji: '🙅', caption: 'Quitarle el rompecabezas' },
+          { emoji: '🚶', caption: 'Ignorarla' },
+        ], doneLine: 'Preguntar primero es muy amable.' },
+      { kind: 'choice', say: 'A Otto se le cayó su merienda y parece que va a llorar. ¿Cómo se siente Otto?',
+        npc: { face: '😢', mood: MOOD('sad'), thought: { emoji: '🍪' } },
+        options: [feel('sad', true), feel('angry'), feel('surprised')] },
+      { kind: 'choice', say: '¿Qué le puedes decir a Otto?',
+        npc: { face: '😢', mood: MOOD('sad') },
+        options: [
+          { emoji: '💗', caption: '¿Quieres compartir la mía?', correct: true },
+          { emoji: '😝', caption: '¡Qué mal por ti!' },
+          { emoji: '🤐', caption: 'No decir nada' },
+        ], doneLine: 'Compartir hace sentir mejor a los amigos.' },
+    ],
+  },
+];
+
+const MEADOW = isEs() ? MEADOW_EN.map((item, i) => MEADOW_ES[i] ?? item) : MEADOW_EN;
+
 // ===========================================================================
 // MORNING MOUNTAIN — Life Skills
 // ===========================================================================
@@ -208,7 +332,7 @@ function step(emoji: string, caption: string, correct = false): Orb {
   return { emoji, caption, correct };
 }
 
-const MOUNTAIN: Quest[] = [
+const MOUNTAIN_EN: Quest[] = [
   {
     zone: 'mountain', level: 1, goal: 'Match each action',
     intro: "Let's get ready for the day! For each question, walk to the one picture that matches.",
@@ -309,11 +433,114 @@ const MOUNTAIN: Quest[] = [
   },
 ];
 
+const MOUNTAIN_ES: Quest[] = [
+  {
+    zone: 'mountain', level: 1, goal: 'Reconoce cada acción',
+    intro: "¡Vamos a alistarnos para el día! En cada pregunta, camina hasta la única imagen que corresponde.",
+    outro: '¡Lo hiciste todo tú solo — estás muy listo!',
+    moment: 'practicó tareas de vida en la montaña',
+    rounds: [
+      { kind: 'choice', say: '¿Cuál usamos para cepillarnos los dientes?',
+        npc: { face: '🦷', mood: MOOD('happy') },
+        options: [step('🪥', 'cepillo', true), step('🍕', 'pizza'), step('⚽', 'pelota')] },
+      { kind: 'choice', say: '¿Cuál nos lava las manos?',
+        npc: { face: '🤲', mood: MOOD('happy') },
+        options: [step('📺', 'televisión'), step('🧼', 'jabón', true), step('🎈', 'globo')] },
+      { kind: 'choice', say: '¿Cuál nos seca el pelo?',
+        npc: { face: '💇', mood: MOOD('happy') },
+        options: [step('🚗', 'carro'), step('🍞', 'pan'), step('🧴', 'secador', true)] },
+      { kind: 'choice', say: '¿Cuál nos ponemos en los pies?',
+        npc: { face: '🦶', mood: MOOD('happy') },
+        options: [step('👟', 'zapatos', true), step('🪀', 'yoyo'), step('🍩', 'dona')] },
+    ],
+  },
+  {
+    zone: 'mountain', level: 2, goal: 'Arma los pasos',
+    intro: "Algunas tareas tienen pasos en orden. ¡Camina hacia cada imagen, de primero a último, para armar los pasos!",
+    outro: '¡Lo hiciste todo tú solo — estás muy listo!',
+    moment: 'practicó tareas de vida en la montaña',
+    rounds: [
+      { kind: 'sequence', say: '¿Cómo nos cepillamos los dientes? Haz los pasos en orden.',
+        npc: { face: '🪥', mood: MOOD('happy') },
+        pool: [step('😁', '¡Cepíllate!'), step('🪥', 'Sacar el cepillo'), step('🧴', 'Pasta de dientes')],
+        order: ['Sacar el cepillo', 'Pasta de dientes', '¡Cepíllate!'],
+        doneLine: '¡Así nos cepillamos los dientes!' },
+      { kind: 'sequence', say: 'Ahora lavarnos las manos. ¿En qué orden?',
+        npc: { face: '🧼', mood: MOOD('happy') },
+        pool: [step('🧻', 'Secar las manos'), step('💧', 'Abrir el agua'), step('🧼', 'Usar jabón')],
+        order: ['Abrir el agua', 'Usar jabón', 'Secar las manos'],
+        doneLine: '¡Manos bien limpias!' },
+      { kind: 'sequence', say: 'Vestirse — de primero a último.',
+        npc: { face: '👕', mood: MOOD('happy') },
+        pool: [step('👖', 'Pantalones'), step('🩲', 'Ropa interior'), step('👕', 'Camisa')],
+        order: ['Ropa interior', 'Camisa', 'Pantalones'],
+        doneLine: '¡Ya vestido!' },
+    ],
+  },
+  {
+    zone: 'mountain', level: 3, goal: 'Toda la mañana',
+    intro: "¡Vamos a hacer TODA la mañana, paso a paso! ¡Camínalos en orden!",
+    outro: '¡Lo hiciste todo tú solo — estás muy listo!',
+    moment: 'practicó tareas de vida en la montaña',
+    rounds: [
+      { kind: 'sequence', say: '¿Qué hacemos primero en la mañana? ¡Ve en orden!',
+        npc: { face: '🌅', mood: MOOD('happy') },
+        pool: [
+          step('🎒', 'Empacar la mochila'), step('😴', 'Despertar'), step('🥣', 'Desayunar'),
+          step('🪥', 'Cepillarse los dientes'), step('👋', 'Despedirse'), step('👕', 'Vestirse'),
+        ],
+        order: ['Despertar', 'Cepillarse los dientes', 'Vestirse', 'Desayunar', 'Empacar la mochila', 'Despedirse'],
+        doneLine: '¡Una mañana perfecta, de principio a fin!' },
+    ],
+  },
+  {
+    zone: 'mountain', level: 4, goal: 'Mantente seguro',
+    intro: "Estar seguro es una habilidad de niño grande. Camina hacia la opción que nos mantiene seguros.",
+    outro: '¡Lo hiciste todo tú solo — estás muy listo!',
+    moment: 'practicó estar seguro en la montaña',
+    rounds: [
+      { kind: 'choice', say: 'Antes de cruzar la calle, ¿qué hacemos primero?',
+        npc: { face: '🚦', mood: MOOD('neutral') },
+        options: [step('👀', 'Mirar a los dos lados', true), step('🏃', 'Cruzar corriendo rápido')],
+        doneLine: '¡Sí — esa es la opción segura!' },
+      { kind: 'choice', say: 'La estufa está caliente y roja. ¿Qué hacemos?',
+        npc: { face: '🔥', mood: MOOD('neutral') },
+        options: [step('🙅', 'Mantenernos lejos', true), step('✋', 'Tocarla')],
+        doneLine: 'Mantenernos lejos nos mantiene seguros.' },
+      { kind: 'choice', say: 'Un desconocido te pide que vayas con él. ¿Qué hacemos?',
+        npc: { face: '❓', mood: MOOD('neutral') },
+        options: [step('🙋', 'Buscar a un adulto de confianza', true), step('🚶', 'Irse con él')],
+        doneLine: 'Siempre busca a un adulto de confianza.' },
+      { kind: 'choice', say: 'Vamos a viajar en carro. ¿Qué hacemos?',
+        npc: { face: '🚗', mood: MOOD('neutral') },
+        options: [step('🔒', 'Abrocharte el cinturón', true), step('🎮', 'Ponerte de pie y jugar')],
+        doneLine: '¡Clic! Seguro y listo.' },
+    ],
+  },
+  {
+    zone: 'mountain', level: 5, goal: 'Todo yo solo',
+    intro: "¿Puedes alistarte tú solo? ¡Camina hasta cada tarea que puedas hacer!",
+    outro: '¡Lo hiciste todo tú solo — estás muy listo!',
+    moment: 'se alistó todo solo',
+    rounds: [
+      { kind: 'multiPick', say: 'Haz cada tarea de la mañana — ¡camina hasta las cinco!', picks: 5,
+        npc: { face: '🌟', mood: MOOD('proud') },
+        options: [
+          step('🛏️', 'Hacer la cama'), step('🪥', 'Cepillarse los dientes'), step('👕', 'Vestirse'),
+          step('🥣', 'Desayunar'), step('🎒', 'Empacar mi mochila'),
+        ],
+        doneLine: '¡Todo listo — te alistaste tú solo! 🌟' },
+    ],
+  },
+];
+
+const MOUNTAIN = isEs() ? MOUNTAIN_EN.map((item, i) => MOUNTAIN_ES[i] ?? item) : MOUNTAIN_EN;
+
 // ===========================================================================
 // CALM COVE — Self-Regulation & Senses
 // ===========================================================================
 
-const CALM_STRATEGIES: Orb[] = [
+const CALM_STRATEGIES_EN: Orb[] = [
   { emoji: '🌬️', caption: 'Deep breaths', correct: true },
   { emoji: '🤫', caption: 'Quiet spot', correct: true },
   { emoji: '✊', caption: 'Squeeze hands', correct: true },
@@ -322,7 +549,18 @@ const CALM_STRATEGIES: Orb[] = [
   { emoji: '🤗', caption: 'Get a big hug', correct: true },
 ];
 
-const COVE: Quest[] = [
+const CALM_STRATEGIES_ES: Orb[] = [
+  { emoji: '🌬️', caption: 'Respirar hondo', correct: true },
+  { emoji: '🤫', caption: 'Lugar tranquilo', correct: true },
+  { emoji: '✊', caption: 'Apretar las manos', correct: true },
+  { emoji: '✋', caption: 'Pedir un descanso', correct: true },
+  { emoji: '🖐️', caption: 'Contar hasta cinco', correct: true },
+  { emoji: '🤗', caption: 'Un abrazo grande', correct: true },
+];
+
+const CALM_STRATEGIES = isEs() ? CALM_STRATEGIES_ES : CALM_STRATEGIES_EN;
+
+const COVE_EN: Quest[] = [
   {
     zone: 'cove', level: 1, goal: 'Breathe with Nilu',
     intro: "Welcome to the cove. Let's feel calm together. Follow the bubble with me.",
@@ -391,11 +629,82 @@ const COVE: Quest[] = [
   },
 ];
 
+const COVE_ES: Quest[] = [
+  {
+    zone: 'cove', level: 1, goal: 'Respira con Nilu',
+    intro: "Bienvenido a la caleta. Vamos a sentirnos tranquilos juntos. Sigue la burbuja conmigo.",
+    outro: 'Ahora me siento tranquilo y a gusto. Gracias por estar conmigo.',
+    moment: 'practicó estar tranquilo en la caleta',
+    rounds: [
+      { kind: 'breathe', say: 'Inhala mientras la burbuja crece, exhala mientras se encoge.',
+        npc: { face: '😌', mood: MOOD('calm') }, cycles: 2 },
+    ],
+  },
+  {
+    zone: 'cove', level: 2, goal: 'Una calma más larga',
+    intro: "Vamos a tomarnos una calma más larga juntos. Sigue la burbuja.",
+    outro: 'Ahora me siento tranquilo y a gusto. Gracias por estar conmigo.',
+    moment: 'practicó estar tranquilo en la caleta',
+    rounds: [
+      { kind: 'breathe', say: 'Inhala mientras la burbuja crece, exhala mientras se encoge.',
+        npc: { face: '😌', mood: MOOD('calm') }, cycles: 3 },
+    ],
+  },
+  {
+    zone: 'cove', level: 3, goal: 'Revisión del cuerpo',
+    intro: "Vamos a notar nuestro cuerpo. Elige un lugar para enviar calma, y luego respiraremos.",
+    outro: 'Ahora me siento tranquilo y a gusto. Gracias por estar conmigo.',
+    moment: 'hizo una revisión de calma en la caleta',
+    rounds: [
+      { kind: 'choice', say: '¿A dónde vas a enviar tu calma? Camina hacia un lugar.',
+        npc: { face: '😌', mood: MOOD('calm') },
+        options: [
+          { emoji: '🫄', caption: 'Barriga', correct: true },
+          { emoji: '🫁', caption: 'Pecho', correct: true },
+          { emoji: '💪', caption: 'Hombros', correct: true },
+          { emoji: '🤲', caption: 'Manos', correct: true },
+        ], doneLine: 'Qué lindo. Enviando calma ahí ahora.' },
+      { kind: 'breathe', say: "Ahora respira conmigo, enviando calma a ese lugar.",
+        npc: { face: '😌', mood: MOOD('calm') }, cycles: 2 },
+    ],
+  },
+  {
+    zone: 'cove', level: 4, goal: 'Elige una estrategia',
+    intro: "A veces las cosas se sienten demasiado grandes. Aquí hay mucho ruido y movimiento. ¿Qué te ayuda?",
+    outro: 'Ahora me siento tranquilo y a gusto. Gracias por estar conmigo.',
+    moment: 'eligió una estrategia de calma en la caleta',
+    rounds: [
+      { kind: 'choice', say: 'Hay mucho ruido y movimiento. Camina hacia algo que te ayude a sentirte tranquilo.',
+        npc: { face: '🫨', mood: MOOD('frustrated') },
+        options: CALM_STRATEGIES.slice(0, 4),
+        doneLine: 'Buena idea — eso sí ayuda. Una respiración tranquila ahora.' },
+      { kind: 'breathe', say: 'Una respiración tranquila juntos.',
+        npc: { face: '😌', mood: MOOD('calm') }, cycles: 1 },
+    ],
+  },
+  {
+    zone: 'cove', level: 5, goal: 'Mi plan de calma',
+    intro: "Vamos a construir TU plan de calma. Elige tres cosas que más te ayudan.",
+    outro: 'Ese es un plan de calma maravilloso. Ahora me siento tranquilo y a gusto.',
+    moment: 'construyó su propio plan de calma',
+    rounds: [
+      { kind: 'multiPick', say: 'Camina hacia TRES cosas para tu propio plan de calma.', picks: 3,
+        npc: { face: '🌟', mood: MOOD('calm') },
+        options: CALM_STRATEGIES,
+        doneLine: 'Un plan de calma maravilloso. Una respiración para terminar.' },
+      { kind: 'breathe', say: "Vamos a terminar con una respiración tranquila.",
+        npc: { face: '😌', mood: MOOD('calm') }, cycles: 1 },
+    ],
+  },
+];
+
+const COVE = isEs() ? COVE_EN.map((item, i) => COVE_ES[i] ?? item) : COVE_EN;
+
 // ===========================================================================
 // FRIENDSHIP FOREST — Expressive Language
 // ===========================================================================
 
-const FOREST: Quest[] = [
+const FOREST_EN: Quest[] = [
   {
     zone: 'forest', level: 1, goal: 'Ask for it',
     intro: "My forest friends want things. Help them ask! Walk to what they want.",
@@ -550,11 +859,168 @@ const FOREST: Quest[] = [
   },
 ];
 
+const FOREST_ES: Quest[] = [
+  {
+    zone: 'forest', level: 1, goal: 'Pídelo',
+    intro: "Mis amigos del bosque quieren cosas. ¡Ayúdalos a pedir! Camina hacia lo que quieren.",
+    outro: '¡Usaste tus palabras tan bien! Me encantó hablar contigo.',
+    moment: 'usó sus palabras en el bosque',
+    rounds: [
+      { kind: 'choice', say: 'El zorro quiere algo. Mira la burbuja — ¿qué quiere Zorro?',
+        npc: { face: '🦊', mood: MOOD('happy'), thought: { emoji: '🍎' } },
+        options: [
+          { emoji: '🍎', caption: 'Quiero manzana', correct: true },
+          { emoji: '⚽', caption: 'Quiero pelota' },
+          { emoji: '📖', caption: 'Quiero libro' },
+        ], doneLine: '¡Sí! "¡Quiero manzana!" ¡Aquí tienes! 🎉' },
+      { kind: 'choice', say: '¿Qué quiere Conejo?',
+        npc: { face: '🐰', mood: MOOD('happy'), thought: { emoji: '⚽' } },
+        options: [
+          { emoji: '⚽', caption: 'Quiero pelota', correct: true },
+          { emoji: '🥤', caption: 'Quiero bebida' },
+          { emoji: '🍎', caption: 'Quiero manzana' },
+        ], doneLine: '¡Sí! "¡Quiero pelota!" 🎉' },
+      { kind: 'choice', say: '¿Y qué quiere Oso?',
+        npc: { face: '🐻', mood: MOOD('happy'), thought: { emoji: '📖' } },
+        options: [
+          { emoji: '📖', caption: 'Quiero libro', correct: true },
+          { emoji: '⚽', caption: 'Quiero pelota' },
+          { emoji: '🥤', caption: 'Quiero bebida' },
+        ], doneLine: '¡Sí! "¡Quiero libro!" 🎉' },
+    ],
+  },
+  {
+    zone: 'forest', level: 2, goal: 'Palabras de acción',
+    intro: "Mira lo que hacen mis amigos. ¡Camina hacia la palabra de acción!",
+    outro: '¡Usaste tus palabras tan bien! Me encantó hablar contigo.',
+    moment: 'usó sus palabras en el bosque',
+    rounds: [
+      { kind: 'choice', say: '¡El zorro se mueve rápido! ¿Qué está haciendo el zorro?',
+        npc: { face: '🦊', mood: MOOD('excited'), thought: { emoji: '💨' } },
+        options: [
+          { emoji: '🏃', caption: 'corriendo', correct: true },
+          { emoji: '😴', caption: 'durmiendo' },
+          { emoji: '🍽️', caption: 'comiendo' },
+        ], doneLine: '¡Sí! ¡El zorro está corriendo!' },
+      { kind: 'choice', say: '¡Allá en el cielo! ¿Qué está haciendo el pájaro?',
+        npc: { face: '🐦', mood: MOOD('excited'), thought: { emoji: '☁️' } },
+        options: [
+          { emoji: '🕊️', caption: 'volando', correct: true },
+          { emoji: '🦘', caption: 'saltando' },
+          { emoji: '🍽️', caption: 'comiendo' },
+        ], doneLine: '¡Sí! ¡El pájaro está volando!' },
+      { kind: 'choice', say: '¡Qué rico! ¿Qué está haciendo el oso?',
+        npc: { face: '🐻', mood: MOOD('happy'), thought: { emoji: '🍯' } },
+        options: [
+          { emoji: '🍽️', caption: 'comiendo', correct: true },
+          { emoji: '🏃', caption: 'corriendo' },
+          { emoji: '🕊️', caption: 'volando' },
+        ], doneLine: '¡Sí! ¡El oso está comiendo!' },
+      { kind: 'choice', say: '¡Salta, salta! ¿Qué está haciendo el conejo?',
+        npc: { face: '🐰', mood: MOOD('excited'), thought: { emoji: '⬆️' } },
+        options: [
+          { emoji: '🦘', caption: 'saltando', correct: true },
+          { emoji: '😴', caption: 'durmiendo' },
+          { emoji: '🕊️', caption: 'volando' },
+        ], doneLine: '¡Sí! ¡El conejo está saltando!' },
+    ],
+  },
+  {
+    zone: 'forest', level: 3, goal: 'Dos palabras',
+    intro: "Vamos a juntar dos palabras. ¡Camina hacia las palabras en orden!",
+    outro: '¡Usaste tus palabras tan bien! Me encantó hablar contigo.',
+    moment: 'usó sus palabras en el bosque',
+    rounds: [
+      { kind: 'sequence', say: 'Dilo conmigo: "quiero pelota". Camina hacia las palabras en orden.',
+        npc: { face: '🐰', mood: MOOD('happy') },
+        pool: [{ emoji: '📖', caption: 'libro' }, { emoji: '🙋', caption: 'quiero' }, { emoji: '⚽', caption: 'pelota' }],
+        order: ['quiero', 'pelota'], doneLine: '"quiero pelota" — ¡perfecto! 🌟' },
+      { kind: 'sequence', say: 'Ahora: "quiero manzana".',
+        npc: { face: '🦊', mood: MOOD('happy') },
+        pool: [{ emoji: '🥤', caption: 'bebida' }, { emoji: '🙋', caption: 'quiero' }, { emoji: '🍎', caption: 'manzana' }],
+        order: ['quiero', 'manzana'], doneLine: '"quiero manzana" — ¡perfecto! 🌟' },
+      { kind: 'sequence', say: 'Y: "abrazo grande".',
+        npc: { face: '🐻', mood: MOOD('happy') },
+        pool: [{ emoji: '⚽', caption: 'pelota' }, { emoji: '🫅', caption: 'grande' }, { emoji: '🤗', caption: 'abrazo' }],
+        order: ['abrazo', 'grande'], doneLine: '"abrazo grande" — ¡perfecto! 🌟' },
+    ],
+  },
+  {
+    zone: 'forest', level: 4, goal: 'Veo…',
+    intro: "Cuando notamos cosas, podemos decir 'Veo…'. ¡Camina hacia lo que ves!",
+    outro: '¡Usaste tus palabras tan bien! Me encantó hablar contigo.',
+    moment: 'usó sus palabras en el bosque',
+    rounds: [
+      { kind: 'choice', say: '¡Notaste algo! Di "Veo un…" — camina hacia eso.',
+        npc: { face: '👀', mood: MOOD('happy'), thought: { emoji: '🐶' } },
+        options: [
+          { emoji: '🐶', caption: 'perro', correct: true },
+          { emoji: '🐱', caption: 'gato' },
+          { emoji: '🐟', caption: 'pez' },
+        ], doneLine: '¡Veo un perro! ¡Qué buena observación! 👀' },
+      { kind: 'choice', say: '¡Qué buena mirada! ¿Qué ves?',
+        npc: { face: '👀', mood: MOOD('happy'), thought: { emoji: '🌳' } },
+        options: [
+          { emoji: '🌳', caption: 'árbol', correct: true },
+          { emoji: '🪨', caption: 'roca' },
+          { emoji: '☁️', caption: 'nube' },
+        ], doneLine: '¡Veo un árbol! 👀' },
+      { kind: 'choice', say: '¡Muy arriba! ¿Qué ves?',
+        npc: { face: '👀', mood: MOOD('happy'), thought: { emoji: '⭐' } },
+        options: [
+          { emoji: '⭐', caption: 'estrella', correct: true },
+          { emoji: '🌙', caption: 'luna' },
+          { emoji: '☀️', caption: 'sol' },
+        ], doneLine: '¡Veo una estrella! 👀' },
+      { kind: 'choice', say: '¡Qué bonito! ¿Qué ves?',
+        npc: { face: '👀', mood: MOOD('happy'), thought: { emoji: '🦋' } },
+        options: [
+          { emoji: '🦋', caption: 'mariposa', correct: true },
+          { emoji: '🐝', caption: 'abeja' },
+          { emoji: '🐦', caption: 'pájaro' },
+        ], doneLine: '¡Veo una mariposa! 👀' },
+    ],
+  },
+  {
+    zone: 'forest', level: 5, goal: 'Frases y plática',
+    intro: "Vamos a hacer frases completas, ¡y luego turnarnos para platicar como buenos amigos!",
+    outro: '¡Nos turnamos para hablar tan bien! Eso es lo que hacen los amigos. 💜',
+    moment: 'hizo frases y se turnó para hablar',
+    rounds: [
+      { kind: 'sequence', say: 'Di: "Me gustan las manzanas." Camina hacia las palabras en orden.',
+        npc: { face: '😊', mood: MOOD('happy') },
+        pool: [
+          { emoji: '🏃', caption: 'correr' }, { emoji: '🙋', caption: 'me' },
+          { emoji: '🍎', caption: 'manzanas' }, { emoji: '💗', caption: 'gustan' },
+        ],
+        order: ['me', 'gustan', 'manzanas'], doneLine: '"Me gustan las manzanas." ¡Maravilloso!' },
+      { kind: 'sequence', say: 'Ahora: "Te veo."',
+        npc: { face: '😊', mood: MOOD('happy') },
+        pool: [
+          { emoji: '🫅', caption: 'grande' }, { emoji: '🙋', caption: 'yo' },
+          { emoji: '🫵', caption: 'te' }, { emoji: '👀', caption: 'veo' },
+        ],
+        order: ['te', 'veo'], doneLine: '"Te veo." ¡Ahora vamos a platicar — turnen!' },
+      { kind: 'multiPick', say: "¡Vamos a turnarnos! Camina hacia cada burbuja para compartir un turno.", picks: 4,
+        npc: { face: '🐘', mood: MOOD('happy') },
+        options: [
+          { emoji: '💬', caption: 'Mi turno' },
+          { emoji: '🗨️', caption: 'Tu turno' },
+          { emoji: '💬', caption: 'Mi turno' },
+          { emoji: '🗨️', caption: 'Tu turno' },
+        ],
+        doneLine: '¡Nos turnamos tan bien! 💜' },
+    ],
+  },
+];
+
+const FOREST = isEs() ? FOREST_EN.map((item, i) => FOREST_ES[i] ?? item) : FOREST_EN;
+
 // ===========================================================================
 // SHARING SHORE — Sharing & Taking Turns
 // ===========================================================================
 
-const SHORE: Quest[] = [
+const SHORE_EN: Quest[] = [
   {
     zone: 'shore', level: 1, goal: 'Whose turn is it?',
     intro: "My beach friends are playing catch! Help me see whose turn it is.",
@@ -685,6 +1151,139 @@ const SHORE: Quest[] = [
   },
 ];
 
+const SHORE_ES: Quest[] = [
+  {
+    zone: 'shore', level: 1, goal: '¿De quién es el turno?',
+    intro: "¡Mis amigos de la playa están jugando a la pelota! Ayúdame a ver de quién es el turno.",
+    outro: 'Ya sabes todo sobre los turnos. ¡Turnarse hace que los juegos sean divertidos para todos!',
+    moment: 'aprendió sobre los turnos en la orilla',
+    rounds: [
+      { kind: 'choice', say: 'Cangrejo le acaba de lanzar la pelota a Foca. ¿De quién es el turno ahora?',
+        npc: { face: '🦀', mood: MOOD('happy'), thought: { emoji: '⚽' } },
+        options: [
+          { emoji: '🦭', caption: 'Turno de Foca', correct: true },
+          { emoji: '🦀', caption: 'Turno de Cangrejo' },
+        ], doneLine: '¡Sí! Foca tiene la pelota, así que es el turno de Foca!' },
+      { kind: 'choice', say: '¡Foca la devolvió! ¿De quién es el turno ahora?',
+        npc: { face: '🦭', mood: MOOD('excited'), thought: { emoji: '⚽' } },
+        options: [
+          { emoji: '🦀', caption: 'Turno de Cangrejo', correct: true },
+          { emoji: '🦭', caption: 'Turno de Foca' },
+        ], doneLine: '¡Sí! De ida y vuelta — eso es turnarse!' },
+      { kind: 'choice', say: '¡Cangrejo dice que TÚ también puedes jugar! Va Cangrejo, va Foca... ¿quién sigue?',
+        npc: { face: '🦀', mood: MOOD('happy'), thought: { emoji: '🫵' } },
+        options: [
+          { emoji: '🙋', caption: 'Mi turno', correct: true },
+          { emoji: '🦀', caption: 'Turno de Cangrejo' },
+        ], doneLine: '¡Tu turno! Todos tienen su turno cuando compartimos el juego. 🎉' },
+    ],
+  },
+  {
+    zone: 'shore', level: 2, goal: 'Comparte las conchas',
+    intro: "¡Encontré MUCHAS conchas! Compartir significa que todos reciben algunas. Vamos a darles algunas a mis amigos.",
+    outro: 'Compartiste con cada amigo. ¡Mira qué felices están!',
+    moment: 'compartió sus conchas en la orilla',
+    rounds: [
+      { kind: 'multiPick', say: 'Camina hacia una concha para regalarla — ¡una para cada amigo!', picks: 3,
+        npc: { face: '🐢', mood: MOOD('happy') },
+        options: [
+          { emoji: '🐚', caption: 'para Tortuga' },
+          { emoji: '🐚', caption: 'para Cangrejo' },
+          { emoji: '🐚', caption: 'para Foca' },
+        ],
+        doneLine: '¡Una concha para todos! Compartir se siente bien. 💖' },
+      { kind: 'choice', say: 'Tortuga solo tiene un balde, y tú también quieres construir. ¿Cuál es la forma de compartir?',
+        npc: { face: '🐢', mood: MOOD('happy'), thought: { emoji: '🪣' } },
+        options: [
+          { emoji: '🤝', caption: 'usarlo juntos', correct: true },
+          { emoji: '🏃', caption: 'agarrarlo y correr' },
+        ], doneLine: '¡Sí! ¡Podemos usarlo juntos — eso es compartir!' },
+      { kind: 'choice', say: 'Foca quiere ver tu concha brillante. ¡Puedes compartir una MIRADA! ¿Qué dices?',
+        npc: { face: '🦭', mood: MOOD('happy'), thought: { emoji: '✨' } },
+        options: [
+          { emoji: '🫴', caption: '¡ten, mira!', correct: true },
+          { emoji: '🙈', caption: '¡no, es mía!' },
+        ], doneLine: '"¡Ten, mira!" Compartiste y sigue siendo tuya. 🌟' },
+    ],
+  },
+  {
+    zone: 'shore', level: 3, goal: 'Esperar está bien',
+    intro: "A veces esperamos nuestro turno. ¡Esperar también es difícil para mí! Vamos a practicar juntos.",
+    outro: 'Esperaste TAN bien. ¡Esperar significa que tu turno viene pronto!',
+    moment: 'practicó esperar en la orilla',
+    rounds: [
+      { kind: 'choice', say: 'Cangrejo está en el tobogán. ¡Tú quieres un turno! ¿Qué hacemos primero?',
+        npc: { face: '🦀', mood: MOOD('happy'), thought: { emoji: '🛝' } },
+        options: [
+          { emoji: '⏳', caption: 'esperar mi turno', correct: true },
+          { emoji: '😤', caption: 'empujar y pasar' },
+        ], doneLine: '¡Sí — esperamos, y nuestro turno llega!' },
+      { kind: 'breathe', say: '¡Hora de esperar! Respira despacio conmigo mientras Cangrejo termina.',
+        npc: { face: '🐘', mood: MOOD('calm') }, cycles: 2,
+        doneLine: 'Mira — Cangrejo terminó. ¡Ahora es TU turno! 🛝' },
+      { kind: 'choice', say: 'Tortuga todavía está usando el balde. ¿Qué puedes hacer mientras esperas?',
+        npc: { face: '🐢', mood: MOOD('calm'), thought: { emoji: '🪣' } },
+        options: [
+          { emoji: '🏖️', caption: 'jugar cerca', correct: true },
+          { emoji: '😡', caption: 'gritarle a Tortuga' },
+        ], doneLine: '¡Jugar cerca hace que esperar sea fácil — y tu turno igual llega!' },
+    ],
+  },
+  {
+    zone: 'shore', level: 4, goal: 'Pide un turno',
+    intro: "Cuando queremos un turno, podemos PEDIRLO con palabras amables. ¡Vamos a armar las palabras para pedir!",
+    outro: '¡Pediste tan amablemente! Las palabras amables abren el camino a los turnos.',
+    moment: 'pidió un turno en la orilla',
+    rounds: [
+      { kind: 'sequence', say: 'Dilo conmigo: "mi turno por favor". Camina hacia las palabras en orden.',
+        npc: { face: '🦭', mood: MOOD('happy') },
+        pool: [{ emoji: '🏃', caption: 'correr' }, { emoji: '🙋', caption: 'mi turno' }, { emoji: '🙏', caption: 'por favor' }],
+        order: ['mi turno', 'por favor'], doneLine: '"¡Mi turno por favor!" Foca sonríe y te lo entrega. 🌟' },
+      { kind: 'sequence', say: '¡Cangrejo te pidió un turno a TI! Di: "tu turno ahora".',
+        npc: { face: '🦀', mood: MOOD('happy') },
+        pool: [{ emoji: '🐚', caption: 'concha' }, { emoji: '🫵', caption: 'tu turno' }, { emoji: '⏰', caption: 'ahora' }],
+        order: ['tu turno', 'ahora'], doneLine: '"¡Tu turno ahora!" Dar un turno es un regalo. 💖' },
+      { kind: 'choice', say: 'Pediste, pero Tortuga dice "todavía no — un minuto más." ¿Qué hacemos?',
+        npc: { face: '🐢', mood: MOOD('calm'), thought: { emoji: '⏳' } },
+        options: [
+          { emoji: '👍', caption: 'está bien, puedo esperar', correct: true },
+          { emoji: '😭', caption: 'agarrarlo de todas formas' },
+        ], doneLine: '¡Esperaste con calma — y Tortuga recordó tu turno!' },
+    ],
+  },
+  {
+    zone: 'shore', level: 5, goal: 'Construir juntos',
+    intro: "Conejo quiere construir un castillo de arena... ¡y yo también! Vamos a construir UN castillo — ¡juntos!",
+    outro: 'Lo construimos JUNTOS. Compartir lo hizo dos veces mejor. 🏰',
+    moment: 'construyó un castillo de arena con un amigo',
+    rounds: [
+      { kind: 'choice', say: 'Un montón de arena, dos constructores. ¿Cómo empezamos?',
+        npc: { face: '🐰', mood: MOOD('excited'), thought: { emoji: '🏰' } },
+        options: [
+          { emoji: '🤝', caption: 'construir juntos', correct: true },
+          { emoji: '🧱', caption: 'construir un muro entre nosotros' },
+        ], doneLine: '¡Juntos! Dos constructores hacen un castillo INCREÍBLE.' },
+      { kind: 'multiPick', say: '¡Túrnense para agregar partes! Camina hacia cada turno para construir.', picks: 4,
+        npc: { face: '🐰', mood: MOOD('happy') },
+        options: [
+          { emoji: '🏰', caption: 'mi torre' },
+          { emoji: '🐰', caption: 'el muro de Conejo' },
+          { emoji: '🚩', caption: 'mi bandera' },
+          { emoji: '🐚', caption: 'las conchas de Conejo' },
+        ],
+        doneLine: '¡Turno a turno, el castillo creció! 🏰' },
+      { kind: 'choice', say: '¡El castillo está listo! Conejo se ve muy orgulloso. ¿Qué decimos?',
+        npc: { face: '🐰', mood: MOOD('proud'), thought: { emoji: '🏰' } },
+        options: [
+          { emoji: '🎉', caption: '¡lo logramos!', correct: true },
+          { emoji: '😤', caption: 'el mío es mejor' },
+        ], doneLine: '"¡LO logramos!" Esa es la mejor parte de compartir. 💜' },
+    ],
+  },
+];
+
+const SHORE = isEs() ? SHORE_EN.map((item, i) => SHORE_ES[i] ?? item) : SHORE_EN;
+
 // ===========================================================================
 // NILU'S DAY ARC — School, Fun Corner, and Sleepy Island. Same shape as every
 // other island: 5 levels, short warm rounds, errorless, no timers, no losing.
@@ -692,7 +1291,7 @@ const SHORE: Quest[] = [
 
 // ---- SCHOOL ISLAND — School Skills ----------------------------------------
 
-const SCHOOL: Quest[] = [
+const SCHOOL_EN: Quest[] = [
   {
     zone: 'school', level: 1, goal: 'Getting ready to learn',
     intro: "Good morning! It's school time. Owl teacher is here. Let's get ready to learn together.",
@@ -803,9 +1402,122 @@ const SCHOOL: Quest[] = [
   },
 ];
 
+const SCHOOL_ES: Quest[] = [
+  {
+    zone: 'school', level: 1, goal: 'Prepararse para aprender',
+    intro: "¡Buenos días! Es hora de la escuela. La maestra Búho está aquí. Vamos a prepararnos para aprender juntos.",
+    outro: '¡Ya sabes exactamente cómo prepararte para aprender. Muy bien hecho!',
+    moment: 'se preparó para aprender en la Isla Escuela',
+    rounds: [
+      { kind: 'carry', say: "¡Vamos a empacar la mochila! ¡Recoge el libro y llévalo al lugar 1!",
+        npc: { face: '🎒', mood: MOOD('happy') },
+        items: [
+          { emoji: '📚', caption: 'libro' },
+          { emoji: '🥪', caption: 'lonchera' },
+          { emoji: '💧', caption: 'botella de agua' },
+        ],
+        doneLine: '¡Empacado y listo — libro, lonchera, botella de agua!' },
+      { kind: 'choice', say: 'La maestra le está hablando a la clase. ¿Qué hago?',
+        npc: { face: '🦉', mood: MOOD('happy') },
+        options: [
+          step('👂', 'Escuchar', true), step('📢', 'Gritar'), step('🚶', 'Irse caminando'),
+        ], doneLine: 'Escuchar bien te ayuda a aprender.' },
+    ],
+  },
+  {
+    zone: 'school', level: 2, goal: 'Levantar la mano',
+    intro: "En la escuela, usamos la mano para hablar. ¡Vamos a practicar levantarla!",
+    outro: 'Levantaste la mano tan bien. La maestra siempre te ve.',
+    moment: 'practicó levantar la mano en la Isla Escuela',
+    rounds: [
+      { kind: 'choice', say: 'Tengo una pregunta para mi maestra. ¿Qué hago?',
+        npc: { face: '🦉', mood: MOOD('happy'), thought: { emoji: '❓' } },
+        options: [
+          step('✋', 'Levantar la mano y esperar', true), step('📢', 'Gritar'), step('🤚', 'Agarrar a la maestra'),
+        ], doneLine: 'Levanta la mano y espera — la maestra te va a ver.' },
+      { kind: 'choice', say: 'La maestra está ayudando a Conejo ahora mismo. ¿Qué hago?',
+        npc: { face: '🐰', mood: MOOD('happy'), thought: { emoji: '⏳' } },
+        options: [
+          step('⏳', 'Esperar mi turno', true), step('🗣️', 'Interrumpir'),
+        ], doneLine: 'Esperar es difícil, pero tu turno viene pronto.' },
+    ],
+  },
+  {
+    zone: 'school', level: 3, goal: 'Quedarse en mi silla y pedir un descanso',
+    intro: "Sentarse un rato puede sentirse difícil. ¡Siempre está bien pedir un descanso!",
+    outro: 'Pedir un descanso siempre está bien — lo hiciste muy bien.',
+    moment: 'practicó pedir un descanso en la Isla Escuela',
+    rounds: [
+      { kind: 'choice', say: 'Es hora de trabajar en mi mesa. ¿Qué hago?',
+        npc: { face: '🦉', mood: MOOD('happy') },
+        options: [
+          step('🪑', 'Quedarme en mi silla', true), step('🚶', 'Andar de un lado a otro'),
+        ], doneLine: 'Quedarte en tu silla te ayuda a terminar tu trabajo.' },
+      { kind: 'choice', say: 'Mi cuerpo se siente inquieto y quiero moverme. ¿Qué puedo hacer?',
+        npc: { face: '🦉', mood: MOOD('neutral'), thought: { emoji: '🌀' } },
+        options: [
+          step('🙋', 'Pedir un descanso', true), step('🏃', 'Salir corriendo por la puerta'), step('🙈', 'Esconderme bajo el escritorio'),
+        ], doneLine: '¡Pedir un descanso siempre está bien!' },
+      { kind: 'breathe', say: '¡La maestra dice que sí! Toma tu descanso — respira despacio conmigo.',
+        npc: { face: '🦉', mood: MOOD('calm') }, cycles: 2,
+        doneLine: 'Un descanso tranquilo te ayuda a sentirte listo otra vez.' },
+    ],
+  },
+  {
+    zone: 'school', level: 4, goal: 'Modales a la hora del almuerzo',
+    intro: "¡Es hora del almuerzo! Vamos a usar modales amables con nuestros amigos.",
+    outro: 'Qué modales tan amables — compartiste la mesa muy bien.',
+    moment: 'practicó modales de almuerzo en la Isla Escuela',
+    rounds: [
+      { kind: 'choice', say: 'Oso tiene una galleta muy rica en el almuerzo. ¡Se ve tan buena! ¿Qué hago?',
+        npc: { face: '🐻', mood: MOOD('happy'), thought: { emoji: '🍪' } },
+        options: [
+          step('🙏', 'Preguntar primero', true), step('🤚', 'Tomarla sin preguntar'), step('😋', 'Agarrar un poco'),
+        ], doneLine: 'Preguntar primero es amable. Luego es decisión de Oso compartir.' },
+      { kind: 'sort', say: "¡Vamos a ordenar las cosas del almuerzo! Lleva cada una a quien pertenece.",
+        npc: { face: '🦉', mood: MOOD('happy') },
+        tables: [
+          { emoji: '🎒', caption: 'Mis cosas' },
+          { emoji: '🐻', caption: 'Las cosas de Oso' },
+        ],
+        items: [
+          { emoji: '🍱', caption: 'Mi lonchera', table: 0 },
+          { emoji: '💧', caption: 'Mi botella de agua', table: 0 },
+          { emoji: '🍪', caption: 'La galleta de Oso', table: 1 },
+        ],
+        doneLine: '¡Lo tuyo se queda contigo, lo de Oso se queda con Oso!' },
+    ],
+  },
+  {
+    zone: 'school', level: 5, goal: 'Ser un buen amigo en el salón',
+    intro: "La mejor parte de la escuela es ser un buen amigo. ¡Vamos a practicar la amabilidad en el salón!",
+    outro: '¡Terminaste todo un día de escuela siendo tan buen amigo — estoy TAN orgulloso de ti!',
+    moment: 'fue un buen amigo en la Isla Escuela',
+    rounds: [
+      { kind: 'choice', say: '¡A Conejo se le cayeron sus libros al piso! ¿Qué es algo amable que puedes hacer?',
+        npc: { face: '🐰', mood: MOOD('sad'), thought: { emoji: '📚' } },
+        options: [
+          step('🤝', 'Ayudar a recogerlos', true), step('😆', 'Reírse'), step('🚶', 'Irse caminando'),
+        ], doneLine: 'Ayudar a un amigo es lo más amable que puedes hacer.' },
+      { kind: 'choice', say: 'Estamos construyendo con los bloques del salón juntos. Mis manos deben ser...',
+        npc: { face: '🦉', mood: MOOD('happy') },
+        options: [
+          step('🤲', 'Suaves', true), step('✊', 'Bruscas'),
+        ], doneLine: 'Las manos suaves mantienen los bloques — y a tus amigos — seguros.' },
+      { kind: 'choice', say: 'Oso quiere un turno con el juguete del salón. ¿Qué hago?',
+        npc: { face: '🐻', mood: MOOD('happy'), thought: { emoji: '🧸' } },
+        options: [
+          step('🔄', 'Darle un turno a Oso', true), step('🙅', 'Quedármelo para mí'),
+        ], doneLine: 'Turnarse hace que el juguete sea divertido para todos.' },
+    ],
+  },
+];
+
+const SCHOOL = isEs() ? SCHOOL_EN.map((item, i) => SCHOOL_ES[i] ?? item) : SCHOOL_EN;
+
 // ---- FUN CORNER — Home Routines --------------------------------------------
 
-const AFTERNOON: Quest[] = [
+const AFTERNOON_EN: Quest[] = [
   {
     zone: 'afternoon', level: 1, goal: 'Coming home',
     intro: "We're home from school! Buddy Dog is SO happy to see you. Let's do our coming-home steps.",
@@ -917,9 +1629,123 @@ const AFTERNOON: Quest[] = [
   },
 ];
 
+const AFTERNOON_ES: Quest[] = [
+  {
+    zone: 'afternoon', level: 1, goal: 'Llegando a casa',
+    intro: "¡Ya llegamos de la escuela! Perro Amigo está TAN feliz de verte. Vamos a hacer nuestros pasos de llegada a casa.",
+    outro: '¡Llegar a casa a lo acogedor — sabes exactamente qué hacer!',
+    moment: 'practicó llegar a casa en el Rincón Divertido',
+    rounds: [
+      { kind: 'sequence', say: "¡Ya llegamos! Camina hacia los pasos en orden.",
+        npc: { face: '🐕', mood: MOOD('happy'), thought: { emoji: '👟' } },
+        pool: [
+          step('👟', 'Quitarme los zapatos'), step('🧼', 'Lavarme las manos'),
+          step('🤗', 'Abrazar a mi familia'), step('📺', 'Encender la tele'),
+        ],
+        order: ['Quitarme los zapatos', 'Lavarme las manos', 'Abrazar a mi familia'],
+        doneLine: 'En casa, seguro y limpio — ¡ahora los abrazos!' },
+      { kind: 'choice', say: 'Perro Amigo corre a recibirte en la puerta. ¿Qué le dices?',
+        npc: { face: '🐕', mood: MOOD('excited') },
+        options: [
+          step('👋', '¡Hola, Perro Amigo!', true), step('🙈', 'Ignorarlo'),
+        ], doneLine: '¡A Perro Amigo le encanta que lo saluden!' },
+    ],
+  },
+  {
+    zone: 'afternoon', level: 2, goal: 'Hora de la merienda',
+    intro: "¡Hora de la merienda en la mesita! Vamos a elegir algo saludable y a pedirlo amablemente.",
+    outro: 'Esa fue la merienda más linda de todas.',
+    moment: 'compartió la merienda en el Rincón Divertido',
+    rounds: [
+      { kind: 'sort', say: "¡Vamos a ordenar las meriendas! Lleva cada una al plato correcto.",
+        npc: { face: '🐕', mood: MOOD('happy'), thought: { emoji: '🍎' } },
+        tables: [
+          { emoji: '🍎', caption: 'Todos los días' },
+          { emoji: '🎉', caption: 'A veces' },
+        ],
+        items: [
+          { emoji: '🍎', caption: 'manzana', table: 0 },
+          { emoji: '🥕', caption: 'zanahoria', table: 0 },
+          { emoji: '🍬', caption: 'dulce', table: 1 },
+          { emoji: '🍟', caption: 'papitas', table: 1 },
+        ],
+        doneLine: 'Comidas de todos los días y gustitos de a veces — ¡ambos están bien, solo que no en la misma cantidad!' },
+      { kind: 'choice', say: 'Quieres una merienda de la cocina. ¿Qué haces?',
+        npc: { face: '🐕', mood: MOOD('happy') },
+        options: [
+          step('🙋', 'Preguntarle a un adulto', true), step('🤚', 'Agarrarla yo mismo'),
+        ], doneLine: 'Preguntar primero es la forma segura y amable.' },
+    ],
+  },
+  {
+    zone: 'afternoon', level: 3, goal: 'Primero la tarea, luego jugar',
+    intro: "¡Es hora de Primero-Luego! Primero la tarea, luego algo divertido.",
+    outro: '¡Primero la tarea, LUEGO jugar — te lo ganaste!',
+    moment: 'hizo la tarea primero y luego jugó en el Rincón Divertido',
+    rounds: [
+      { kind: 'choice', say: 'Primero la tarea, luego...',
+        npc: { face: '🐕', mood: MOOD('happy'), thought: { emoji: '📝' } },
+        options: [
+          step('🧸', 'Jugar', true), step('📚', 'Más tarea'),
+        ], doneLine: '¡Primero la tarea, luego jugar — ese es el plan!' },
+      { kind: 'steps', say: "¡Vamos a caminar el plan: Primero, Luego, Después!",
+        npc: { face: '🐕', mood: MOOD('happy') },
+        count: 3,
+        labels: ['Primero: tarea 📖', 'Luego: rompecabezas 🧩', 'Después: jugar ⚽'],
+        doneLine: '¡Primero la tarea, luego el rompecabezas, después a jugar — seguiste todo el plan!' },
+    ],
+  },
+  {
+    zone: 'afternoon', level: 4, goal: 'Opciones de la hora de jugar',
+    intro: "¡Ahora la MEJOR parte — hora de jugar! Vamos a jugar afuera de forma amigable.",
+    outro: 'Jugar contigo es la mejor parte de mi día.',
+    moment: 'jugó afuera de forma amigable en el Rincón Divertido',
+    rounds: [
+      { kind: 'choice', say: 'Quieres ir a jugar afuera. ¿Qué hacemos primero?',
+        npc: { face: '🐕', mood: MOOD('excited'), thought: { emoji: '🚪' } },
+        options: [
+          step('🙋', 'Preguntarle a un adulto', true), step('🚪', 'Simplemente salir'),
+        ], doneLine: 'Preguntar primero te mantiene seguro.' },
+      { kind: 'choice', say: 'Perro Amigo también quiere un turno en el columpio. ¿Qué hacemos?',
+        npc: { face: '🐕', mood: MOOD('happy'), thought: { emoji: '🛝' } },
+        options: [
+          step('🔄', 'Turnarse', true), step('🙅', 'Seguir columpiándome'),
+        ], doneLine: 'Turnarse significa que todos tienen su turno.' },
+      { kind: 'choice', say: 'Tienes una pelota para compartir afuera. ¿Cuál es la forma de compartir?',
+        npc: { face: '🐕', mood: MOOD('happy'), thought: { emoji: '⚽' } },
+        options: [
+          step('🤝', 'Jugar juntos', true), step('🙅', 'Quedarme con la pelota'),
+        ], doneLine: 'Compartir hace que jugar afuera sea más divertido.' },
+    ],
+  },
+  {
+    zone: 'afternoon', level: 5, goal: 'Hora de ordenar',
+    intro: "La hora de jugar está terminando. ¡Vamos a ordenar — todo tiene su propio lugar!",
+    outro: '¡Todo de vuelta en su lugar — el Rincón Divertido brilla!',
+    moment: 'ordenó el Rincón Divertido',
+    rounds: [
+      { kind: 'carry', say: '¡Hora de ordenar! Recoge los juguetes y llévalos al lugar 1!',
+        npc: { face: '🐕', mood: MOOD('happy'), thought: { emoji: '🧸' } },
+        items: [
+          { emoji: '🧸', caption: 'juguetes' },
+          { emoji: '📚', caption: 'libros' },
+          { emoji: '👕', caption: 'ropa' },
+        ],
+        doneLine: '¡Juguetes en el cesto, libros en el estante, ropa en la canasta — todo ordenado!' },
+      { kind: 'choice', say: 'Hay un calcetín perdido en el piso. ¿A dónde va?',
+        npc: { face: '🐕', mood: MOOD('happy') },
+        options: [
+          step('🧺', 'La canasta de ropa sucia', true), step('🛏️', 'Debajo de la cama'),
+        ], doneLine: 'Cada cosita tiene su lugar.' },
+    ],
+  },
+];
+
+const AFTERNOON = isEs() ? AFTERNOON_EN.map((item, i) => AFTERNOON_ES[i] ?? item) : AFTERNOON_EN;
+
 // ---- SLEEPY ISLAND — Bedtime Routines ---------------------------------------
 
-const NIGHT: Quest[] = [
+const NIGHT_EN: Quest[] = [
   {
     zone: 'night', level: 1, goal: 'Dinner together',
     intro: "The moon is up and it's dinner time. Sheep is here to eat together, nice and slow.",
@@ -1016,6 +1842,106 @@ const NIGHT: Quest[] = [
     ],
   },
 ];
+
+const NIGHT_ES: Quest[] = [
+  {
+    zone: 'night', level: 1, goal: 'Cenar juntos',
+    intro: "La luna ya salió y es hora de cenar. Oveja está aquí para comer juntos, tranquilos y despacio.",
+    outro: 'Cenar juntos se siente tan acogedor contigo.',
+    moment: 'cenó junto a otros en la Isla del Sueño',
+    rounds: [
+      { kind: 'choice', say: 'Nos sentamos a cenar. ¿Qué hacemos antes de comer?',
+        npc: { face: '🐑', mood: MOOD('calm'), thought: { emoji: '🍽️' } },
+        options: [
+          step('🍽️', 'Esperar a todos', true), step('🍴', 'Empezar a comer solo'),
+        ], doneLine: 'Esperar a todos hace que la cena sea agradable juntos.' },
+      { kind: 'choice', say: 'Hay una comida nueva en tu plato. ¿Qué podemos probar?',
+        npc: { face: '🐑', mood: MOOD('calm'), thought: { emoji: '🥦' } },
+        options: [
+          step('😋', 'Un bocadito', true), step('🙅', 'Negarse a probarla'),
+        ], doneLine: '¡Un bocadito es valiente — gracias por intentarlo!' },
+      { kind: 'choice', say: 'La cena terminó. ¿Qué decimos?',
+        npc: { face: '🐑', mood: MOOD('calm') },
+        options: [
+          step('🙏', '¡Gracias!', true), step('🚶', 'Irse sin decir nada'),
+        ], doneLine: '"¡Gracias!" hace sentir bien a quien cocinó.' },
+    ],
+  },
+  {
+    zone: 'night', level: 2, goal: 'Hora del baño',
+    intro: "¡Hora del baño! Vamos a hacer los pasos del baño en orden, tranquilos y fáciles.",
+    outro: '¡Limpio y acogedor, listo para la pijama!',
+    moment: 'se bañó en la Isla del Sueño',
+    rounds: [
+      { kind: 'sequence', say: '¡Hora del baño! Camina hacia los pasos en orden.',
+        npc: { face: '🐑', mood: MOOD('calm'), thought: { emoji: '🛁' } },
+        pool: [
+          step('🛁', 'Meterse al agua'), step('🧼', 'Lavarse'),
+          step('🧻', 'Secarse'), step('🛌', 'Ponerse la pijama'),
+        ],
+        order: ['Meterse al agua', 'Lavarse', 'Secarse', 'Ponerse la pijama'],
+        doneLine: '¡Bien limpio y cómodo — qué buen baño!' },
+    ],
+  },
+  {
+    zone: 'night', level: 3, goal: 'Cepillarse los dientes',
+    intro: "Los dientes brillantes nos ayudan a dormir dulce. Vamos a cepillarnos, paso a paso.",
+    outro: '¡Dientes brillantes y limpios, listo para dormir!',
+    moment: 'se cepilló los dientes en la Isla del Sueño',
+    rounds: [
+      { kind: 'sequence', say: "Vamos a cepillarnos los dientes. Camina hacia los pasos en orden.",
+        npc: { face: '🐑', mood: MOOD('calm'), thought: { emoji: '🪥' } },
+        pool: [step('🪥', 'Sacar mi cepillo'), step('🧴', 'Ponerle pasta'), step('😁', '¡Cepíllate!')],
+        order: ['Sacar mi cepillo', 'Ponerle pasta', '¡Cepíllate!'],
+        doneLine: '¡Cepilla, cepilla, cepilla — brillante!' },
+      { kind: 'steps', say: '¡Hora de cepillarse! Cuenta conmigo mientras caminas cada número.',
+        npc: { face: '🐑', mood: MOOD('calm'), thought: { emoji: '🪥' } },
+        count: 4,
+        doneLine: '¡Uno, dos, tres, cuatro — cada diente está bien limpio!' },
+    ],
+  },
+  {
+    zone: 'night', level: 4, goal: 'Preparar mi cama',
+    intro: "Vamos a preparar tu cama para una noche acogedora. ¡Camina hacia todo lo que necesitas!",
+    outro: '¡Tu cama está lista para una noche acogedora!',
+    moment: 'preparó su cama en la Isla del Sueño',
+    rounds: [
+      { kind: 'carry', say: '¡Recoge la almohada y llévala al lugar 1 en la cama!',
+        npc: { face: '🐑', mood: MOOD('calm') },
+        items: [
+          { emoji: '🛏️', caption: 'almohada' },
+          { emoji: '🧸', caption: 'osito' },
+          { emoji: '💧', caption: 'vaso de agua' },
+        ],
+        doneLine: '¡Almohada, osito, vaso de agua — tu cama está lista!' },
+    ],
+  },
+  {
+    zone: 'night', level: 5, goal: 'Buenas noches',
+    intro: "El día completo terminó — mañana, escuela, juego, y ahora dormir. Vamos a terminar con un cuento y buenas noches.",
+    outro: '¡Tuviste todo un día maravilloso! Mañana el patio arcoíris nos espera de nuevo. Buenas noches, mi amigo. 🌙',
+    moment: 'dijo buenas noches en la Isla del Sueño',
+    rounds: [
+      { kind: 'choice', say: '¡Es hora del cuento! ¿Cuál historia suena linda esta noche?',
+        npc: { face: '🐑', mood: MOOD('calm'), thought: { emoji: '📖' } },
+        options: [
+          step('🦕', 'El libro de dinosaurios', true), step('🐰', 'El libro del conejito', true),
+        ], doneLine: '¡Qué cuento tan lindo! A acurrucarse.' },
+      { kind: 'choice', say: 'El cuento terminó. ¿Qué le decimos a nuestra familia?',
+        npc: { face: '🐑', mood: MOOD('calm'), thought: { emoji: '💤' } },
+        options: [
+          step('😴', '¡Buenas noches!', true), step('🏃', 'Una vuelta más corriendo'),
+        ], doneLine: '"¡Buenas noches!" Dulce y suave.' },
+      { kind: 'choice', say: 'Las luces se están apagando poco a poco. ¿Qué pasa ahora?',
+        npc: { face: '🐑', mood: MOOD('calm'), thought: { emoji: '🌙' } },
+        options: [
+          step('💤', 'Hora de dormir', true), step('🎮', 'Más tiempo de jugar'),
+        ], doneLine: 'Las luces bajitas significan que es hora de descansar. Dulces sueños. 🌙✨' },
+    ],
+  },
+];
+
+const NIGHT = isEs() ? NIGHT_EN.map((item, i) => NIGHT_ES[i] ?? item) : NIGHT_EN;
 
 // ===========================================================================
 

--- a/components/game/BelusWorld/three/quest/storyContent.ts
+++ b/components/game/BelusWorld/three/quest/storyContent.ts
@@ -7,6 +7,7 @@
 // ---------------------------------------------------------------------------
 
 import type { AnimalSpecies, AnimalMood } from './Animal3D';
+import { isEs } from '../../../../../lib/lang';
 
 export interface HelpOption {
   emoji: string;
@@ -98,6 +99,67 @@ const FEELINGS: Record<AnimalMood, { clues: string[]; helps: HelpOption[] }> = {
   happy: { clues: ['feels happy!'], helps: [{ emoji: '🎉', label: 'Celebrate!', correct: true }] },
 };
 
+// ---- Spanish voice + feeling tables (same shape/order as above) -----------
+const THANKS_ES: Record<AnimalSpecies, string[]> = {
+  fox: ['¡Gracias! Ahora me siento valiente. *ladrido feliz!*', '¡Te quedaste conmigo — eres un verdadero amigo!'],
+  bunny: ['¡Salta, salta! Me hiciste sentir el corazón calientito. 💛', '¡Gracias, amigo! ¿Saltamos juntos?'],
+  bear: ['Aww… ese abrazo grande me ayudó mucho. *sonrisa de oso*', '¡Gracias! Das los mejores abrazos.'],
+  bird: ['¡Pío pío! ¡Ahora me siento ligero como una pluma! 🪶', '¡Me alegraste el día — cantemos juntos!'],
+  cat: ['Ronroneo… ahora me siento tranquilo y calientito. Gracias.', '¡Miau! Eres el amigo más bueno del prado.'],
+};
+
+const FEELINGS_ES: Record<AnimalMood, { clues: string[]; helps: HelpOption[] }> = {
+  scared: {
+    clues: [
+      'se está escondiendo y temblando — tiene miedo.',
+      'está hecho bolita con los ojos bien abiertos — tiene miedo.',
+      'está temblando detrás del pasto — algo lo asustó.',
+    ],
+    helps: [
+      { emoji: '🤫', label: 'Quedarse cerca en silencio', correct: true },
+      { emoji: '👻', label: 'Saltar y gritar' },
+      { emoji: '🚶', label: 'Irse' },
+    ],
+  },
+  sad: {
+    clues: [
+      'está encogido y callado — se siente triste.',
+      'tiene los hombros caídos y la cara llorosa — se siente triste.',
+      'suspira con la cabeza baja — se siente triste.',
+    ],
+    helps: [
+      { emoji: '🤗', label: 'Dar un abrazo cálido', correct: true },
+      { emoji: '🙅', label: 'Decir "deja de llorar"' },
+      { emoji: '😆', label: 'Reírse de él' },
+    ],
+  },
+  lonely: {
+    clues: [
+      'está sentado solito — se siente solo.',
+      'mira a los demás jugar, solito — se siente solo.',
+      'no tiene con quién jugar — se siente solo.',
+    ],
+    helps: [
+      { emoji: '🎈', label: 'Invitarlo a jugar', correct: true },
+      { emoji: '🙈', label: 'Ignorarlo' },
+      { emoji: '🚶', label: 'Dejarlo solo' },
+    ],
+  },
+  worried: {
+    clues: [
+      'se mueve nervioso y mira alrededor — está preocupado.',
+      'camina de un lado a otro y se muerde el labio — está preocupado.',
+      'no puede quedarse quieto y mira por todos lados — está preocupado.',
+    ],
+    helps: [
+      { emoji: '🌬️', label: 'Respirar despacio juntos', correct: true },
+      { emoji: '🏃', label: 'Apurarlo' },
+      { emoji: '🙄', label: 'Decir que es una tontería' },
+    ],
+  },
+  happy: { clues: ['¡se siente feliz!'], helps: [{ emoji: '🎉', label: '¡Celebrar!', correct: true }] },
+};
+
 function f(species: AnimalSpecies, feeling: AnimalMood, x: number, z: number): StoryFriend {
   const cfg = FEELINGS[feeling];
   // deterministic pick from position so it varies without Math.random
@@ -113,7 +175,22 @@ function f(species: AnimalSpecies, feeling: AnimalMood, x: number, z: number): S
   };
 }
 
-export const MEADOW_STORY: StoryLevel[] = [
+function fEs(species: AnimalSpecies, feeling: AnimalMood, x: number, z: number): StoryFriend {
+  const cfg = FEELINGS_ES[feeling];
+  // deterministic pick from position so it varies without Math.random
+  const pick = Math.abs(Math.round((x * 7 + z * 13)));
+  const thanksList = THANKS_ES[species];
+  return {
+    species,
+    feeling,
+    clue: cfg.clues[pick % cfg.clues.length],
+    helps: cfg.helps,
+    pos: [x, z],
+    thanks: thanksList[pick % thanksList.length],
+  };
+}
+
+const MEADOW_STORY_EN: StoryLevel[] = [
   {
     goal: 'Help 2 friends',
     intro: "Some meadow friends are feeling big feelings. Walk up close, see how they feel, and choose a kind way to help!",
@@ -158,3 +235,53 @@ export const MEADOW_STORY: StoryLevel[] = [
     fireflies: [[6, 0], [-6, 0], [0, 6], [5, -5], [-5, 5], [6, 5]],
   },
 ];
+
+const MEADOW_STORY_ES: StoryLevel[] = [
+  {
+    goal: 'Ayuda a 2 amigos',
+    intro: 'Algunos amigos del prado tienen sentimientos grandes. Acércate, mira cómo se sienten y elige una forma amable de ayudar.',
+    outro: '¡Ayudaste a cada amigo a sentirse mejor. Eres muy bondadoso! ☀️',
+    moment: 'ayudó a los amigos del prado',
+    friends: [fEs('fox', 'scared', -2, 0), fEs('bunny', 'sad', 3, 1)],
+    fireflies: [[5, -4], [-5, 3], [1, 5]],
+  },
+  {
+    goal: 'Ayuda a 3 amigos',
+    intro: 'Más amigos necesitan un compañero amable. Mira cómo se ve y se siente cada uno, y luego ayuda.',
+    outro: '¡Tres amigos felices — todo el prado está sonriendo! 🌈',
+    moment: 'ayudó a los amigos del prado',
+    friends: [fEs('bear', 'sad', -3, 2), fEs('bird', 'scared', 3, -2), fEs('bunny', 'lonely', 0, 3)],
+    fireflies: [[5, 4], [-5, -3], [4, 5], [-4, 4]],
+  },
+  {
+    goal: 'Lee 3 sentimientos y ayuda',
+    intro: 'Observa bien sus cuerpitos — cada uno siente algo diferente. Elige cómo ayudar a cada uno.',
+    outro: '¡Leíste cada sentimiento y ayudaste. Qué bondad tan increíble! ☀️',
+    moment: 'ayudó a los amigos del prado',
+    friends: [fEs('cat', 'worried', -3, -2), fEs('bear', 'sad', 3, 2), fEs('fox', 'scared', -2, 3)],
+    fireflies: [[5, 4], [-5, 3], [4, -4], [0, 5]],
+  },
+  {
+    goal: 'Ayuda a 4 amigos',
+    intro: 'Muchos amigos necesitan ayuda hoy. Tú sabes cómo ser amable — ¡ve a cada uno!',
+    outro: '¡Cuatro amigos, cuatro sonrisas. Eres un amigo maravilloso! 🌻',
+    moment: 'ayudó a los amigos del prado',
+    friends: [fEs('bunny', 'sad', -4, 0), fEs('bird', 'lonely', 4, 0), fEs('bear', 'worried', 0, -3), fEs('cat', 'scared', 0, 3)],
+    fireflies: [[5, 5], [-5, -4], [5, -4], [-5, 4], [2, 6]],
+  },
+  {
+    goal: 'Sé el amigo amable de todos',
+    intro: '¡Todo el prado tiene sentimientos grandes. Ayuda a cada amigo a sentirse seguro y feliz!',
+    outro: '¡Eres el amigo más bondadoso de las islas del cielo. El prado está en plena floración! 🌷',
+    moment: 'esparció bondad por el prado',
+    friends: [
+      fEs('bear', 'sad', -4, -2), fEs('cat', 'scared', 4, -2), fEs('bunny', 'lonely', -3, 3),
+      fEs('fox', 'worried', 3, 3), fEs('bird', 'sad', 0, 0),
+    ],
+    fireflies: [[6, 0], [-6, 0], [0, 6], [5, -5], [-5, 5], [6, 5]],
+  },
+];
+
+export const MEADOW_STORY: StoryLevel[] = isEs()
+  ? MEADOW_STORY_EN.map((item, i) => MEADOW_STORY_ES[i] ?? item)
+  : MEADOW_STORY_EN;

--- a/public/gamekit/kit.js
+++ b/public/gamekit/kit.js
@@ -72,6 +72,38 @@
   };
   K.kt = KT;
 
+  // AI-translation disclaimer (kit games): in Spanish mode, a small dismissible
+  // note — translation is entirely AI-made, creators aren't Spanish speakers,
+  // please report mistakes. Shown once per session, auto-hides.
+  if (LANG === 'es') {
+    const showEsNote = () => {
+      try {
+        if (sessionStorage.getItem('abe_es_note')) return;
+        sessionStorage.setItem('abe_es_note', '1');
+      } catch (e) {}
+      const n = document.createElement('div');
+      n.id = 'abeEsNote';
+      n.style.cssText = 'position:fixed;left:50%;bottom:8px;transform:translateX(-50%);z-index:99990;' +
+        'max-width:min(92vw,560px);background:rgba(255,255,255,.96);color:#3a3a5a;border:2px solid #ffd43b;' +
+        "border-radius:14px;padding:10px 38px 10px 14px;font:600 12.5px/1.45 'Comic Sans MS','Chalkboard SE',sans-serif;" +
+        'box-shadow:0 6px 18px rgba(40,40,90,.25);';
+      n.innerHTML = '🌐 La traducción al español fue hecha <b>completamente con IA</b> y puede tener errores — ' +
+        'los creadores no hablan español. Si encuentras un error, por favor avísanos en ' +
+        '<b>aariasblueelephant.org</b>. ¡Gracias! 💙' +
+        "<div style='font-weight:500;font-size:10.5px;opacity:.75;margin-top:3px'>Spanish translation is AI-made and may contain mistakes — please report any at aariasblueelephant.org.</div>";
+      const x = document.createElement('button');
+      x.textContent = '✕';
+      x.setAttribute('aria-label', 'Cerrar');
+      x.style.cssText = 'position:absolute;top:4px;right:6px;border:0;background:none;font-size:16px;font-weight:900;color:#3a3a5a;cursor:pointer;padding:4px;';
+      x.addEventListener('click', () => n.remove());
+      n.appendChild(x);
+      document.body.appendChild(n);
+      setTimeout(() => { if (n.parentNode) n.remove(); }, 20000);
+    };
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', showEsNote);
+    else showEsNote();
+  }
+
   // ---------- profiles (siblings share a tablet without clobbering each other) ----------
   // Profile p1 maps to the ORIGINAL unprefixed keys so nobody's saves are lost.
   const AVATARS = [

--- a/public/gamekit/lang.js
+++ b/public/gamekit/lang.js
@@ -44,4 +44,37 @@
       return b;
     },
   };
+
+  /* AI-translation disclaimer: whenever Spanish mode is on, every game shows a
+   * small dismissible note (once per session) — the translation is entirely
+   * AI-made and the creators are not Spanish speakers; please report mistakes. */
+  if (lang === "es") {
+    var show = function () {
+      try {
+        if (sessionStorage.getItem("abe_es_note")) return;
+        sessionStorage.setItem("abe_es_note", "1");
+      } catch (e) {}
+      var n = document.createElement("div");
+      n.id = "abeEsNote";
+      n.style.cssText = "position:fixed;left:50%;bottom:8px;transform:translateX(-50%);z-index:99990;" +
+        "max-width:min(92vw,560px);background:rgba(255,255,255,.96);color:#3a3a5a;border:2px solid #ffd43b;" +
+        "border-radius:14px;padding:10px 38px 10px 14px;font:600 12.5px/1.45 'Comic Sans MS','Chalkboard SE',sans-serif;" +
+        "box-shadow:0 6px 18px rgba(40,40,90,.25);";
+      n.innerHTML = "🌐 La traducción al español fue hecha <b>completamente con IA</b> y puede tener errores — " +
+        "los creadores no hablan español. Si encuentras un error, por favor avísanos en " +
+        "<b>aariasblueelephant.org</b>. ¡Gracias! 💙" +
+        "<div style='font-weight:500;font-size:10.5px;opacity:.75;margin-top:3px'>Spanish translation is AI-made and may contain mistakes — please report any at aariasblueelephant.org.</div>";
+      var x = document.createElement("button");
+      x.textContent = "✕";
+      x.setAttribute("aria-label", "Cerrar");
+      x.style.cssText = "position:absolute;top:4px;right:6px;border:0;background:none;font-size:16px;" +
+        "font-weight:900;color:#3a3a5a;cursor:pointer;padding:4px;";
+      x.addEventListener("click", function () { n.remove(); });
+      n.appendChild(x);
+      document.body.appendChild(n);
+      setTimeout(function () { if (n.parentNode) n.remove(); }, 20000);
+    };
+    if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", show);
+    else show();
+  }
 })();

--- a/public/legal/disclosure.html
+++ b/public/legal/disclosure.html
@@ -97,6 +97,10 @@
 <h2>Content and characters</h2>
 <p>All characters and scenarios are fictional and taught by role (for example, "the teacher," "a firefighter") rather than by personal name. Any resemblance to real people is coincidental. Game content may change as we improve it, including in response to clinical review and caregiver feedback.</p>
 
+<h2>Spanish translation / Traducción al español</h2>
+<p>The Spanish version of our games was produced <strong>entirely using AI translation</strong>. The creators are not Spanish speakers, and while we have tried to keep the translations warm, accurate, and age-appropriate, they may contain mistakes. The English text remains the authoritative version — in particular for safety-education content, which undergoes clinical review in English. If you find an error or awkward phrasing, please tell us; we will fix it gratefully.</p>
+<p lang="es">La versión en español de nuestros juegos fue creada <strong>completamente con inteligencia artificial</strong>. Los creadores no hablan español y, aunque intentamos que las traducciones sean cálidas, correctas y apropiadas para cada edad, pueden contener errores. El texto en inglés es la versión oficial — especialmente el contenido de educación sobre seguridad, que pasa por revisión clínica en inglés. Si encuentras un error o una frase extraña, por favor escríbenos; lo corregiremos con mucho gusto.</p>
+
 <div class="contact">
   <strong>Questions, concerns, or feedback?</strong> We genuinely want to hear it — especially from parents, educators, and clinicians.<br>
   Write to us: <a href="mailto:hi@aariasblueelephant.org">hi@aariasblueelephant.org</a>


### PR DESCRIPTION
Per AJ: Spanish is a live draft — every game in Spanish mode now shows a dismissible in-Spanish note that the translation is entirely AI-made and may contain mistakes (creators aren't Spanish speakers; report at aariasblueelephant.org), with an English echo line. Disclosure page gains a bilingual section stating English is canonical. Also completes the one known gap: Floating Islands' full quest content translated (8+4 zones, quiz correctness verified preserved, tsc clean, scripted cross-check on sequence rounds). Verified: disclaimer renders in both kit and legacy games; build + checker green.