### PR TITLE
Games page: grown-ups link to Playtest Corner (app has no address bar)

### DIFF
--- a/pages/Games.tsx
+++ b/pages/Games.tsx
@@ -99,6 +99,8 @@ const Games: React.FC = () => {
       Grown-ups: our games collect no personal information — see our{' '}
       <a href="/privacy-policy" className="underline">privacy policy</a> and{' '}
       <a href="/legal/disclosure.html" className="underline">general disclosure</a>.
+      {' '}Running a games table at an event?{' '}
+      <a href="/playtest" className="underline">Playtest Corner</a>.
     </p>
   </div>
   );


### PR DESCRIPTION
One footer line on /games so Playtest Corner is reachable inside the native app (no URL bar there). Discreet, in the grown-ups fine print next to privacy/disclosure. tsc clean.