### PR TITLE
Block Craft: skin switcher lives in Settings only

### DIFF
--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -517,7 +517,6 @@ try{
     <button class="menuBtn deskOnly" id="stickersBtn" title="My Treasures">🏅</button>
     <button class="menuBtn deskOnly" id="friendsBtn" title="Friend Book">📖</button>
     <button class="menuBtn" id="speedBtn" title="Game speed — tap for more time 🐢 or faster 🚀">🎛️</button>
-    <button class="menuBtn" id="skinToggleBtn" title="Switch Modern / Smooth / Classic look">🎨</button>
     <button class="menuBtn deskOnly" id="fsBtn" title="Full screen">⛶</button>
     <button class="menuBtn deskOnly" id="settingsBtn" title="Settings">⚙️</button>
     <button class="menuBtn deskOnly" id="helpBtn" title="How to play">❓</button>


### PR DESCRIPTION
Removes the redundant toolbar 🎨 cycler; the Settings '🎨 Block look' row (already present) is the single home for Modern/Smooth/Classic. Modern stays default.