### PR TITLE
ci: add security audit (npm audit high/critical, daily)

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,45 @@
+name: Security Audit
+
+# Runs `npm audit` against production dependencies on a daily cadence and on
+# pull requests that touch package files. Fails on `high` or `critical` so a
+# fresh template/site is never deployed with known-exploitable libraries.
+#
+# Dependabot still handles the upgrades; this workflow makes sure we notice if
+# a published advisory lands between Dependabot runs.
+
+on:
+  schedule:
+    - cron: '30 6 * * *' # daily, 06:30 UTC
+  pull_request:
+    branches: ['main']
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: npm audit (production)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install (no scripts)
+        run: npm ci --ignore-scripts
+
+      - name: Audit high-severity production deps
+        run: npm run audit:high

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
+    "audit:high": "npm audit --omit=dev --audit-level=high",
     "dev": "vite",
     "fetch-data": "tsx scripts/fetch-resilience-data.ts",
     "build": "npm run check:controls && npm run fetch-data && tsc && vite build && cp data/games.json dist/games-catalog.json && node prerender.js && node scripts/minify-games.mjs",


### PR DESCRIPTION
Adds dependency-vulnerability detection to this site. Opened by Free For Charity automation.

- `.github/workflows/security-audit.yml` — daily `npm audit` on production dependencies, copied verbatim from [the FFC template](https://github.com/FreeForCharity/FFC-IN-FFC_Single_Page_Template/blob/main/.github/workflows/security-audit.yml) apart from the schedule.
- `package.json` — an `audit:high` script (`npm audit --omit=dev --audit-level=high`), which is what that workflow runs.

Scheduled at `30 6 * * *` (30 past 06:00 UTC). The minute is derived from this repo's name so the fleet spreads across the hour instead of every site starting at once.

Both files land together on purpose: the workflow without the script fails on every run, and the script without the workflow never runs at all.

**If this PR's first Security Audit run goes red, that is the workflow working** — it means this site already depends on a package with a published high or critical advisory. The upgrade is tracked separately in [FFC-Cloudflare-Automation#822](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/822); this change only makes it visible.

Generated by FFC workflow **742. Repo - Fleet Security Audit Backfill**. Refs [FreeForCharity/FFC-Cloudflare-Automation#838](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/838).