### PR TITLE
My Movie fixes for legacy games (Block Craft + Elly-Tubbies)

### DIFF
--- a/public/blockcraft/js/main.js
+++ b/public/blockcraft/js/main.js
@@ -1275,8 +1275,9 @@
      A rolling, RAM-only recorder: while playing normally we sample position+yaw
      every 250ms into a flat ring buffer (max 5 minutes ≈ 1200 samples), plus a
      tiny list of fun moments (place/dig/jump/friend/star/heart/treasure).
-     Nothing is persisted; replay only MOVES the camera & avatar and fires
-     sound/particle cues — it never touches the world, scores, or quests. */
+     Persisted across visits (blockcraft.replay.v1); replay only MOVES the
+     camera & avatar and fires sound/particle cues — it never touches the
+     world, scores, or quests. */
   const REC_MS = 250, REC_MAX = 1200;                 // 1200 × 250ms = 5 minutes
   const recPos = new Float32Array(REC_MAX * 4);       // x, y, z, yaw per sample
   let recHead = 0;                                    // total samples ever taken
@@ -1294,6 +1295,8 @@
 
   function recordSample(dt) {
     if (!started || replaying || ABC.ui.isOpen()) return;
+    recPer += dt;
+    if (recPer > 12) { recPer = 0; persistRec(); }   // safety net: pagehide can be missed
     recTimer += dt;
     if (recTimer < REC_MS / 1000) return;
     recTimer = 0;
@@ -1303,6 +1306,40 @@
     recCount = Math.min(recCount + 1, REC_MAX);
     while (recEvents.length && recEvents[0].i < recHead - REC_MAX) recEvents.shift();
   }
