### PR TITLE
Block Craft: fix Start-over being undone by the unload auto-save

### DIFF
--- a/public/blockcraft/js/main.js
+++ b/public/blockcraft/js/main.js
@@ -905,6 +905,7 @@
   const SAVE_KEY = 'aariasBlockCraft3';   // v3: infinite world (edits-only saves)
   let saveTimer = null;
   function saveNow() {
+    if (ABC._resetting) return;       // 🧹 Start-over: beforeunload auto-save must not resurrect the erased world
     if (ABC.state.visiting) return;   // visiting a friend's world — never touch the child's own save
     try {
       const s = ABC.audio.settings;
@@ -1361,6 +1362,7 @@
   let recPer = 0;
   function persistRec() {
     try {
+      if (ABC._resetting) return;     // 🧹 Start-over: don't resurrect the movie either
       if (recCount < 8) return;
       const base = recHead - recCount, s = [];
       for (let i = 0; i < recCount; i++) {

--- a/public/blockcraft/js/ui.js
+++ b/public/blockcraft/js/ui.js
@@ -816,8 +816,12 @@ ABC.ui = (function () {
     wire('setDone',  () => closeDialog());
     wire('setReset', () => {
       message('Start over?', 'This erases the whole world. Are you sure?', 'Yes, new world! 🌍', () => {
+        // the beforeunload auto-save must NOT resurrect the world we just
+        // erased — flag the reset so every save path stands down
+        ABC._resetting = true;
         localStorage.removeItem('aariasBlockCraft3');
         localStorage.removeItem('aariasBlockCraft2');
+        localStorage.removeItem('blockcraft.replay.v1');   // fresh start = fresh movie too
         location.reload();
       }, '🧹');
     });


### PR DESCRIPTION
The beforeunload auto-save was resurrecting the world immediately after Start-over erased it. A reset flag now stands the save paths down; the adventure movie is cleared too. Headless-verified.