### PR TITLE
Block Craft Modern skin: 53x faster edits, hidden-face culling, PBR surfaces, real sun and water

### DIFF
--- a/public/blockcraft/js/main.js
+++ b/public/blockcraft/js/main.js
@@ -86,6 +86,13 @@
       composer = new L.EffectComposer(renderer);
       composer.addPass(new L.RenderPass(scene, camera));
       const gtao = new L.GTAOPass(scene, camera, W, H);
+      // GTAOPass ships metre-scale defaults (radius 0.25, denoise depthPhi 2), but a
+      // block here is 1 unit — so retune in block units: occlusion reaches 3/4 of a
+      // face, a hit only counts as an occluder within one block's depth (cubes are
+      // solid, not shells), and the denoise stops at half a block so AO can't bleed
+      // over a 1-block ledge. 12 samples = 3 directions x 4 steps, the tablet rung.
+      gtao.updateGtaoMaterial({ radius: 0.75, thickness: 1.0, samples: 12 });
+      gtao.updatePdMaterial({ radius: 6, depthPhi: 0.5 });
       gtao.blendIntensity = 0.85;            // soft contact shading, not a dirt pass
       // decorative geometry (grass tufts, rain, smoke, clouds, footprints) must
       // not write AO — alphaTest quads/points read as solid slabs in the AO

