### PR TITLE
Block Craft: Mirror Magic — symmetric building

### DIFF
--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -622,7 +622,7 @@ document.addEventListener('DOMContentLoaded', function () {
     'js/data.js', 'js/audio.js', 'js/world.js', 'js/animals.js', 'js/squishy.js',
     'js/weather.js', 'js/parks.js', 'js/shops.js', 'js/signs.js', 'js/portal.js',
     'js/ui.js', 'js/activities.js', 'js/copycat.js', 'js/music.js', 'js/pet.js', 'js/stickers.js',
-    'js/friends.js', 'js/overnight.js', 'js/photo.js', 'js/dig.js', 'js/train.js', 'js/main.js'
+    'js/friends.js', 'js/overnight.js', 'js/photo.js', 'js/dig.js', 'js/train.js', 'js/mirror.js', 'js/main.js'
   ];
 
   function loadSeq(i) {                          // classic sequential script chain

--- a/public/blockcraft/js/lang-es.js
+++ b/public/blockcraft/js/lang-es.js
@@ -23,6 +23,12 @@
     '🚂 All aboard! Off we go — toot toot!': '🚂 ¡Todos a bordo! Allá vamos — ¡tut tut!',
     '🚂 End of the line! Turning around…': '🚂 ¡Fin de la línea! Dando la vuelta…',
     'What a wonderful train ride! 🚂💙': '¡Qué paseo en tren tan maravilloso! 🚂💙',
+    /* ---------------- 🪞 mirror magic ---------------- */
+    'Mirror': 'Espejo',
+    'Mirror Magician': 'Mago del Espejo',
+    'Build with the magic mirror!': '¡Construye con el espejo mágico!',
+    '🪞 Mirror Magic ON! Build on one side — the mirror builds the other!': '🪞 ¡Espejo Mágico ACTIVADO! Construye de un lado — ¡el espejo construye el otro!',
+    '🪞 Mirror Magic off. Your buildings stay!': '🪞 Espejo Mágico apagado. ¡Tus construcciones se quedan!',
     /* ---------------- title screen ---------------- */
     'Who is playing?': '¿Quién está jugando?',
     '▶ Play!': '▶ ¡Jugar!',

--- a/public/blockcraft/js/main.js
+++ b/public/blockcraft/js/main.js
@@ -114,6 +114,7 @@
   ABC.animals.spawnAll(scene);
   ABC.squishy.init(scene);
   ABC.train.init(scene);
+  ABC.mirror.init(scene);
   ABC.portal.init(scene);
   ABC.music.init(scene);
   ABC.weather.init(scene);
@@ -558,6 +559,7 @@
       if (digging) {
         const t = ABC.world.get(info.cell.x, info.cell.y, info.cell.z);
         if (ABC.world.remove(info.cell.x, info.cell.y, info.cell.z)) {
+          ABC.mirror.echoDig(info.cell);                         // 🪞 dig both sides
           ABC.world.flush(); ABC.audio.sfx.remove(); saveSoon();
           ABC.state.metrics.digs++;                              // 👨‍👩‍👧 parent dashboard
           ABC.replayEvent && ABC.replayEvent('dig');             // 🎬 adventure recorder
@@ -595,6 +597,7 @@
       }
       const rot = def.rotates ? ((Math.round(yaw / (Math.PI / 2)) % 4) + 4) % 4 : 0;
       if (ABC.world.set(p.x, p.y, p.z, id, rot)) {
+        if (ABC.mirror.echoPlace(p, id, rot)) ABC.state.placedCount = (ABC.state.placedCount || 0) + 1;   // 🪞
         ABC.world.flush(); ABC.audio.sfx.pop(); saveSoon();
         ABC.replayEvent && ABC.replayEvent('place');            // 🎬 adventure recorder
         ABC.state.placedCount = (ABC.state.placedCount || 0) + 1;
@@ -1520,6 +1523,11 @@
   }
   ABC.startTrainRide = startRide;
   ABC.endTrainRide = endRide;
+  /* 🪞 the mirror rises where the child is standing */
+  ABC.startMirror = () => {
+    if (!started || replaying || riding) return;
+    ABC.mirror.toggle(feet.x, feet.z);
+  };
   function updateRide(dt) {
     if (!riding) return;
     const seat = ABC.train.seatPose();
@@ -1579,6 +1587,7 @@
       ABC.pet.update(dt, feet);
       ABC.squishy.update(dt, camera);
       ABC.train.tick(dt);
+      ABC.mirror.update(dt);
       ABC.portal.update(dt);
       if (!ABC.ui.isOpen() && !replaying && !riding) ABC.portal.checkWalkIn(feet, dt);
       // hover highlight follows the mouse

--- a/public/blockcraft/js/mirror.js
+++ b/public/blockcraft/js/mirror.js
@@ -1,0 +1,99 @@
+/* Aaria's Block Craft 3D — Mirror Magic 🪞: a shimmering magic mirror rises
+   where you stand, and every block you place (or dig) happens on BOTH sides.
+   Instant castles! Symmetry is the trick — the child builds one half and the
+   mirror builds the other, which is both delightful and quietly teaches the
+   concept. Session-only: the mirror goes away when you leave, the blocks stay. */
+ABC.mirror = (function () {
+  let scene = null;
+  let on = false;
+  let planeX = 0;          // mirror plane at this integer x boundary
+  let wall = null;         // the shimmering visual
+  let sparkles = [];
+  let t = 0, firstUse = false;
+
+  function init(sc) { scene = sc; }
+
+  function buildWall() {
+    const g = new THREE.Group();
+    const c = document.createElement('canvas'); c.width = 32; c.height = 128;
+    const ctx = c.getContext('2d');
+    const gr = ctx.createLinearGradient(0, 0, 0, 128);
+    gr.addColorStop(0, 'rgba(180,220,255,0)');
+    gr.addColorStop(0.5, 'rgba(190,225,255,0.5)');
+    gr.addColorStop(1, 'rgba(200,235,255,0.15)');
+    ctx.fillStyle = gr; ctx.fillRect(0, 0, 32, 128);
+    const tex = new THREE.CanvasTexture(c);
+    const m = new THREE.Mesh(new THREE.PlaneGeometry(30, 9),
+      new THREE.MeshBasicMaterial({ map: tex, transparent: true, side: THREE.DoubleSide,
+        depthWrite: false, blending: THREE.AdditiveBlending }));
+    m.rotation.y = Math.PI / 2;
+    m.position.y = 4.5;
+    g.add(m);
+    g.userData.sheet = m;
+    // a sparkling seam so the mirror line is easy to see on the ground
+    for (let i = 0; i < 14; i++) {
+      const s = new THREE.Mesh(new THREE.SphereGeometry(0.07, 6, 5),
+        new THREE.MeshBasicMaterial({ color: 0xdff3ff }));
+      s.position.set(0, 0.15, -14 + i * 2.15);
+      s.userData = { z0: s.position.z, ph: i * 0.9 };
+      g.add(s); sparkles.push(s);
+    }
+    return g;
+  }
+
+  function toggle(atX, atZ) {
+    on = !on;
+    if (on) {
+      planeX = Math.round(atX);
+      if (!wall) { wall = buildWall(); }
+      wall.position.set(planeX, 0, Math.round(atZ || 0));
+      scene.add(wall);
+      ABC.audio.sfx.shimmer ? ABC.audio.sfx.shimmer() : ABC.audio.sfx.ding();
+      ABC.ui.toast(ABC.tpl('🪞 Mirror Magic ON! Build on one side — the mirror builds the other!'), 4200, true);
+    } else {
+      if (wall) scene.remove(wall);
+      ABC.ui.toast(ABC.tpl('🪞 Mirror Magic off. Your buildings stay!'), 2800, true);
+      ABC.audio.sfx.pop();
+    }
+    return on;
+  }
+
+  const isOn = () => on;
+  const mx = (x) => 2 * planeX - x - 1;              // mirrored cell x
+  /* rotations 0..3 face N/E/S/W; reflecting across an x-plane swaps E and W */
+  const mrot = (rot) => (rot === 1 ? 3 : rot === 3 ? 1 : rot);
+
+  /* called by main.js right after a successful place — echoes it across the mirror */
+  function echoPlace(cell, id, rot) {
+    if (!on) return false;
+    const x2 = mx(cell.x);
+    if (x2 === cell.x) return false;
+    if (ABC.world.set(x2, cell.y, cell.z, id, mrot(rot))) {
+      if (!firstUse) {
+        firstUse = true;
+        ABC.stickers.award && ABC.stickers.award('mirror-magic');
+      }
+      return true;
+    }
+    return false;
+  }
+  /* and after a successful dig */
+  function echoDig(cell) {
+    if (!on) return false;
+    const x2 = mx(cell.x);
+    if (x2 === cell.x) return false;
+    return !!ABC.world.remove(x2, cell.y, cell.z);
+  }
+
+  function update(dt) {
+    if (!on || !wall) return;
+    t += dt;
+    wall.userData.sheet.material.opacity = 0.5 + Math.sin(t * 1.6) * 0.18;
+    for (const s of sparkles) {
+      s.position.y = 0.15 + (Math.sin(t * 1.2 + s.userData.ph) + 1) * 2.2;
+      s.scale.setScalar(0.7 + Math.sin(t * 3 + s.userData.ph) * 0.4);
+    }
+  }
+
+  return { init, toggle, isOn, echoPlace, echoDig, update, mx };
+})();

--- a/public/blockcraft/js/stickers.js
+++ b/public/blockcraft/js/stickers.js
@@ -6,6 +6,7 @@ ABC.stickers = (function () {
   const DEFS = [
     { id:'first-build',     emoji:'🧱', label:'First Builder',   hint:'Place your very first block!' },
     { id:'train-ride',      emoji:'🚂', label:'Train Rider',     hint:'Lay tracks and ride your very own train!' },
+    { id:'mirror-magic',    emoji:'🪞', label:'Mirror Magician', hint:'Build with the magic mirror!' },
     { id:'villa-done',      emoji:'🏡', label:'Villa Champion',  hint:'Finish the Two-Storey Villa!' },
     { id:'rocket-launched', emoji:'🚀', label:'Space Explorer',  hint:'Build the rocket and blast off!' },
     { id:'10-hearts',       emoji:'💖', label:'Kind Heart',      hint:'Collect 10 kindness hearts!' },

--- a/public/blockcraft/js/ui.js
+++ b/public/blockcraft/js/ui.js
@@ -708,6 +708,7 @@ ABC.ui = (function () {
           closeDialog();
           setHand({ kind: 'track', ico: '🛤️' }, ABC.tpl('🛤️ Tap the ground to lay train tracks! Lay a line and your train will come!'));
         } },
+      { ico: '🪞', label: 'Mirror',     go: () => { closeDialog(); ABC.startMirror && ABC.startMirror(); } },
       { ico: '🐱', label: 'Copy Cat',   go: press('copycatBtn') },
       { ico: '🏅', label: 'Stickers',   go: press('stickersBtn') },
       { ico: '📖', label: 'Friends',    go: press('friendsBtn') },


### PR DESCRIPTION
Quick-menu toggle raises a magic mirror where the child stands; every block placed or dug is echoed across it (rotations flipped correctly). Instant symmetric castles. Mirror Magician sticker, bilingual, guarded during replay/rides. Headless-verified + visual twin-tower proof; checker/smoke/build green.