+
+  /* keep the adventure across visits, matching the game-kit standard — a
+     RAM-only ring meant "My Movie" always forgot the previous game */
+  const REC_KEY = 'blockcraft.replay.v1';
+  let recPer = 0;
+  function persistRec() {
+    try {
+      if (recCount < 8) return;
+      const base = recHead - recCount, s = [];
+      for (let i = 0; i < recCount; i++) {
+        const o = ((base + i) % REC_MAX) * 4;
+        s.push([+recPos[o].toFixed(2), +recPos[o + 1].toFixed(2), +recPos[o + 2].toFixed(2), +recPos[o + 3].toFixed(3)]);
+      }
+      const e = recEvents.map((ev) => ({ i: ev.i - base, k: ev.k })).filter((ev) => ev.i >= 0).slice(-400);
+      localStorage.setItem(REC_KEY, JSON.stringify({ v: 1, s, e }));
+    } catch (err) {}
+  }
+  (function restoreRec() {
+    try {
+      const d = JSON.parse(localStorage.getItem(REC_KEY) || 'null');
+      if (!d || d.v !== 1 || !Array.isArray(d.s)) return;
+      const src = d.s.filter((x) => Array.isArray(x) && x.length === 4 && x.every(Number.isFinite)).slice(-REC_MAX);
+      for (let i = 0; i < src.length; i++) {
+        const o = i * 4;
+        recPos[o] = src[i][0]; recPos[o + 1] = src[i][1]; recPos[o + 2] = src[i][2]; recPos[o + 3] = src[i][3];
+      }
+      recHead = src.length; recCount = src.length;
+      if (Array.isArray(d.e)) for (const ev of d.e) {
+        if (ev && Number.isFinite(+ev.i) && ev.i >= 0 && ev.i <= src.length && typeof ev.k === 'string') recEvents.push({ i: ev.i, k: ev.k });
+      }
+    } catch (err) {}
+  })();
+  addEventListener('pagehide', persistRec);
+  document.addEventListener('visibilitychange', () => { if (document.hidden) persistRec(); });
 
   /* angle-aware lerp so the avatar turns the short way round */
   function lerpAngle(a, b, t) {

--- a/public/elly-tubbies/index.html
+++ b/public/elly-tubbies/index.html
@@ -2578,16 +2578,21 @@ function floatSprite(ch,pos,rise=3,dur=1.4,scale=1.3){
    quests/friendship/state. Samples: [tMs,x,z,rotY]. Events: [tMs,type,extra].
    ========================================================================== */
 const REC_SAMPLE_MS=250, REC_MAX_SAMPLES=1200, REC_MAX_EVENTS=500, REC_MIN_MS=20000;
-let REC={t0:0,acc:0,samples:[],events:[]};
+/* REC.pt is a GAMEPLAY clock (sum of played dt) — wall clock would turn pause
+   time / replay-watching time into long frozen gaps inside the movie. */
+let REC={pt:0,acc:0,per:0,samples:[],events:[]};
 let replaying=false,replayData=null,replayIdx=0,replayElapsed=0,replaySpeed=1,replaySaved=null,replayIsOwn=false;
+const recT=()=>Math.round((REC.resumeAt||0)+REC.pt);
 function recTick(dt,now){
   if(paused||replaying||mode==='intro'||mode==='finale')return;
+  REC.pt+=dt*1000;
+  REC.per+=dt;
+  if(REC.per>12){REC.per=0;persistRec();}  /* safety net: pagehide can be missed */
   REC.acc+=dt*1000;
   if(REC.acc<REC_SAMPLE_MS)return;
   REC.acc=0;
-  if(!REC.t0)REC.t0=now-(REC.resumeAt||0);
   const p=player.group.position;
-  REC.samples.push([Math.round(now-REC.t0),Math.round(p.x*100)/100,Math.round(p.z*100)/100,
+  REC.samples.push([recT(),Math.round(p.x*100)/100,Math.round(p.z*100)/100,
     Math.round(player.group.rotation.y*1000)/1000]);
   if(REC.samples.length>REC_MAX_SAMPLES){
     REC.samples.shift();
@@ -2598,8 +2603,7 @@ function recTick(dt,now){
 /* call from wherever a fun, recordable moment happens — cheap, no-op while paused/replaying */
 function recEvent(type,extra){
   if(paused||replaying||mode==='intro'||mode==='finale')return;
-  if(!REC.t0)REC.t0=performance.now()-(REC.resumeAt||0);
-  REC.events.push([Math.round(performance.now()-REC.t0),type,extra===undefined?0:extra]);
+  REC.events.push([recT(),type,extra===undefined?0:extra]);
   if(REC.events.length>REC_MAX_EVENTS)REC.events.shift();
 }
 function recordedSpanMs(){const s=REC.samples;return s.length<2?0:s[s.length-1][0]-s[0][0];}

--- a/public/gamekit/kit.js
+++ b/public/gamekit/kit.js
@@ -321,22 +321,28 @@
   }
 
   // ---------- adventure recorder (RAM ring, persisted; NO identifiers) ----------
-  const REC = { t0: 0, samples: [], events: [], resumeAt: 0 };
+  // REC.on: recording starts at Play, NOT at page load — otherwise the title
+  // screen silently records static frames and the ring buffer evicts the
+  // child's previous adventure ("My Movie" losing the old game).
+  // REC.pt: a GAMEPLAY clock (sum of played dt), not wall clock — so time on
+  // the title screen, in pause, or watching a replay never becomes a long
+  // frozen gap inside the movie.
+  const REC = { on: false, pt: 0, samples: [], events: [], resumeAt: 0 };
   const REC_MS = 250, REC_MAX = 1200, REC_MIN = 20000;
   let recAcc = 0;
+  const recT = () => Math.round(REC.resumeAt + REC.pt);
   K.recordEvent = (kind, extra) => {
-    if (K.paused || K.replaying) return;
-    const t = performance.now() - REC.t0 + REC.resumeAt;
-    REC.events.push([Math.round(t), kind, extra || 0]);
+    if (!REC.on || K.paused || K.replaying) return;
+    REC.events.push([recT(), kind, extra || 0]);
     if (REC.events.length > 400) REC.events.shift();
   };
   function recTick(dt, pos) {
-    if (K.paused || K.replaying || !pos) return;
+    if (!REC.on || K.paused || K.replaying || !pos) return;
+    REC.pt += dt * 1000;
     recAcc += dt * 1000;
     if (recAcc < REC_MS) return;
     recAcc = 0;
-    const t = performance.now() - REC.t0 + REC.resumeAt;
-    REC.samples.push([Math.round(t), +pos.x.toFixed(2), +pos.z.toFixed(2), +(pos.ry || 0).toFixed(2)]);
+    REC.samples.push([recT(), +pos.x.toFixed(2), +pos.z.toFixed(2), +(pos.ry || 0).toFixed(2)]);
     while (REC.samples.length > REC_MAX) {
       REC.samples.shift();
       while (REC.events.length && REC.events[0][0] < REC.samples[0][0]) REC.events.shift();
@@ -547,6 +553,7 @@
     const saved = K.load('replay.v1', null);
     REC.samples = (saved && saved.samples) || []; REC.events = (saved && saved.events) || [];
     REC.resumeAt = (REC.samples.length ? REC.samples[REC.samples.length - 1][0] : 0) + 1000;
+    REC.pt = 0;
     $('kTitleMovie').style.display = recSpan() >= REC_MIN ? '' : 'none';
     refreshAvatars(); K.sfx.tap();
   }
@@ -643,7 +650,7 @@
     };
     $('ksVoice').onclick = () => { S.voice = !S.voice; saveS(); p.remove(); openSettings(); };
     $('ksImport').onclick = () => { p.remove(); $('kImportFile').click(); };
-    $('ksHome').onclick = () => { location.href = '/games'; };
+    $('ksHome').onclick = () => { persistRec(); location.href = '/games'; };
     $('ksClose').onclick = () => p.remove();
   }
 
@@ -661,15 +668,16 @@
       REC.samples = saved.samples; REC.events = saved.events || [];
       REC.resumeAt = (REC.samples.length ? REC.samples[REC.samples.length - 1][0] : 0) + 1000;
     }
+    REC.pt = 0;
     if (recSpan() >= REC_MIN) { $('kTitleExtras').style.display = 'block'; }
     else { $('kTitleExtras').style.display = 'block'; $('kTitleMovie').style.display = 'none'; }
-    REC.t0 = performance.now();
 
     const begin = (then) => {
       $('kTitle').style.display = 'none';
       $('kHud').style.display = 'flex'; $('kStick').style.display = 'block'; $('kActs').style.display = 'flex';
       $('kExit').style.display = 'flex';
       ac(); ping(); startMusic();
+      REC.on = true;
       TIME.on = true; TIME.last = performance.now();
       if (stampToday()) setTimeout(() => { K.toast(KT('🛂 Passport stamped! ⭐')); K.sfx.pop(); }, 1500);
       maybeCelebrateMilestone(); applyKnobBadge();
@@ -689,7 +697,7 @@
     $('kTitleImport').onclick = () => { begin(); $('kImportFile').click(); };
     $('kImportFile').addEventListener('change', (e) => { if (e.target.files[0]) importAdventure(e.target.files[0]); e.target.value = ''; });
     $('kMute').onclick = () => { muted = !muted; if (muted && window.speechSynthesis) speechSynthesis.cancel(); refreshMute(); refreshMusic(); K.toast(muted ? '🔇 Sound is off' : '🔊 Sound is on!'); };
-    $('kExit').onclick = () => { location.href = '/games'; };
+    $('kExit').onclick = () => { persistRec(); location.href = '/games'; };
     $('kPauseBtn').onclick = () => { setPaused(true); stopMusic(); };
     $('kResume').onclick = () => { setPaused(false); refreshMusic(); };
     $('kMovie').onclick = () => { recSpan() >= REC_MIN ? startReplay({ samples: REC.samples, events: REC.events }, true) : K.toast(KT('Play a little first, then watch your movie! ▶️')); };
@@ -702,12 +710,15 @@
     document.addEventListener('visibilitychange', () => { if (document.hidden && !K.paused && $('kTitle').style.display === 'none') setPaused(true); });
 
     // main loop wrapper: the game renders; the kit records
-    let last = performance.now();
+    let last = performance.now(), perT = 0;
     function loop(now) {
       const dt = Math.min(0.05, (now - last) / 1000); last = now;
       if (!K.paused) {
         cfg.onFrame && cfg.onFrame(dt);
         if (cfg.playerPos && !K.replaying) recTick(dt, cfg.playerPos());
+        // safety-net persist: pagehide alone can be missed (app kill, crash)
+        perT += dt;
+        if (perT > 12) { perT = 0; if (REC.on && !K.replaying) persistRec(); }
       }
       requestAnimationFrame(loop);
     }


### PR DESCRIPTION
Block Craft's adventure recorder was RAM-only (movie forgot the previous visit) → persisted + restored across visits. Elly-Tubbies used wall-clock timing (pause/replay time became frozen gaps) → gameplay clock matching the kit, plus periodic persistence. Magnet Blocks needs no change (build-history replay persists with the save). Headless-verified both; checker/smoke/build green.