--- a/public/blockcraft/js/world.js
+++ b/public/blockcraft/js/world.js
@@ -37,9 +37,41 @@ ABC.world = (function () {
 
   let scene, materials = {}, meshes = {}, dirty = new Set(), underMesh = null;
   let blockGeo = null;
-  let _maxAniso = 1, _sky = null, _shadowR = 32;   // smooth-skin render state
+  let _maxAniso = 1, _sky = null, _shadowR = 32, _sunBall = null;   // smooth-skin render state
   const _clouds = [];                              // modern drifting clouds
-  const map = new Map();      // "x,y,z" -> type
+  /* "x,y,z" -> type. A thin wrapper over a real Map that ALSO keeps a
+     type -> Set(key) index up to date on every write. rebuild(type) used to
+     scan every loaded block in the world (~130k entries, each with a
+     split(',').map(Number)) to find the few thousand of one type — so the cost
+     of placing a block grew with how much you had already built. With the index
+     a rebuild only ever walks its own type. The wrapper keeps the index honest
+     without touching the eleven places that write to the map. */
+  const byType = new Map();   // type -> Set(key)
+  const map = {
+    _m: new Map(),
+    get(k) { return this._m.get(k); },
+    has(k) { return this._m.has(k); },
+    get size() { return this._m.size; },
+    keys() { return this._m.keys(); },
+    entries() { return this._m.entries(); },
+    [Symbol.iterator]() { return this._m[Symbol.iterator](); },
+    set(k, t) {
+      const old = this._m.get(k);
+      if (old === t) return this;
+      if (old !== undefined) { const s = byType.get(old); if (s) s.delete(k); }
+      this._m.set(k, t);
+      let s = byType.get(t); if (!s) byType.set(t, s = new Set());
+      s.add(k);
+      return this;
+    },
+    delete(k) {
+      const old = this._m.get(k);
+      if (old === undefined) return false;
+      const s = byType.get(old); if (s) s.delete(k);
+      return this._m.delete(k);
+    },
+    clear() { this._m.clear(); byType.clear(); },
+  };
   const rotMap = new Map();   // "x,y,z" -> 0..3 quarter-turns (rotating shapes only)
   const key = (x,y,z) => x + ',' + y + ',' + z;
 
@@ -734,11 +766,41 @@ ABC.world = (function () {
   }
 
   const _m4 = new THREE.Matrix4(), _v1 = new THREE.Vector3(), _cJ = new THREE.Color();
+  /* Modern only: a flat "real ground" cube whose six neighbours are all flat
+     ground cubes can never be seen, so it gets no instance at all. Restricted to
+     REAL_GROUND on purpose — those are the only blocks modernGeoFor gives a
+     seam-tiling flat BoxGeometry. The craft blocks keep their 0.07 bevel, which
+     leaves a visible gap at every join, so hiding one behind another would punch
+     a hole through a wall. Below MIN_Y counts as covered: the dark underMesh
+     already seals the floor, so the whole bedrock layer drops out too. */
+  const SOLID_HIDE = MODERN ? new Set(REAL_GROUND) : null;
+  function buried(type, x, y, z) {
+    const s = SOLID_HIDE;
+    if (!s || !s.has(type)) return false;
+    return s.has(map.get(key(x + 1, y, z))) && s.has(map.get(key(x - 1, y, z)))
+        && s.has(map.get(key(x, y, z + 1))) && s.has(map.get(key(x, y, z - 1)))
+        && s.has(map.get(key(x, y + 1, z)))
+        && (y - 1 < MIN_Y || s.has(map.get(key(x, y - 1, z))));
+  }
+  /* an edit can EXPOSE a neighbour that was culled (dig the grass off a hillside
+     and the dirt under it has to appear), so every write also dirties the types
+     around it. Cheap now that a rebuild only walks its own type. */
+  function dirtyAround(x, y, z) {
+    if (!SOLID_HIDE) return;
+    for (const d of NEIGHBORS) {
+      const t = map.get(key(x + d[0], y + d[1], z + d[2]));
+      if (t && SOLID_HIDE.has(t)) dirty.add(t);
+    }
+  }
+  const NEIGHBORS = [[1,0,0],[-1,0,0],[0,1,0],[0,-1,0],[0,0,1],[0,0,-1]];
+
   function rebuild(type) {
     let m = meshes[type];
     const pos = [], keys = [];
-    for (const [k, t] of map) if (t === type) {
+    const own = byType.get(type);
+    if (own) for (const k of own) {
       const [x,y,z] = k.split(',').map(Number);
+      if (buried(type, x, y, z)) continue;
       pos.push([x,y,z]); keys.push(k);
     }
     if (pos.length > m.instanceMatrix.count) {       // grow capacity
@@ -800,6 +862,7 @@ ABC.world = (function () {
     map.set(k, type);
     if (rot) rotMap.set(k, rot); else rotMap.delete(k);
     dirty.add(type);
+    dirtyAround(x, y, z);                       // swapping dirt for glass exposes its neighbours
     editSet.set(k, { t: type, r: rot || 0 });   // player edits persist forever
     editDel.delete(k);
     return true;
@@ -812,6 +875,7 @@ ABC.world = (function () {
     map.delete(k);
     rotMap.delete(k);
     dirty.add(old);
+    dirtyAround(x, y, z);                 // digging a hole reveals whatever was culled behind it
     editSet.delete(k);
     editDel.add(k);                              // remember the hole forever
     return true;
@@ -1174,13 +1238,21 @@ ABC.world = (function () {
      1024 map covers a small area at high quality. Rounds the target to reduce
      shadow swim as you walk (a soft help — the sun axis is diagonal, so it's not
      a perfect texel lock, but enough at this map size to stay calm). */
-  const _sunBase = new THREE.Vector3(40, 80, 25);
+  /* Sun direction. The old (40,80,25) sat ~60° up — near-noon, so every block
+     cast a stubby shadow and the world read flat. (62,52,38) is the same
+     distance but ~36° up: long raking shadows down the side of a build, which
+     is the single strongest "this is a real game" cue in a voxel screenshot. */
+  const _sunBase = new THREE.Vector3(62, 52, 38);
+  const SUN_DIST = 2.7;                     // ball sits at 2.7x the light's offset (≈241 — inside the 280 sky dome)
   function updateSun(px, pz) {
     if (!SMOOTH || !sunLight) return;
     const texel = (_shadowR * 2) / sunLight.shadow.mapSize.x;
     const tx = Math.round(px / texel) * texel, tz = Math.round(pz / texel) * texel;
     sunLight.target.position.set(tx, 0, tz);
     sunLight.position.set(tx + _sunBase.x, _sunBase.y, tz + _sunBase.z);
+    // the visible sun sits along the SAME ray the light comes from, so shadows
+    // finally point away from the thing casting them
+    if (_sunBall) _sunBall.position.set(tx + _sunBase.x * SUN_DIST, _sunBase.y * SUN_DIST, tz + _sunBase.z * SUN_DIST);
   }
 
   function updateSky(cam, dt) {
@@ -1223,16 +1295,22 @@ ABC.world = (function () {
       scene.environment = makeEnvironment(renderer);   // soft daylight fill for the PBR blocks
       // one warm key sun that casts a single soft, player-following shadow
       sunLight = new THREE.DirectionalLight(0xfff3da, 2.4 * LIGHT_SCALE);
-      sunLight.position.set(40, 80, 25);
+      sunLight.position.copy(_sunBase);
       sunLight.castShadow = true;
-      // modern: crisper, wider shadows (2048px over R=40) — r170 handles it fine
+      // modern: crisper, wider shadows (2048px over R=55) — r170 handles it fine.
+      // R grew with the lower sun: a 35° sun throws a shadow ~1.4x the caster's
+      // height, so a tall build at the edge of the old R=40 box lost its tip.
       sunLight.shadow.mapSize.set(MODERN ? 2048 : 1024, MODERN ? 2048 : 1024);
-      _shadowR = MODERN ? 40 : 32;
+      _shadowR = MODERN ? 55 : 32;
       const sc = sunLight.shadow.camera;
       sc.left = -_shadowR; sc.right = _shadowR; sc.top = _shadowR; sc.bottom = -_shadowR;
       sc.near = 1; sc.far = 220; sc.updateProjectionMatrix();
-      sunLight.shadow.bias = -0.0005;
-      sunLight.shadow.normalBias = 0.5;               // primary fix for axis-aligned voxel acne
+      // normalBias 0.5 was a sledgehammer against axis-aligned voxel acne, and it
+      // ate the contact shadow at every block seam along with the acne. Modern's
+      // ground is flat, seam-tiling cubes, so a bias just over one shadow texel
+      // (2*55/2048 ≈ 0.054) is enough — block-on-block contact comes back.
+      sunLight.shadow.bias = MODERN ? -0.0009 : -0.0005;
+      sunLight.shadow.normalBias = MODERN ? 0.06 : 0.5;
       scene.add(sunLight); scene.add(sunLight.target);
       scene.add(new THREE.AmbientLight(0xcfe8ff, 0.5 * LIGHT_SCALE));
       hemiLight = new THREE.HemisphereLight(0xbfe3ff, 0x6f9c52, 0.34 * LIGHT_SCALE);
@@ -1294,11 +1372,17 @@ ABC.world = (function () {
     }
     // sun ball — on modern its color sits above 1.0 so the bloom pass gives it
     // a real glow (everything else stays under the bloom threshold)
-    const sunMat = new THREE.MeshBasicMaterial({ color:0xffe45e });
+    // The ball used to be nailed to world (70,60,-80) while the light shone from
+    // player+(40,80,25) — so the shadows pointed away from a sun that wasn't
+    // there, and after a long walk the "sun" slid off behind you. It now rides
+    // the light's own direction (see updateSky) and ignores fog, so it stays put
+    // in the sky wherever you wander.
+    const sunMat = new THREE.MeshBasicMaterial({ color:0xffe45e, fog:false });
     if (MODERN) sunMat.color.setRGB(2.6, 2.2, 1.2);
-    const sunBall = new THREE.Mesh(new THREE.SphereGeometry(5, 16, 16), sunMat);
-    sunBall.position.set(70, 60, -80);
-    scene.add(sunBall);
+    _sunBall = new THREE.Mesh(new THREE.SphereGeometry(5, 16, 16), sunMat);
+    _sunBall.frustumCulled = false;
+    _sunBall.userData.noAO = true;          // a glowing ball must not stamp AO on the sky
+    scene.add(_sunBall);
     buildStars();
     initMeshes();
     return scene;

--- a/public/blockcraft/js/world.js
+++ b/public/blockcraft/js/world.js
@@ -507,26 +507,43 @@ ABC.world = (function () {
     t.needsUpdate = true;                    // colorSpace stays linear — these are DATA, not colour
     return t;
   }
+  let _pbrMs = 0, _pbrMaps = 0;         // diagnostics — see ABC.world.diag()
   function pbrTex(kind, base, base2, bump) {
     const map = realTexture(kind, base, base2);
     const ck = kind + base + (base2 || ''), pk = ck + '|' + bump;
     if (_realPbr[pk]) return _realPbr[pk];
     const cv = _realCv[ck];
     if (!cv) return (_realPbr[pk] = { map });
+    const _t0 = performance.now();
     const S = cv.width;
     let src;
     try { src = cv.getContext('2d').getImageData(0, 0, S, S).data; }
     catch (e) { return (_realPbr[pk] = { map }); }   // tainted canvas — colour only, still fine
-    const lum = new Float32Array(S * S);
-    for (let i = 0; i < S * S; i++)
-      lum[i] = (src[i*4] * 0.299 + src[i*4+1] * 0.587 + src[i*4+2] * 0.114) / 255;
-    const at = (x, y) => lum[((y % S) + S) % S * S + (((x % S) + S) % S)];
-    const nrm = new Uint8Array(S * S * 4), rgh = new Uint8Array(S * S * 4);
-    for (let y = 0; y < S; y++) for (let x = 0; x < S; x++) {
-      const i = y * S + x;
+    /* Derive at HALF the colour map's resolution. Relief survives downsampling
+       far better than colour does, and full res cost real money on the devices
+       this game is for: measured at 256 the Sobel was 274ms of a 428ms scene
+       build and the derived maps alone were ~18MB of texture. Half res is a
+       quarter of both, for no difference you can see on a block face. */
+    const D = S >> 1, sc = S / D;
+    const lum = new Float32Array(D * D);
+    for (let y = 0; y < D; y++) for (let x = 0; x < D; x++) {
+      let a = 0;                                     // box-filter down, then Sobel that
+      for (let oy = 0; oy < sc; oy++) for (let ox = 0; ox < sc; ox++) {
+        const j = ((y * sc + oy) * S + (x * sc + ox)) * 4;
+        a += src[j] * 0.299 + src[j+1] * 0.587 + src[j+2] * 0.114;
+      }
+      lum[y * D + x] = a / (255 * sc * sc);
+    }
+    const at = (x, y) => lum[((y % D) + D) % D * D + (((x % D) + D) % D)];
+    // a feature spans half as many texels at half res, so the same visual slope
+    // comes out of half the gain
+    const gain = bump / sc;
+    const nrm = new Uint8Array(D * D * 4), rgh = new Uint8Array(D * D * 4);
+    for (let y = 0; y < D; y++) for (let x = 0; x < D; x++) {
+      const i = y * D + x;
       const dx = (at(x+1,y-1) + 2*at(x+1,y) + at(x+1,y+1)) - (at(x-1,y-1) + 2*at(x-1,y) + at(x-1,y+1));
       const dy = (at(x-1,y+1) + 2*at(x,y+1) + at(x+1,y+1)) - (at(x-1,y-1) + 2*at(x,y-1) + at(x+1,y-1));
-      const nx = -dx * bump, ny = -dy * bump, l = Math.hypot(nx, ny, 1);
+      const nx = -dx * gain, ny = -dy * gain, l = Math.hypot(nx, ny, 1);
       nrm[i*4]     = (nx / l * 0.5 + 0.5) * 255;
       nrm[i*4 + 1] = (ny / l * 0.5 + 0.5) * 255;
       nrm[i*4 + 2] = (1  / l * 0.5 + 0.5) * 255;
@@ -534,7 +551,9 @@ ABC.world = (function () {
       const r = 255 * (0.58 + (1 - lum[i]) * 0.42);
       rgh[i*4] = rgh[i*4 + 1] = rgh[i*4 + 2] = r; rgh[i*4 + 3] = 255;
     }
-    return (_realPbr[pk] = { map, normalMap: dataTex(nrm, S), roughnessMap: dataTex(rgh, S) });
+    const out = { map, normalMap: dataTex(nrm, D), roughnessMap: dataTex(rgh, D) };
+    _pbrMs += performance.now() - _t0; _pbrMaps += 2;
+    return (_realPbr[pk] = out);
   }
 
   function modernStd(tex, extra) {
@@ -1539,7 +1558,9 @@ ABC.world = (function () {
   }
 
   /* ---------- scene setup ---------- */
+  let _initMs = 0;
   function initScene(renderer) {
+    const _t0 = performance.now();
     scene = new THREE.Scene();
     _maxAniso = renderer.capabilities.getMaxAnisotropy();
     if (SMOOTH) {
@@ -1647,7 +1668,28 @@ ABC.world = (function () {
     scene.add(_sunBall);
     buildStars();
     initMeshes();
+    _initMs = performance.now() - _t0;
     return scene;
+  }
+  /* what the scene cost to stand up — how long initScene took, how much of that
+     was deriving normal/roughness maps, and the texture memory they add. Read by
+     scripts/bc-verify.mjs; safe to call any time. */
+  function diag() {
+    const seen = new Set();
+    let bytes = 0, count = 0;
+    const add = (t) => {
+      if (!t || seen.has(t)) return;
+      seen.add(t);
+      const w = (t.image && t.image.width) || 0, h = (t.image && t.image.height) || 0;
+      if (!w) return;
+      count++;
+      bytes += w * h * 4 * (t.generateMipmaps ? 4 / 3 : 1);
+    };
+    for (const m of Object.values(materials))
+      for (const one of (Array.isArray(m) ? m : [m]))
+        { add(one.map); add(one.normalMap); add(one.roughnessMap); }
+    return { initMs: +_initMs.toFixed(1), pbrMs: +_pbrMs.toFixed(1), pbrMaps: _pbrMaps,
+             texCount: count, texMB: +(bytes / 1048576).toFixed(2) };
   }
 
   /* ---------- save / load (diff against the generated world) ---------- */
@@ -2078,5 +2120,5 @@ ABC.world = (function () {
   return { SIZE, MAX_Y, MIN_Y, initScene, generate: infiniteInit, get, set, remove, flush, key,
            blockMeshes, serialize: serializeEdits, deserialize: deserializeEdits, materials,
            ensureChunks, setTheme, gradeFrame, updateSky, updateSun, getRot, topBlock,
-           entityShadows, setSkyPipeline, footstep, findNear, getScene: () => scene };
+           entityShadows, setSkyPipeline, footstep, findNear, getScene: () => scene, diag };
 })();

--- a/public/blockcraft/js/world.js
+++ b/public/blockcraft/js/world.js
@@ -379,6 +379,81 @@ ABC.world = (function () {
         }
         for (let i = 0; i < 10; i++) blob(rnd() * S, rnd() * S, 8 + rnd() * 14, '#ffffff', 0.14); // sparkle
         break;
+      /* ---- crafted surfaces: the blocks kids actually BUILD with ----
+         The natural ground already looked real while planks and bricks were
+         still on the old flat pattern painter, so every house read as a toy
+         sitting in a convincing landscape. These four cover the whole build
+         palette once modernMaterial routes them by def.pat. */
+      case 'plank': {
+        const rows = 4, rh = S / rows;
+        g.fillStyle = shade(base, -0.06); g.fillRect(0, 0, S, S);
+        for (let r = 0; r < rows; r++) {
+          const y0 = r * rh;
+          g.fillStyle = shade(base, -0.10 + rnd() * 0.2);   // each board a slightly different cut
+          g.fillRect(0, y0, S, rh);
+          for (let i = 0; i < 34; i++) {                    // long grain, period-exact so it tiles in x
+            const gy = y0 + 3 + rnd() * (rh - 6), wob = 1 + (rnd() * 2 | 0), ph = rnd() * 7;
+            g.strokeStyle = shade(base, -0.3 + rnd() * 0.5); g.lineWidth = 0.7 + rnd();
+            g.globalAlpha = 0.22 + rnd() * 0.3; g.beginPath();
+            for (let x = 0; x <= S; x += 8) g.lineTo(x, gy + Math.sin(x / S * Math.PI * 2 * wob + ph) * 1.8);
+            g.stroke(); g.globalAlpha = 1;
+          }
+          if (rnd() < 0.45) {                               // the odd knot
+            const kx = 20 + rnd() * (S - 40), ky = y0 + rh * 0.5;
+            for (let rr = 7; rr > 1.5; rr -= 1.8) {
+              g.fillStyle = shade(base, rr % 3.6 < 1.8 ? -0.34 : 0.08);
+              g.beginPath(); g.ellipse(kx, ky, rr * 1.6, rr, 0, 0, 7); g.fill();
+            }
+          }
+          g.globalAlpha = 0.85; g.fillStyle = shade(base, -0.55);   // shadowed seam between boards
+          g.fillRect(0, y0, S, 2.5);
+          g.globalAlpha = 0.35; g.fillStyle = shade(base, 0.32);    // lit lip just under it
+          g.fillRect(0, y0 + 2.5, S, 1.5); g.globalAlpha = 1;
+        }
+        break; }
+      case 'brick': {
+        const rows = 4, rh = S / rows, bw = S / 2, m = 3;
+        g.fillStyle = shade(base, -0.42); g.fillRect(0, 0, S, S);   // mortar bed
+        for (let r = 0; r < rows; r++) {
+          const off = (r % 2) ? bw / 2 : 0, y = r * rh;
+          for (let c = -1; c < 3; c++) {                            // -1..2 so the running bond wraps
+            const x = c * bw + off;
+            g.fillStyle = shade(base, -0.12 + rnd() * 0.24);
+            g.fillRect(x + m, y + m, bw - m * 2, rh - m * 2);
+            g.globalAlpha = 0.55; g.lineWidth = 1.6;                // sun-catching top-left arris…
+            g.strokeStyle = shade(base, 0.3);
+            g.beginPath(); g.moveTo(x+m, y+rh-m); g.lineTo(x+m, y+m); g.lineTo(x+bw-m, y+m); g.stroke();
+            g.strokeStyle = shade(base, -0.38);                     // …shadowed bottom-right
+            g.beginPath(); g.moveTo(x+bw-m, y+m); g.lineTo(x+bw-m, y+rh-m); g.lineTo(x+m, y+rh-m); g.stroke();
+            g.globalAlpha = 0.3;
+            for (let i = 0; i < 18; i++) {                          // fired-clay speckle
+              g.fillStyle = shade(base, (rnd() - 0.5) * 0.34);
+              g.fillRect(x + m + rnd() * (bw - m*2), y + m + rnd() * (rh - m*2), 2, 2);
+            }
+            g.globalAlpha = 1;
+          }
+        }
+        break; }
+      case 'plaster':                          // the solid colour blocks: painted render, not flat fill
+        g.fillStyle = base; g.fillRect(0, 0, S, S);
+        mottle(16, 0.07, 30, 90);
+        for (let i = 0; i < 900; i++) {
+          const c = shade(base, (rnd() < 0.5 ? -1 : 1) * (0.05 + rnd() * 0.09));
+          W(rnd() * S, rnd() * S, (px, py) => { g.fillStyle = c; g.fillRect(px, py, 1.6, 1.6); });
+        }
+        break;
+      case 'glasspane':                        // faint sheen + a catch along the pane edge
+        g.fillStyle = base; g.fillRect(0, 0, S, S);
+        g.globalAlpha = 0.16; g.strokeStyle = shade(base, 0.75);
+        for (let i = 0; i < 4; i++) {
+          const x0 = rnd() * S; g.lineWidth = 8 + rnd() * 20;
+          g.beginPath(); g.moveTo(x0, 0); g.lineTo(x0 + S * 0.6, S); g.stroke();
+          g.beginPath(); g.moveTo(x0 - S, 0); g.lineTo(x0 - S + S * 0.6, S); g.stroke();
+        }
+        g.globalAlpha = 0.45; g.lineWidth = 5; g.strokeStyle = shade(base, 0.55);
+        g.strokeRect(2.5, 2.5, S - 5, S - 5);
+        g.globalAlpha = 1;
+        break;
       case 'tuft': case 'tuftFlower': {        // transparent blade fan for scattered grass tufts
         g.clearRect(0, 0, S, S);
         for (let i = 0; i < 15; i++) {
@@ -409,33 +484,96 @@ ABC.world = (function () {
     tex.generateMipmaps = true;
     tex.anisotropy = Math.min(16, _maxAniso);
     tex.needsUpdate = true;
+    _realCv[ck] = cv;                        // kept so pbrTex can derive relief from it
     return (_realTex[ck] = tex);
+  }
+
+  /* ---------- derived relief: normal + roughness from the SAME canvas ----------
+     Every texture above already draws its relief as light and shade — bark
+     ridges, stone cracks, the mortar between bricks, the soil under a grass
+     lip. That means a Sobel over the painted luminance IS the bump map, and
+     the inverse of that luminance is a serviceable roughness (crevices hold
+     grit and scatter; lit ridges are worn smoother). Free, no assets to fetch,
+     and it stays in step with the colour map because it IS the colour map.
+     Sampling wraps, so the derived maps tile exactly like their source. */
+  const _realCv = {}, _realPbr = {};
+  function dataTex(buf, S) {
+    const t = new THREE.DataTexture(buf, S, S, THREE.RGBAFormat);
+    t.wrapS = t.wrapT = THREE.RepeatWrapping;
+    t.magFilter = THREE.LinearFilter;
+    t.minFilter = THREE.LinearMipmapLinearFilter;
+    t.generateMipmaps = true;
+    t.anisotropy = Math.min(16, _maxAniso);
+    t.needsUpdate = true;                    // colorSpace stays linear — these are DATA, not colour
+    return t;
+  }
+  function pbrTex(kind, base, base2, bump) {
+    const map = realTexture(kind, base, base2);
+    const ck = kind + base + (base2 || ''), pk = ck + '|' + bump;
+    if (_realPbr[pk]) return _realPbr[pk];
+    const cv = _realCv[ck];
+    if (!cv) return (_realPbr[pk] = { map });
+    const S = cv.width;
+    let src;
+    try { src = cv.getContext('2d').getImageData(0, 0, S, S).data; }
+    catch (e) { return (_realPbr[pk] = { map }); }   // tainted canvas — colour only, still fine
+    const lum = new Float32Array(S * S);
+    for (let i = 0; i < S * S; i++)
+      lum[i] = (src[i*4] * 0.299 + src[i*4+1] * 0.587 + src[i*4+2] * 0.114) / 255;
+    const at = (x, y) => lum[((y % S) + S) % S * S + (((x % S) + S) % S)];
+    const nrm = new Uint8Array(S * S * 4), rgh = new Uint8Array(S * S * 4);
+    for (let y = 0; y < S; y++) for (let x = 0; x < S; x++) {
+      const i = y * S + x;
+      const dx = (at(x+1,y-1) + 2*at(x+1,y) + at(x+1,y+1)) - (at(x-1,y-1) + 2*at(x-1,y) + at(x-1,y+1));
+      const dy = (at(x-1,y+1) + 2*at(x,y+1) + at(x+1,y+1)) - (at(x-1,y-1) + 2*at(x,y-1) + at(x+1,y-1));
+      const nx = -dx * bump, ny = -dy * bump, l = Math.hypot(nx, ny, 1);
+      nrm[i*4]     = (nx / l * 0.5 + 0.5) * 255;
+      nrm[i*4 + 1] = (ny / l * 0.5 + 0.5) * 255;
+      nrm[i*4 + 2] = (1  / l * 0.5 + 0.5) * 255;
+      nrm[i*4 + 3] = 255;
+      const r = 255 * (0.58 + (1 - lum[i]) * 0.42);
+      rgh[i*4] = rgh[i*4 + 1] = rgh[i*4 + 2] = r; rgh[i*4 + 3] = 255;
+    }
+    return (_realPbr[pk] = { map, normalMap: dataTex(nrm, S), roughnessMap: dataTex(rgh, S) });
   }
 
   function modernStd(tex, extra) {
     return new THREE.MeshStandardMaterial(Object.assign(
       { map: tex, roughness: 0.96, metalness: 0, envMapIntensity: 0.22 }, extra));
   }
+  /* same, but fed the {map, normalMap, roughnessMap} bundle from pbrTex. The
+     authored `roughness` stays as a MULTIPLIER over the derived map so the
+     per-surface tuning below (snow 0.9, leaf 0.88 …) keeps its meaning. */
+  function modernPbr(bundle, extra) {
+    return new THREE.MeshStandardMaterial(Object.assign(
+      { roughness: 0.96, metalness: 0, envMapIntensity: 0.22 }, bundle, extra));
+  }
+  /* how hard to push the Sobel for each surface — deep-cut things (bark ridges,
+     mortar courses, stone cracks) take a strong slope; flat paint barely any */
+  const PAT_KIND = { planks: 'plank', bricks: 'brick', plain: 'plaster', glass: 'glasspane' };
+  const BUMP = { bark: 2.2, stone: 1.8, brick: 2.0, plank: 1.4, dirt: 1.6, grassSide: 1.4,
+                 grassTop: 1.0, foliage: 0.9, sand: 0.8, snow: 0.5, plaster: 0.5, glasspane: 0.3 };
   /* material overrides for the "real" blocks; grass gets per-face materials
      (green top / lipped dirt sides / dirt bottom — BoxGeometry group order
      is +x,-x,+y,-y,+z,-z). Everything else in the game keeps its Smooth look. */
   function modernMaterial(id, def) {
     const base = def.color;
+    const pbr = (kind, b, b2) => pbrTex(kind, b, b2, BUMP[kind] || 1);
     switch (id) {
       case 'grass': {
         const lip = def.top || base;           // data.js has always defined top: — finally used!
-        const side = modernStd(realTexture('grassSide', lip, ABC.BLOCK_DEFS.dirt.color));
-        return [side, side, modernStd(realTexture('grassTop', lip)),
-                modernStd(realTexture('dirt', ABC.BLOCK_DEFS.dirt.color)), side, side];
+        const side = modernPbr(pbr('grassSide', lip, ABC.BLOCK_DEFS.dirt.color));
+        return [side, side, modernPbr(pbr('grassTop', lip)),
+                modernPbr(pbr('dirt', ABC.BLOCK_DEFS.dirt.color)), side, side];
       }
-      case 'moss':      return modernStd(realTexture('grassTop', base));
-      case 'dirt':      return modernStd(realTexture('dirt', base));
-      case 'sand': case 'sandstone': return modernStd(realTexture('sand', base));
-      case 'snow':      return modernStd(realTexture('snow', base), { roughness: 0.9, envMapIntensity: 0.45 });
+      case 'moss':      return modernPbr(pbr('grassTop', base));
+      case 'dirt':      return modernPbr(pbr('dirt', base));
+      case 'sand': case 'sandstone': return modernPbr(pbr('sand', base));
+      case 'snow':      return modernPbr(pbr('snow', base), { roughness: 0.9, envMapIntensity: 0.45 });
       case 'stone': case 'redrock': case 'granite': case 'blackrock':
-                        return modernStd(realTexture('stone', base));
-      case 'wood':      return modernStd(realTexture('bark', base));
-      case 'leaf':      return modernStd(realTexture('foliage', base), { roughness: 0.88 });
+                        return modernPbr(pbr('stone', base));
+      case 'wood':      return modernPbr(pbr('bark', base));
+      case 'leaf':      return modernPbr(pbr('foliage', base), { roughness: 0.88 });
       case 'water': {
         const tex = realTexture('water', base);
         tex.wrapS = tex.wrapT = THREE.RepeatWrapping;   // the map drifts each frame
@@ -459,7 +597,21 @@ ABC.world = (function () {
         return m;
       }
     }
-    return null;
+    /* Everything a child actually BUILDS with. Routed by def.pat rather than by
+       id, so the shaped variants inherit the same surface as the full cube they
+       are cut from: the plank slab, plank stair, brick wedge, glass pane and
+       wooden door all pick this up for free.
+       Glow blocks are deliberately left to makeBlockMaterial — their emissive is
+       hand-balanced against ACES (see the lava note there) and a roughness map
+       over the top would unbalance it. */
+    if (def.glow) return null;
+    const kind = PAT_KIND[def.pat];
+    if (!kind) return null;
+    const b = pbr(kind, base);
+    const extra = def.alpha != null
+      ? { transparent: true, opacity: def.alpha, roughness: 0.16, envMapIntensity: 0.8 }
+      : { roughness: 0.92, envMapIntensity: 0.3 };
+    return modernPbr(b, extra);
   }
   let _waterTex = null, _waterT = 0;
   const _waterWave = { value: 0 };
@@ -736,7 +888,10 @@ ABC.world = (function () {
     const m = new THREE.InstancedMesh(modernGeoFor(id) || geoFor(ABC.BLOCK_DEFS[id]), materials[id], cap);
     m.count = 0;
     m.userData.type = id;
-    m.userData.positions = [];
+    m.userData.positions = [];      // slot i -> [x,y,z]  (also read by findNear + rebuildTufts)
+    m.userData.keys = [];           // slot i -> "x,y,z"
+    m.userData.lo = m.userData.hi = null;   // dirtied slot range, for partial uploads
+    m.userData.full = true;         // a fresh buffer must be uploaded whole once
     m.frustumCulled = false;
     if (SMOOTH) {
       // opaque blocks cast shadows; transparent ones (water/glass/ice/slime/pane)
@@ -782,20 +937,141 @@ ABC.world = (function () {
         && s.has(map.get(key(x, y + 1, z)))
         && (y - 1 < MIN_Y || s.has(map.get(key(x, y - 1, z))));
   }
-  /* an edit can EXPOSE a neighbour that was culled (dig the grass off a hillside
-     and the dirt under it has to appear), so every write also dirties the types
-     around it. Cheap now that a rebuild only walks its own type. */
-  function dirtyAround(x, y, z) {
-    if (!SOLID_HIDE) return;
-    for (const d of NEIGHBORS) {
-      const t = map.get(key(x + d[0], y + d[1], z + d[2]));
-      if (t && SOLID_HIDE.has(t)) dirty.add(t);
-    }
-  }
   const NEIGHBORS = [[1,0,0],[-1,0,0],[0,1,0],[0,-1,0],[0,0,1],[0,0,-1]];
 
-  function rebuild(type) {
+  /* ---------- instance slots ----------
+     positions[i]/keys[i] ARE the instance living in slot i; slotIdx/slotTyp say
+     where a given block currently sits and what it is drawn as. With that
+     bookkeeping a single edit patches its own slot (plus at most six
+     neighbours') in place instead of rewriting a whole block type. That matters
+     most for grass, whose per-instance moisture tint costs a vnoise per
+     instance — rewriting ten thousand of those on every dig was ~18ms. */
+  const slotIdx = new Map();      // key -> instance slot
+  const slotTyp = new Map();      // key -> the type it is currently DRAWN as
+  const pending = new Set();      // meshes whose instance buffer needs an upload
+
+  function markSlot(m, i) {
+    const u = m.userData;
+    if (u.lo == null || i < u.lo) u.lo = i;
+    if (u.hi == null || i > u.hi) u.hi = i;
+    pending.add(m);
+  }
+  /* write one instance. Identical maths to the old rebuild loop — modern "real
+     world" blocks get a hash-keyed (stable, so no flicker) yaw + brightness
+     jitter to break up the tiled texture; leaf puffs also wobble in size so
+     canopies read as organic clumps; grass carries a broad moisture tint. */
+  function writeInst(m, i, k, x, y, z, type) {
+    if (MODERN && REAL_JITTER.has(type)) {
+      const leafy = type === 'leaf';
+      const h = hash2(x * 13 + y * 7, z * 11 + y);
+      // ground boxes must stay grid-flush: yaw only in exact quarter turns
+      _m4.makeRotationY(leafy ? h * 6.283 : ((h * 4) | 0) * Math.PI / 2);
+      if (leafy) { const s = 0.9 + ((h * 31) % 1) * 0.5; _m4.scale(_v1.set(s, s * (0.85 + ((h * 17) % 1) * 0.3), s)); }
+      // subtle brightness jitter (stronger reads as checkerboard under ACES)
+      const j2 = 0.95 + ((h * 53) % 1) * 0.1;
+      if (type === 'grass') {
+        // broad, gentle moisture drift — tighter scales/deltas read as blotches
+        const moist = vnoise(x + 31, z - 17, 61);
+        _cJ.setRGB(j2 * (1 + (0.5 - moist) * 0.13), j2 * (1 + (moist - 0.5) * 0.08), j2 * (1 - Math.abs(moist - 0.5) * 0.05));
+      } else _cJ.setScalar(j2);
+      m.setColorAt(i, _cJ);
+    } else {
+      const raw = rotMap.get(k) || 0;
+      const rot = (raw & 3) + ((raw & 4) ? 1 : 0);    // bit 4 = door swung open
+      _m4.makeRotationY(rot * Math.PI / 2);
+    }
+    _m4.setPosition(x + 0.5, y + 0.5, z + 0.5);
+    m.setMatrixAt(i, _m4);
+    markSlot(m, i);
+  }
+  function ensureCap(type, need) {
     let m = meshes[type];
+    if (need <= m.instanceMatrix.count) return m;
+    let cap = m.instanceMatrix.count || 1;
+    while (cap < need) cap *= 2;
+    const old = m;
+    scene.remove(old);
+    m = meshes[type] = newMesh(type, cap);
+    m.userData.positions = old.userData.positions;
+    m.userData.keys = old.userData.keys;
+    m.count = old.count;
+    for (let i = 0; i < m.count; i++) {
+      const p = m.userData.positions[i];
+      writeInst(m, i, m.userData.keys[i], p[0], p[1], p[2], type);
+    }
+    m.userData.full = true;                 // brand new buffer: upload all of it
+    pending.delete(old); old.dispose();
+    return m;
+  }
+  function instAdd(type, k, x, y, z) {
+    const m = ensureCap(type, meshes[type].count + 1);
+    const i = m.count++;
+    m.userData.positions[i] = [x, y, z];
+    m.userData.keys[i] = k;
+    writeInst(m, i, k, x, y, z, type);
+    slotIdx.set(k, i); slotTyp.set(k, type);
+    if (MODERN && type === 'grass') _tuftsDirty = true;
+  }
+  function instDel(k) {
+    const type = slotTyp.get(k);
+    if (type === undefined) return;
+    const m = meshes[type], i = slotIdx.get(k), last = m.count - 1;
+    if (i !== last) {                       // swap the tail instance into the hole
+      const p = m.userData.positions[last], lk = m.userData.keys[last];
+      m.userData.positions[i] = p; m.userData.keys[i] = lk;
+      writeInst(m, i, lk, p[0], p[1], p[2], type);
+      slotIdx.set(lk, i);
+    }
+    m.userData.positions.length = last;
+    m.userData.keys.length = last;
+    m.count = last;
+    slotIdx.delete(k); slotTyp.delete(k);
+    pending.add(m);
+    if (MODERN && type === 'grass') _tuftsDirty = true;
+  }
+  /* bring ONE cell's instance in line with the map — the whole incremental path */
+  function syncCell(x, y, z) {
+    const k = key(x, y, z);
+    const t = map.get(k);
+    const want = t !== undefined && !buried(t, x, y, z);
+    const drawnAs = slotTyp.get(k);
+    if (drawnAs !== undefined && (!want || drawnAs !== t)) instDel(k);
+    if (!want) return;
+    if (slotTyp.get(k) === undefined) instAdd(t, k, x, y, z);
+    else writeInst(meshes[t], slotIdx.get(k), k, x, y, z, t);   // same type, rotation may have moved
+  }
+  /* an edit can expose or hide its neighbours (dig the grass off a hillside and
+     the dirt under it has to appear), so each write settles its own cell and the
+     six around it. Seven O(1) patches instead of seven whole-type rebuilds. */
+  function syncAround(x, y, z) {
+    syncCell(x, y, z);
+    for (const d of NEIGHBORS) syncCell(x + d[0], y + d[1], z + d[2]);
+  }
+  function uploadPending() {
+    for (const m of pending) {
+      const u = m.userData, im = m.instanceMatrix;
+      if (u.full || u.lo == null) im.needsUpdate = true;
+      else if (im.addUpdateRange) {          // r170: a list of ranges
+        if (im.updateRanges) im.updateRanges.length = 0;
+        im.addUpdateRange(u.lo * 16, (u.hi - u.lo + 1) * 16);
+        im.needsUpdate = true;
+      } else if (im.updateRange) {           // r128: a single range
+        im.updateRange.offset = u.lo * 16;
+        im.updateRange.count = (u.hi - u.lo + 1) * 16;
+        im.needsUpdate = true;
+      } else im.needsUpdate = true;
+      if (m.instanceColor) m.instanceColor.needsUpdate = true;
+      u.lo = u.hi = null; u.full = false;
+    }
+    pending.clear();
+  }
+
+  /* full rebuild of one type — still the right tool for bulk work (a chunk
+     generating or unloading, a save being loaded), and authoritative over
+     anything the incremental path did. */
+  function rebuild(type) {
+    const old = meshes[type];
+    for (const k of old.userData.keys) { slotIdx.delete(k); slotTyp.delete(k); }
     const pos = [], keys = [];
     const own = byType.get(type);
     if (own) for (const k of own) {
@@ -803,53 +1079,41 @@ ABC.world = (function () {
       if (buried(type, x, y, z)) continue;
       pos.push([x,y,z]); keys.push(k);
     }
+    let m = old;
     if (pos.length > m.instanceMatrix.count) {       // grow capacity
       scene.remove(m);
-      let cap = m.instanceMatrix.count;
+      let cap = m.instanceMatrix.count || 1;
       while (cap < pos.length) cap *= 2;
       m = meshes[type] = newMesh(type, cap);
+      pending.delete(old); old.dispose();
     }
     m.count = pos.length;
-    const slabOff = ABC.BLOCK_DEFS[type].shape === 'slab' ? 0 : 0;  // slab geo already offset
-    // modern "real world": break the tiled-texture repetition with a hash-keyed
-    // (stable — no flicker on rebuild) yaw + brightness jitter per block; leaf
-    // puffs also get a size wobble so canopies read as organic clumps.
-    const jitter = MODERN && REAL_JITTER.has(type);
-    const leafy = jitter && type === 'leaf';
-    for (let i=0;i<m.count;i++) {
-      const raw = rotMap.get(keys[i]) || 0;
-      const rot = (raw & 3) + ((raw & 4) ? 1 : 0);    // bit 4 = door swung open
-      if (jitter) {
-        const h = hash2(pos[i][0] * 13 + pos[i][1] * 7, pos[i][2] * 11 + pos[i][1]);
-        // ground boxes must stay grid-flush: yaw only in exact quarter turns
-        _m4.makeRotationY(leafy ? h * 6.283 : ((h * 4) | 0) * Math.PI / 2);
-        if (leafy) { const s = 0.9 + ((h * 31) % 1) * 0.5; _m4.scale(_v1.set(s, s * (0.85 + ((h * 17) % 1) * 0.3), s)); }
-        // subtle brightness jitter (stronger reads as checkerboard under ACES);
-        // grass ALSO gets a large-scale moisture tint — lush deep green in damp
-        // hollows drifting to warm straw on dry rises, like a real meadow
-        const j2 = 0.95 + ((h * 53) % 1) * 0.1;
-        if (type === 'grass') {
-          // broad, gentle moisture drift — tighter scales/deltas read as blotches
-          const moist = vnoise(pos[i][0] + 31, pos[i][2] - 17, 61);
-          _cJ.setRGB(j2 * (1 + (0.5 - moist) * 0.13), j2 * (1 + (moist - 0.5) * 0.08), j2 * (1 - Math.abs(moist - 0.5) * 0.05));
-        } else _cJ.setScalar(j2);
-        m.setColorAt(i, _cJ);
-      } else {
-        _m4.makeRotationY(rot * Math.PI / 2);
-      }
-      _m4.setPosition(pos[i][0]+0.5, pos[i][1]+0.5 + slabOff, pos[i][2]+0.5);
-      m.setMatrixAt(i, _m4);
-    }
     m.userData.positions = pos;
-    m.instanceMatrix.needsUpdate = true;
-    if (m.instanceColor) m.instanceColor.needsUpdate = true;
+    m.userData.keys = keys;
+    for (let i = 0; i < m.count; i++) {
+      writeInst(m, i, keys[i], pos[i][0], pos[i][1], pos[i][2], type);
+      slotIdx.set(keys[i], i); slotTyp.set(keys[i], type);
+    }
+    m.userData.full = true;
+    pending.add(m);
   }
+  /* Tufts scatter over every open grass top, so rebuilding them walks the whole
+     grass instance list. flush() runs several times a FRAME — once per placed
+     block, once per generated chunk — so that walk was happening several times
+     a frame. Record the need here and settle it once, from the per-frame hook.
+     The old `dirty.size > 3` proxy for "a chunk generated" also misfires now
+     that an edit dirties its neighbours' types too; dirty.has('grass') is both
+     cheaper and exactly right. */
+  let _tuftsDirty = false;
   function flush() {
-    if (!dirty.size) return;
-    const grassDirty = MODERN && (dirty.has('grass') || dirty.size > 3);  // >3 ≈ chunk gen/unload
-    for (const t of dirty) rebuild(t); dirty.clear();
-    if (grassDirty) rebuildTufts();
+    if (dirty.size) {                    // bulk work only — single edits already settled themselves
+      if (MODERN && dirty.has('grass')) _tuftsDirty = true;
+      for (const t of dirty) rebuild(t);
+      dirty.clear();
+    }
+    uploadPending();
   }
+  function settleTufts() { if (_tuftsDirty) { _tuftsDirty = false; rebuildTufts(); } }
 
   function inBounds(x,y,z) { return Math.abs(x)<=SIZE && Math.abs(z)<=SIZE && y>=MIN_Y && y<=MAX_Y; }
   function get(x,y,z) { return map.get(key(x,y,z)) || null; }
@@ -858,11 +1122,9 @@ ABC.world = (function () {
     const k = key(x,y,z);
     const old = map.get(k);
     if (old === type && (rotMap.get(k)||0) === (rot||0)) return false;
-    if (old) dirty.add(old);
     map.set(k, type);
     if (rot) rotMap.set(k, rot); else rotMap.delete(k);
-    dirty.add(type);
-    dirtyAround(x, y, z);                       // swapping dirt for glass exposes its neighbours
+    syncAround(x, y, z);                        // O(1): this cell + its six neighbours
     editSet.set(k, { t: type, r: rot || 0 });   // player edits persist forever
     editDel.delete(k);
     return true;
@@ -874,8 +1136,7 @@ ABC.world = (function () {
     if (!old) return false;
     map.delete(k);
     rotMap.delete(k);
-    dirty.add(old);
-    dirtyAround(x, y, z);                 // digging a hole reveals whatever was culled behind it
+    syncAround(x, y, z);                  // digging a hole reveals whatever was culled behind it
     editSet.delete(k);
     editDel.add(k);                              // remember the hole forever
     return true;
@@ -1206,6 +1467,7 @@ ABC.world = (function () {
     }
     updateVolcano(x, z, dt);
     updateFootsteps(dt);
+    settleTufts();                              // at most one tuft rebuild per frame
   }
 
   /* ---------- night sky: stars + Milky Way 🌌 ---------- */
@@ -1715,6 +1977,9 @@ ABC.world = (function () {
         const [cx, cz] = ck.split(',').map(Number);
         if (Math.max(Math.abs(cx - ccx), Math.abs(cz - ccz)) > UNLOAD_R) {
           for (const k of keys) { const t = map.get(k); if (t) { map.delete(k); rotMap.delete(k); dirty.add(t); } }
+          // blocks in the RETAINED chunk next door may have been culled behind
+          // the ones just deleted, so every hideable type has to be re-examined
+          if (SOLID_HIDE) for (const t of SOLID_HIDE) if (byType.get(t)) dirty.add(t);
           chunks.delete(ck);
         }
       }

--- a/public/blockcraft/js/world.js
+++ b/public/blockcraft/js/world.js
@@ -604,14 +604,33 @@ ABC.world = (function () {
         // (Safe to inject — modern pins three at r170, our vendored build.)
         m.onBeforeCompile = (sh) => {
           sh.uniforms.uWave = _waterWave;
-          sh.vertexShader = 'uniform float uWave;\n' + sh.vertexShader.replace(
+          sh.vertexShader = 'uniform float uWave;\nattribute vec2 aWater;\n' +
+            'varying vec2 vWaterD;\nvarying vec3 vLocalP;\n' + sh.vertexShader.replace(
             '#include <begin_vertex>',
             '#include <begin_vertex>\n' +
+            'vWaterD = aWater; vLocalP = position;\n' +
             '#ifdef USE_INSTANCING\n' +
             '  vec4 abcW = instanceMatrix * vec4(position, 1.0);\n' +
             '  if (position.y > 0.45) transformed.y += sin(abcW.x * 0.9 + uWave * 1.6) * 0.05' +
             '    + cos(abcW.z * 0.7 + uWave * 1.15) * 0.05 - 0.05;\n' +
             '#endif\n');
+          /* Injected after emissivemap_fragment because that is the first point
+             where `normal` is resolved — the fresnel term needs it. Three things
+             a flat blue cube cannot do: open water sits darker than a puddle,
+             grazing angles catch the sky instead of staying uniformly blue, and
+             the edge against a bank gets a foam collar. */
+          sh.fragmentShader = 'varying vec2 vWaterD;\nvarying vec3 vLocalP;\n' +
+            sh.fragmentShader.replace(
+            '#include <emissivemap_fragment>',
+            '#include <emissivemap_fragment>\n' +
+            'diffuseColor.rgb *= mix(1.0, 0.62, vWaterD.y);\n' +
+            'float abcF = pow(1.0 - clamp(dot(normalize(normal), normalize(vViewPosition)), 0.0, 1.0), 3.0);\n' +
+            'diffuseColor.rgb = mix(diffuseColor.rgb, vec3(0.55, 0.72, 0.88), abcF * 0.55);\n' +
+            'diffuseColor.a = clamp(diffuseColor.a + abcF * 0.35, 0.0, 1.0);\n' +
+            'float abcRim = max(abs(vLocalP.x), abs(vLocalP.z));\n' +
+            'float abcFoam = vWaterD.x * smoothstep(0.30, 0.5, abcRim) * step(0.45, vLocalP.y);\n' +
+            'diffuseColor.rgb = mix(diffuseColor.rgb, vec3(0.92, 0.97, 1.0), abcFoam * 0.75);\n' +
+            'diffuseColor.a = clamp(diffuseColor.a + abcFoam * 0.4, 0.0, 1.0);\n');
         };
         return m;
       }
@@ -638,7 +657,7 @@ ABC.world = (function () {
   /* geometry overrides: flat seam-tiling boxes for ground (the toy bevel gap
      between blocks is what reads as "plastic"), bark cylinders for trunks,
      lumpy displaced icospheres for foliage. Instanced-safe plain geometry. */
-  let _flatGeo = null, _trunkGeo = null, _foliageGeo = null;
+  let _flatGeo = null, _trunkGeo = null, _foliageGeo = null, _waterGeo = null;
   function foliageGeo() {
     const geo = new THREE.IcosahedronGeometry(0.68, 1);   // non-indexed → faceted, stylized-organic
     const p = geo.attributes.position;
@@ -654,7 +673,11 @@ ABC.world = (function () {
   }
   function modernGeoFor(id) {
     if (!MODERN) return null;
-    if (REAL_GROUND.includes(id) || id === 'water') return _flatGeo || (_flatGeo = new THREE.BoxGeometry(1, 1, 1));
+    // water gets its OWN box, not the shared ground one: it carries a per-instance
+    // aWater attribute (shoreline + depth) and an InstancedBufferAttribute cannot
+    // be shared across meshes with different instance counts
+    if (id === 'water') return _waterGeo || (_waterGeo = new THREE.BoxGeometry(1, 1, 1));
+    if (REAL_GROUND.includes(id)) return _flatGeo || (_flatGeo = new THREE.BoxGeometry(1, 1, 1));
     if (id === 'wood') return _trunkGeo || (_trunkGeo = new THREE.CylinderGeometry(0.44, 0.5, 1, 10));
     if (id === 'leaf') return _foliageGeo || (_foliageGeo = foliageGeo());
     return null;
@@ -911,6 +934,9 @@ ABC.world = (function () {
     m.userData.keys = [];           // slot i -> "x,y,z"
     m.userData.lo = m.userData.hi = null;   // dirtied slot range, for partial uploads
     m.userData.full = true;         // a fresh buffer must be uploaded whole once
+    if (MODERN && id === 'water')   // x = touches a shore, y = has water beneath it
+      m.geometry.setAttribute('aWater',
+        new THREE.InstancedBufferAttribute(new Float32Array(cap * 2), 2));
     m.frustumCulled = false;
     if (SMOOTH) {
       // opaque blocks cast shadows; transparent ones (water/glass/ice/slime/pane)
@@ -1001,7 +1027,20 @@ ABC.world = (function () {
     }
     _m4.setPosition(x + 0.5, y + 0.5, z + 0.5);
     m.setMatrixAt(i, _m4);
+    if (MODERN && type === 'water') writeWater(m, i, x, y, z);
     markSlot(m, i);
+  }
+  /* Per-instance water facts the shader cannot work out for itself: whether this
+     block touches a shore (so it gets a foam collar) and whether more water sits
+     under it (so open lake reads deeper than a puddle). syncCell re-runs this for
+     the six neighbours of any edit, so digging a bank re-foams the water beside it. */
+  function writeWater(m, i, x, y, z) {
+    const a = m.geometry.getAttribute('aWater');
+    if (!a || i >= a.count) return;
+    const edge = (map.get(key(x+1,y,z)) !== 'water' || map.get(key(x-1,y,z)) !== 'water' ||
+                  map.get(key(x,y,z+1)) !== 'water' || map.get(key(x,y,z-1)) !== 'water') ? 1 : 0;
+    a.setXY(i, edge, map.get(key(x, y-1, z)) === 'water' ? 1 : 0);
+    a.needsUpdate = true;
   }
   function ensureCap(type, need) {
     let m = meshes[type];

--- a/scripts/bc-verify.mjs
+++ b/scripts/bc-verify.mjs
@@ -1,0 +1,131 @@
+// Block Craft Modern-skin verification gate.
+// Serves public/ and drives the real game in headless Chrome.
+// Asserts: world builds, culling never hides a VISIBLE block, digging re-exposes
+// buried neighbours, sun ball agrees with the light, and measures ms/placement.
+import http from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { extname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+const puppeteer = require('puppeteer');
+const ROOT = new URL('../public', import.meta.url).pathname;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.png': 'image/png', '.json': 'application/json' };
+
+const srv = http.createServer(async (req, res) => {
+  const p = decodeURIComponent(req.url.split('?')[0]);
+  if (p === '/games' || p === '/') { res.writeHead(200, { 'Content-Type': 'text/html' }); res.end('<title>stub</title>'); return; }
+  try {
+    const d = await readFile(join(ROOT, p));
+    res.writeHead(200, { 'Content-Type': MIME[extname(p)] || 'application/octet-stream' });
+    res.end(d);
+  } catch { res.writeHead(404); res.end(); }
+});
+await new Promise((r) => srv.listen(8901, r));
+
+const browser = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--mute-audio'] });
+const page = await browser.newPage();
+await page.setViewport({ width: 1024, height: 768 });
+const errors = [];
+page.on('pageerror', (e) => errors.push('pageerror: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') errors.push('console: ' + m.text().slice(0, 160)); });
+page.on('requestfailed', (r) => errors.push('404? ' + r.url()));
+page.on('response', (r) => { if (r.status() === 404) errors.push('404 ' + r.url()); });
+
+await page.evaluateOnNewDocument(() => { try { localStorage.setItem('abcSkin', 'modern'); } catch (e) {} });
+await page.goto('http://localhost:8901/blockcraft/index.html', { waitUntil: 'domcontentloaded', timeout: 60000 });
+await new Promise((r) => setTimeout(r, 1500));
+await page.evaluate(() => document.getElementById('playBtn')?.click());
+await new Promise((r) => setTimeout(r, 3500));
+
+const out = await page.evaluate(() => {
+  const W = window.ABC && window.ABC.world;
+  if (!W) return { fatal: 'ABC.world missing' };
+  const R = { skin: window.ABC.SKIN, modern: !!window.ABC.MODERN };
+
+  const meshes = W.blockMeshes();
+  R.drawn = meshes.reduce((a, m) => a + m.count, 0);
+
+  // ---- INVARIANT 1: every drawn instance corresponds to a live block of that type
+  let ghosts = 0;
+  for (const m of meshes) {
+    const t = m.userData.type;
+    for (const p of (m.userData.positions || [])) if (W.get(p[0], p[1], p[2]) !== t) ghosts++;
+  }
+  R.ghostInstances = ghosts;
+
+  // ---- INVARIANT 2 (the culling safety property): no block that a player can
+  // SEE may be missing an instance. Sample a column of air->ground boundaries
+  // around spawn: any block with at least one empty neighbour must be drawn.
+  const drawnSet = new Set();
+  for (const m of meshes) for (const p of (m.userData.positions || [])) drawnSet.add(p[0] + ',' + p[1] + ',' + p[2]);
+  let exposedButMissing = 0, checked = 0;
+  const N = [[1,0,0],[-1,0,0],[0,1,0],[0,-1,0],[0,0,1],[0,0,-1]];
+  for (let x = -24; x <= 24; x++) for (let z = -24; z <= 24; z++) for (let y = W.MIN_Y; y <= 12; y++) {
+    const t = W.get(x, y, z); if (!t) continue;
+    checked++;
+    const exposed = N.some(([dx, dy, dz]) => !W.get(x + dx, y + dy, z + dz) && y + dy >= W.MIN_Y);
+    if (exposed && !drawnSet.has(x + ',' + y + ',' + z)) exposedButMissing++;
+  }
+  R.blocksChecked = checked;
+  R.exposedButMissing = exposedButMissing;
+
+  // ---- INVARIANT 3: digging a surface block re-exposes the one beneath it
+  let sx = 3, sz = 3, sy = null;
+  for (let y = 12; y >= W.MIN_Y; y--) if (W.get(sx, y, sz)) { sy = y; break; }
+  R.digTest = 'skipped';
+  if (sy != null && sy - 1 >= W.MIN_Y && W.get(sx, sy - 1, sz)) {
+    W.remove(sx, sy, sz); W.flush();
+    const below = W.get(sx, sy - 1, sz);
+    const shown = W.blockMeshes().some((m) => (m.userData.positions || [])
+      .some((p) => p[0] === sx && p[1] === sy - 1 && p[2] === sz));
+    R.digTest = shown ? 'pass' : ('FAIL: ' + below + ' at ' + sx + ',' + (sy - 1) + ',' + sz + ' hidden after dig');
+    W.set(sx, sy, sz, 'grass'); W.flush();
+  }
+
+  // ---- INVARIANT 4: sun ball lies along the light's direction
+  const sc = W.getScene();
+  let sun = null, ball = null;
+  sc.traverse((o) => {
+    if (o.isDirectionalLight) sun = o;
+    if (o.isMesh && o.geometry && o.geometry.type === 'SphereGeometry' && o.material && o.material.fog === false) ball = o;
+  });
+  if (sun && ball) {
+    const lp = sun.position.clone().sub(sun.target.position).normalize();
+    const bp = ball.position.clone().sub(sun.target.position).normalize();
+    R.sunDot = +lp.dot(bp).toFixed(4);
+    R.sunElevationDeg = +(Math.asin(lp.y) * 180 / Math.PI).toFixed(1);
+    R.shadowNormalBias = sun.shadow.normalBias;
+    R.shadowRadius = sun.shadow.camera.right;
+  } else R.sunDot = 'no sun/ball found';
+
+  // ---- PERF: 150 place+dig cycles high in the air (no terrain interaction)
+  const cells = [];
+  for (let i = 0; i < 150; i++) cells.push([-20 + (i % 15), 14 + ((i / 15) | 0), -20]);
+  const t0 = performance.now();
+  let did = 0;
+  for (const c of cells) { if (W.set(c[0], c[1], c[2], 'plank')) did++; W.flush(); }
+  for (const c of cells) { if (W.remove(c[0], c[1], c[2])) did++; W.flush(); }
+  R.msPerOp = +((performance.now() - t0) / Math.max(1, did)).toFixed(3);
+  R.opsCounted = did;
+  return R;
+});
+
+await page.screenshot({ path: '/private/tmp/claude-501/-Users-aj-Desktop-ABE-Website/2c1a860c-07f1-40e5-a3e7-fa6ec646a826/scratchpad/bc-modern.png' });
+await browser.close();
+srv.close();
+
+console.log(JSON.stringify(out, null, 2));
+if (errors.length) console.log('\nPAGE ERRORS:\n' + errors.slice(0, 8).join('\n'));
+
+const fails = [];
+if (out.fatal) fails.push(out.fatal);
+if (out.skin !== 'modern') fails.push('not running the modern skin (got ' + out.skin + ')');
+if (out.ghostInstances > 0) fails.push(out.ghostInstances + ' instances drawn for blocks that do not exist');
+if (out.exposedButMissing > 0) fails.push(out.exposedButMissing + ' VISIBLE blocks have no instance (culling is eating real geometry)');
+if (out.digTest !== 'pass' && out.digTest !== 'skipped') fails.push(out.digTest);
+if (typeof out.sunDot === 'number' && out.sunDot < 0.999) fails.push('sun ball not aligned with light (dot=' + out.sunDot + ')');
+if (errors.length) fails.push(errors.length + ' page errors');
+
+if (fails.length) { console.error('\nFAIL:\n' + fails.map((f) => '  x ' + f).join('\n')); process.exit(1); }
+console.log('\nPASS');

--- a/scripts/bc-verify.mjs
+++ b/scripts/bc-verify.mjs
@@ -109,6 +109,8 @@ const out = await page.evaluate(() => {
     return !one.normalMap || !one.roughnessMap;
   });
 
+  R.diag = W.diag ? W.diag() : null;
+
   // ---- PERF: 150 place+dig cycles high in the air (no terrain interaction)
   const cells = [];
   for (let i = 0; i < 150; i++) cells.push([-20 + (i % 15), 14 + ((i / 15) | 0), -20]);

--- a/scripts/bc-verify.mjs
+++ b/scripts/bc-verify.mjs
@@ -14,6 +14,7 @@ const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css
 
 const srv = http.createServer(async (req, res) => {
   const p = decodeURIComponent(req.url.split('?')[0]);
+  if (p === '/favicon.ico') { res.writeHead(204); res.end(); return; }
   if (p === '/games' || p === '/') { res.writeHead(200, { 'Content-Type': 'text/html' }); res.end('<title>stub</title>'); return; }
   try {
     const d = await readFile(join(ROOT, p));
@@ -99,6 +100,15 @@ const out = await page.evaluate(() => {
     R.shadowRadius = sun.shadow.camera.right;
   } else R.sunDot = 'no sun/ball found';
 
+  // ---- INVARIANT 5: crafted build blocks are on real PBR surfaces
+  const mats = W.materials;
+  const want = ['plank','brick','stone','wood','sand','snow','dirt','grass','red','blue','white','slab','stair','wedge','pillar','glass','pane'];
+  R.noNormalMap = want.filter((id) => {
+    const m = mats[id]; if (!m) return false;
+    const one = Array.isArray(m) ? m[0] : m;
+    return !one.normalMap || !one.roughnessMap;
+  });
+
   // ---- PERF: 150 place+dig cycles high in the air (no terrain interaction)
   const cells = [];
   for (let i = 0; i < 150; i++) cells.push([-20 + (i % 15), 14 + ((i / 15) | 0), -20]);
@@ -108,9 +118,26 @@ const out = await page.evaluate(() => {
   for (const c of cells) { if (W.remove(c[0], c[1], c[2])) did++; W.flush(); }
   R.msPerOp = +((performance.now() - t0) / Math.max(1, did)).toFixed(3);
   R.opsCounted = did;
+  // ---- PERF 2: digging GRASS (the path that used to rebuild every tuft)
+  const grass = [];
+  for (let x = -18; x <= -4 && grass.length < 40; x++)
+    for (let z = -18; z <= -4 && grass.length < 40; z++) {
+      for (let y = 8; y >= 0; y--) if (W.get(x, y, z) === 'grass') { grass.push([x, y, z]); break; }
+    }
+  const t1 = performance.now();
+  let dug = 0;
+  for (const c of grass) { if (W.remove(c[0], c[1], c[2])) dug++; W.flush(); }
+  R.msPerGrassDig = +((performance.now() - t1) / Math.max(1, dug)).toFixed(3);
+  R.grassDug = dug;
+
   return R;
 });
 
+await page.evaluate(() => {
+  for (const el of document.querySelectorAll('.dlg, #dialog, .overlay, #toasts, #hud, .modal, [id*=dlg], [class*=dlg]')) el.style.display = 'none';
+  if (window.ABC && ABC.setLook) ABC.setLook(0.6, -0.15);
+});
+await new Promise((r) => setTimeout(r, 700));
 await page.screenshot({ path: '/private/tmp/claude-501/-Users-aj-Desktop-ABE-Website/2c1a860c-07f1-40e5-a3e7-fa6ec646a826/scratchpad/bc-modern.png' });
 await browser.close();
 srv.close();
@@ -125,7 +152,9 @@ if (out.ghostInstances > 0) fails.push(out.ghostInstances + ' instances drawn fo
 if (out.exposedButMissing > 0) fails.push(out.exposedButMissing + ' VISIBLE blocks have no instance (culling is eating real geometry)');
 if (out.digTest !== 'pass' && out.digTest !== 'skipped') fails.push(out.digTest);
 if (typeof out.sunDot === 'number' && out.sunDot < 0.999) fails.push('sun ball not aligned with light (dot=' + out.sunDot + ')');
-if (errors.length) fails.push(errors.length + ' page errors');
+if (out.noNormalMap && out.noNormalMap.length) fails.push('no normal/roughness map on: ' + out.noNormalMap.join(', '));
+const real = errors.filter((e) => !/favicon|supabase/i.test(e));
+if (real.length) fails.push(real.length + ' page errors: ' + real[0]);
 
 if (fails.length) { console.error('\nFAIL:\n' + fails.map((f) => '  x ' + f).join('\n')); process.exit(1); }
 console.log('\nPASS');

--- a/scripts/bc-verify.mjs
+++ b/scripts/bc-verify.mjs
@@ -39,6 +39,18 @@ await new Promise((r) => setTimeout(r, 1500));
 await page.evaluate(() => document.getElementById('playBtn')?.click());
 await new Promise((r) => setTimeout(r, 3500));
 
+// Spawn has no water (the ponds are all out in the park regions), so the water
+// material would never compile and the check below would pass vacuously. Build a
+// pond first, render a few frames, and let any shader error surface.
+await page.evaluate(() => {
+  const W = window.ABC && window.ABC.world; if (!W) return;
+  for (let x = 4; x <= 8; x++) for (let z = 4; z <= 8; z++) {
+    W.set(x, 0, z, 'water'); W.set(x, -1, z, 'water');
+  }
+  W.flush();
+});
+await new Promise((r) => setTimeout(r, 900));
+
 const out = await page.evaluate(() => {
   const W = window.ABC && window.ABC.world;
   if (!W) return { fatal: 'ABC.world missing' };
@@ -109,6 +121,15 @@ const out = await page.evaluate(() => {
     return !one.normalMap || !one.roughnessMap;
   });
 
+  // ---- INVARIANT 6: water carries its per-instance shoreline/depth data
+  const wm = W.blockMeshes().find((m) => m.userData.type === 'water');
+  if (!wm) R.water = 'no water mesh';
+  else {
+    const a = wm.geometry.getAttribute('aWater');
+    let edges = 0, deep = 0;
+    if (a) for (let i = 0; i < wm.count; i++) { if (a.getX(i) > 0.5) edges++; if (a.getY(i) > 0.5) deep++; }
+    R.water = { instances: wm.count, hasAttr: !!a, attrCap: a ? a.count : 0, shoreline: edges, deep: deep };
+  }
   R.diag = W.diag ? W.diag() : null;
 
   // ---- PERF: 150 place+dig cycles high in the air (no terrain interaction)
@@ -136,8 +157,10 @@ const out = await page.evaluate(() => {
 });
 
 await page.evaluate(() => {
-  for (const el of document.querySelectorAll('.dlg, #dialog, .overlay, #toasts, #hud, .modal, [id*=dlg], [class*=dlg]')) el.style.display = 'none';
-  if (window.ABC && ABC.setLook) ABC.setLook(0.6, -0.15);
+  // hide every overlay so the screenshot is the WORLD, then stand at the test pond
+  for (const el of document.body.children) if (el.tagName !== 'CANVAS') el.style.display = 'none';
+  // NB: ABC.teleport/setLook do not stick here — the game loop resets the camera
+  // within a frame — so this screenshot is always the spawn view, NOT the test pond.
 });
 await new Promise((r) => setTimeout(r, 700));
 await page.screenshot({ path: '/private/tmp/claude-501/-Users-aj-Desktop-ABE-Website/2c1a860c-07f1-40e5-a3e7-fa6ec646a826/scratchpad/bc-modern.png' });
@@ -154,6 +177,11 @@ if (out.ghostInstances > 0) fails.push(out.ghostInstances + ' instances drawn fo
 if (out.exposedButMissing > 0) fails.push(out.exposedButMissing + ' VISIBLE blocks have no instance (culling is eating real geometry)');
 if (out.digTest !== 'pass' && out.digTest !== 'skipped') fails.push(out.digTest);
 if (typeof out.sunDot === 'number' && out.sunDot < 0.999) fails.push('sun ball not aligned with light (dot=' + out.sunDot + ')');
+if (!out.water || !out.water.instances) fails.push('water never rendered - the shader is still unverified');
+if (out.water && out.water.instances > 0 && !out.water.hasAttr) fails.push('water mesh has no aWater attribute');
+if (out.water && out.water.instances > 0 && out.water.deep === 0) fails.push('no water block flagged as deep');
+if (out.water && out.water.instances > 0 && out.water.shoreline === 0) fails.push('no water block flagged as shoreline');
+if (out.water && out.water.attrCap < out.water.instances) fails.push('aWater smaller than instance count');
 if (out.noNormalMap && out.noNormalMap.length) fails.push('no normal/roughness map on: ' + out.noNormalMap.join(', '));
 const real = errors.filter((e) => !/favicon|supabase/i.test(e));
 if (real.length) fails.push(real.length + ' page errors: ' + real[0]);


### PR DESCRIPTION
Tier 1 (performance) and Tier 2 (rendering) for the Block Craft **Modern** skin. Smooth and Classic are untouched — every change is behind `MODERN`, except the instance bookkeeping, which is skin-agnostic and benefits all three.

## Measured

Same harness, same scene, `scripts/bc-verify.mjs`:

| | before | after |
|---|---|---|
| ms per block edit | 0.211 | **0.004** (53x) |
| ms per grass dig | 21.3 | **0.008** |
| instances drawn at spawn | 24,199 | **20,098** |
| sun ball vs light (dot) | -0.269 | **1.000** |
| build blocks on PBR surfaces | 0/17 | **17/17** |
| `initScene` | — | 218ms (was 428ms at full-res derivation) |
| texture memory | — | 15MB (was 28MB) |

## Tier 1 — performance

- **O(1) block edits.** `rebuild(type)` used to scan every loaded block (~130k entries, each with a `split(',').map(Number)`) to find one type, so editing got slower the more you had built. Now the map maintains a `type -> Set(key)` index, and instance slots are tracked so an edit patches its own slot plus at most six neighbours' in place. Bulk paths still use `rebuild()`, which stays authoritative.
- **Partial buffer uploads** (r170 `addUpdateRange` / r128 `updateRange`), full upload on any freshly allocated buffer.
- **Hidden-face culling**, Modern only, restricted to the flat `REAL_GROUND` set — the craft blocks keep their 0.07 bevel and would show gaps. Below `MIN_Y` counts as covered, so the bedrock layer drops out.
- **Tufts rebuild once per frame** instead of once per `flush()` (which runs several times a frame).

## Tier 2 — rendering

- **The sun was broken.** The visible ball was nailed to world (70,60,-80) while the light shone from player+(40,80,25) — shadows pointed ~106 degrees away from it, and it drifted off after a walk. Now on the light's own ray, fog-exempt, lowered 59.5 -> 35.6 degrees for raking shadows, shadow box widened 40 -> 55 to fit them.
- **`shadow.normalBias` 0.5 -> 0.06.** The old value erased block-seam contact shadows along with the acne it targeted.
- **Normal + roughness maps derived** from the same canvas each texture is painted on (Sobel over luminance / inverse luminance), at half resolution. No assets.
- **Four new crafted surfaces** — plank, brick, plaster, glasspane — routed by `def.pat`, so the plank slab, plank stair, brick wedge and glass pane inherit the surface of the cube they're cut from. Glow blocks stay on `makeBlockMaterial`; their emissive is hand-balanced against ACES.
- **GTAO tuned to voxel scale** (radius 0.75 world units, thickness 1.0, samples 12, denoise depthPhi 0.5), API verified against the vendored `GTAOPass.js`.
- **Water** gets depth, fresnel and a shoreline foam collar via a per-instance `aWater` attribute.

## Verification

New `scripts/bc-verify.mjs` drives the real game in headless Chrome: 0 instances drawn for dead blocks, **0 visible blocks missing an instance across 7,425 sampled cells**, dig-reveals-neighbour, sun/light alignment, 17/17 PBR maps, and water shoreline/depth flags exact on a purpose-built test pond.

`npm run smoke` (7 games control standard + 11 games placement) and `npm run lint` pass.

## Known limits

- Everything was verified under **headless SwiftShader, not a real GPU**. Partial buffer uploads and normal maps are exactly what mobile drivers get wrong — worth a look on an actual tablet.
- The water shader compiles and its per-instance data is correct, but the water has **not been seen rendered** — `ABC.teleport` doesn't stick in the harness.
- The culling gain (24,199 -> 20,098) is the flat spawn meadow; the mountain and canyon regions, where columns run 20-30 deep, are unmeasured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)