### PR TITLE
Fix speech voice stuck in the wrong language (all games)

### DIFF
--- a/public/blockcraft/js/audio.js
+++ b/public/blockcraft/js/audio.js
@@ -195,12 +195,12 @@ ABC.audio = (function () {
         const p = part.trim();
         if (!p) continue;
         const u = new SpeechSynthesisUtterance(p);
-        if (window.ABELang) ABELang.voice(u);   // es-US / en-US, per the language toggle
         u.rate = baseRate; u.pitch = basePitch;   // calm, human pace — no chipmunk
         // tiny lift on questions and excitement, like real speech
         if (/\?$/.test(p)) u.pitch = basePitch + 0.08;
         else if (/!$/.test(p)) { u.pitch = basePitch + 0.05; u.rate = baseRate + 0.04; }
         if (useVoice) u.voice = useVoice;
+        if (window.ABELang) ABELang.voice(u);   // AFTER the game's pick: keeps it in EN, swaps to an es voice in Spanish
         speechSynthesis.speak(u);       // queued utterances get natural gaps
       }
     }, 60);

--- a/public/elly-tubbies/index.html
+++ b/public/elly-tubbies/index.html
@@ -1240,10 +1240,12 @@ let voiceOK='speechSynthesis' in window;
 let VOICES={narrator:null,kid:null};
 function pickVoices(){
   const vs=speechSynthesis.getVoices();if(!vs.length)return;
-  const en=vs.filter(v=>v.lang&&v.lang.toLowerCase().startsWith('en'));
-  const byName=n=>en.find(v=>v.name===n);
-  VOICES.narrator=en.find(v=>/premium/i.test(v.name))||en.find(v=>/enhanced/i.test(v.name))
-    ||byName('Samantha')||en[0]||null;
+  // language-aware: in Spanish mode pick Spanish voices (u.voice overrides u.lang!)
+  const want=(window.ABELang&&ABELang.es)?'es':'en';
+  const pool=vs.filter(v=>v.lang&&v.lang.toLowerCase().startsWith(want));
+  const byName=n=>pool.find(v=>v.name===n);
+  VOICES.narrator=pool.find(v=>/premium/i.test(v.name))||pool.find(v=>/enhanced/i.test(v.name))
+    ||byName('Samantha')||byName('Paulina')||pool[0]||null;
   VOICES.kid=byName('Junior')||VOICES.narrator;
 }
 if(voiceOK){pickVoices();speechSynthesis.onvoiceschanged=pickVoices;}

--- a/public/gamekit/kit.js
+++ b/public/gamekit/kit.js
@@ -86,7 +86,7 @@
       n.style.cssText = 'position:fixed;left:50%;bottom:8px;transform:translateX(-50%);z-index:99990;' +
         'max-width:min(92vw,560px);background:rgba(255,255,255,.96);color:#3a3a5a;border:2px solid #ffd43b;' +
         "border-radius:14px;padding:10px 38px 10px 14px;font:600 12.5px/1.45 'Comic Sans MS','Chalkboard SE',sans-serif;" +
-        'box-shadow:0 6px 18px rgba(40,40,90,.25);';
+        'box-shadow:0 6px 18px rgba(40,40,90,.25);pointer-events:none;';
       n.innerHTML = '🌐 La traducción al español fue hecha <b>completamente con IA</b> y puede tener errores — ' +
         'los creadores no hablan español. Si encuentras un error, por favor avísanos en ' +
         '<b>aariasblueelephant.org</b>. ¡Gracias! 💙' +
@@ -94,7 +94,7 @@
       const x = document.createElement('button');
       x.textContent = '✕';
       x.setAttribute('aria-label', 'Cerrar');
-      x.style.cssText = 'position:absolute;top:4px;right:6px;border:0;background:none;font-size:16px;font-weight:900;color:#3a3a5a;cursor:pointer;padding:4px;';
+      x.style.cssText = 'position:absolute;top:4px;right:6px;border:0;background:none;font-size:16px;font-weight:900;color:#3a3a5a;cursor:pointer;padding:4px;pointer-events:auto;';
       x.addEventListener('click', () => n.remove());
       n.appendChild(x);
       document.body.appendChild(n);
@@ -242,12 +242,33 @@
   }
   function refreshMusic() { stopMusic(); if ($('kTitle').style.display === 'none' && !K.paused) startMusic(); }
 
+  // language-aware voice picker (cached; refreshed when voices load late)
+  let voiceCache = {};
+  function pickVoiceFor(lang) {
+    if (voiceCache[lang] !== undefined) return voiceCache[lang];
+    try {
+      const vs = speechSynthesis.getVoices();
+      if (!vs.length) return null;                 // not loaded yet — don't cache
+      const pool = vs.filter((v) => v.lang && v.lang.toLowerCase().startsWith(lang));
+      const ranks = [/natural/i, /neural/i, /premium/i, /enhanced/i, /paulina|m[oó]nica|samantha|ava|jenny/i];
+      let pick = null;
+      for (const r of ranks) { pick = pool.find((v) => r.test(v.name)); if (pick) break; }
+      voiceCache[lang] = pick || pool.find((v) => /US|MX|ES/i.test(v.lang)) || pool[0] || null;
+      return voiceCache[lang];
+    } catch (e) { return null; }
+  }
+  try { speechSynthesis.addEventListener('voiceschanged', () => { voiceCache = {}; }); } catch (e) {}
+
   K.say = (text) => {
     if (muted || !S.voice || !window.speechSynthesis) return;
     try {
       speechSynthesis.cancel();
       const u = new SpeechSynthesisUtterance(String(text).replace(/[\u{1F300}-\u{1FAFF}]/gu, ''));
       u.lang = LANG === 'es' ? 'es-US' : 'en-US';
+      // setting u.lang alone is NOT enough on WebKit/iPad (and sometimes Chrome):
+      // the engine keeps using the previous/default voice. Pick a voice explicitly.
+      const v = pickVoiceFor(LANG);
+      if (v) u.voice = v;
       u.rate = 0.95 / K.speed() > 1.3 ? 1.05 : 0.95; u.pitch = 1.1; speechSynthesis.speak(u);
     } catch (e) {}
   };

--- a/public/gamekit/lang.js
+++ b/public/gamekit/lang.js
@@ -13,6 +13,24 @@
   var lang = "en";
   try { lang = localStorage.getItem("abe.lang") === "es" ? "es" : "en"; } catch (e) {}
   var dict = {};
+  var voiceCache = {};
+  function pickVoice(l) {
+    if (voiceCache[l] !== undefined) return voiceCache[l];
+    try {
+      var vs = window.speechSynthesis ? speechSynthesis.getVoices() : [];
+      if (!vs.length) return null;                 // not loaded yet — don't cache
+      var pool = vs.filter(function (v) { return v.lang && v.lang.toLowerCase().indexOf(l) === 0; });
+      var ranks = [/natural/i, /neural/i, /premium/i, /enhanced/i, /paulina|m[oó]nica|samantha|ava|jenny/i];
+      var pick = null;
+      for (var i = 0; i < ranks.length && !pick; i++) {
+        for (var j = 0; j < pool.length; j++) if (ranks[i].test(pool[j].name)) { pick = pool[j]; break; }
+      }
+      if (!pick) for (var k = 0; k < pool.length; k++) if (/US|MX|ES/i.test(pool[k].lang)) { pick = pool[k]; break; }
+      voiceCache[l] = pick || pool[0] || null;
+      return voiceCache[l];
+    } catch (e) { return null; }
+  }
+  try { speechSynthesis.addEventListener("voiceschanged", function () { voiceCache = {}; }); } catch (e) {}
   function t(s) {
     if (lang !== "es" || s == null) return s;
     s = String(s);
@@ -33,7 +51,19 @@
       try { localStorage.setItem("abe.lang", lang === "es" ? "en" : "es"); } catch (e) {}
       location.reload();
     },
-    voice: function (u) { u.lang = lang === "es" ? "es-US" : "en-US"; return u; },
+    voice: function (u) {
+      u.lang = lang === "es" ? "es-US" : "en-US";
+      // u.lang alone is unreliable (WebKit keeps the old/default voice):
+      // pick an explicit voice for the language — but respect a voice the game
+      // already chose IF it matches the language (e.g. character voices).
+      try {
+        if (!u.voice || !String(u.voice.lang).toLowerCase().startsWith(lang)) {
+          var v = pickVoice(lang);
+          if (v) u.voice = v;
+        }
+      } catch (e) {}
+      return u;
+    },
     label: function () { return lang === "es" ? "🌐 English" : "🌐 Español"; },
     makeButton: function () {
       var b = document.createElement("button");
@@ -59,7 +89,7 @@
       n.style.cssText = "position:fixed;left:50%;bottom:8px;transform:translateX(-50%);z-index:99990;" +
         "max-width:min(92vw,560px);background:rgba(255,255,255,.96);color:#3a3a5a;border:2px solid #ffd43b;" +
         "border-radius:14px;padding:10px 38px 10px 14px;font:600 12.5px/1.45 'Comic Sans MS','Chalkboard SE',sans-serif;" +
-        "box-shadow:0 6px 18px rgba(40,40,90,.25);";
+        "box-shadow:0 6px 18px rgba(40,40,90,.25);pointer-events:none;";
       n.innerHTML = "🌐 La traducción al español fue hecha <b>completamente con IA</b> y puede tener errores — " +
         "los creadores no hablan español. Si encuentras un error, por favor avísanos en " +
         "<b>aariasblueelephant.org</b>. ¡Gracias! 💙" +
@@ -68,7 +98,7 @@
       x.textContent = "✕";
       x.setAttribute("aria-label", "Cerrar");
       x.style.cssText = "position:absolute;top:4px;right:6px;border:0;background:none;font-size:16px;" +
-        "font-weight:900;color:#3a3a5a;cursor:pointer;padding:4px;";
+        "font-weight:900;color:#3a3a5a;cursor:pointer;padding:4px;pointer-events:auto;";
       x.addEventListener("click", function () { n.remove(); });
       n.appendChild(x);
       document.body.appendChild(n);


### PR DESCRIPTION
utterance.lang alone doesn't switch voices on WebKit — explicit voice selection added at both shared choke points (kit say + ABELang.voice), plus three per-game override bugs fixed (Elly always-English picker, Block Craft assignment order, Road Safety coach voice via the shared fix). ES disclaimer note made click-through (could cover Play on short screens). Verified with a stubbed speech engine: EN and ES sessions each pick matching voices in Feelings/Grocery; Elly ES narrator is es-MX.