### PR TITLE
Block Craft: one cycling Look button + bump the cache-bust so the Modern work actually ships

### DIFF
--- a/public/blockcraft/index.html
+++ b/public/blockcraft/index.html
@@ -468,23 +468,26 @@ try{
   <button class="bigBtn green" id="playBtn">▶ Play!</button>
   <div style="display:flex; gap:14px; flex-wrap:wrap; justify-content:center;">
     <button class="bigBtn" id="howBtn" style="font-size:20px; padding:12px 30px;">❓ How to Play</button>
-    <div style="display:flex; gap:12px; justify-content:center; flex-wrap:wrap; margin-top:4px;">
-      <button class="bigBtn skin-selector" data-skin="modern" style="font-size:20px; padding:12px 28px; border:3px solid #1fb4a6;">✨ Modern</button>
-      <button class="bigBtn skin-selector" data-skin="smooth" style="font-size:20px; padding:12px 28px;">🌤️ Smooth</button>
-      <button class="bigBtn skin-selector" data-skin="classic" style="font-size:20px; padding:12px 28px;">🧱 Classic</button>
-    </div>
+    <button class="bigBtn" id="skinBtn" style="font-size:20px; padding:12px 30px;">🎨 Look: Modern ✨</button>
     <button class="bigBtn" id="fsTitleBtn" style="font-size:20px; padding:12px 30px;">⛶ Full Screen</button>
     <button class="bigBtn" id="titleMovieBtn" style="font-size:20px; padding:12px 30px; display:none;">▶️ My Movie — watch your world grow!</button>
     <button class="bigBtn" id="titleVisitBtn" style="font-size:20px; padding:12px 30px;">📥 Visit a friend's world</button>
     <button class="bigBtn" id="titleLangBtn" data-abe="lang" style="font-size:18px; padding:10px 24px;">🌐 Español</button>
     <script>
-      document.querySelectorAll('.skin-selector').forEach(btn => {
-        btn.addEventListener('click', function() {
-          const skin = this.dataset.skin;
-          try { localStorage.setItem('abcSkin', skin); } catch(e) {}
+      /* One cycling button instead of three fixed ones — Modern → Smooth →
+         Classic → Modern. main.js re-labels and re-binds this the moment it
+         loads; this stub only exists so an early tap during the script chain
+         isn't swallowed. */
+      (function () {
+        var b = document.getElementById('skinBtn');
+        if (!b) return;
+        var ORDER = ['modern', 'smooth', 'classic'];
+        var cur = window.__ABC_SKIN || 'modern';
+        b.onclick = function () {
+          try { localStorage.setItem('abcSkin', ORDER[(ORDER.indexOf(cur) + 1) % ORDER.length]); } catch (e) {}
           location.reload();
-        });
-      });
+        };
+      })();
     </script>
   </div>
   <div id="skinHint" style="font-size:14px; color:#2b517d; background:rgba(255,255,255,.55); padding:6px 16px; border-radius:14px; max-width:520px;">✨ <b>Modern</b> is our newest look — sharper lighting and richer detail (still being polished!).</div>
@@ -585,7 +588,7 @@ document.addEventListener('DOMContentLoaded', function () {
     if (howBtn) howBtn.textContent = ABELang.t(howBtn.textContent);
     var fsTitleBtn = document.getElementById('fsTitleBtn');
     if (fsTitleBtn) fsTitleBtn.textContent = ABELang.t(fsTitleBtn.textContent);
-    document.querySelectorAll('.skin-selector').forEach(function (b) { b.textContent = ABELang.t(b.textContent); });
+    // #skinBtn is labelled by main.js labelSkinBtn(), which translates itself
     var titleVisitBtn = document.getElementById('titleVisitBtn');
     if (titleVisitBtn) titleVisitBtn.textContent = ABELang.t(titleVisitBtn.textContent);
     var skinHint = document.getElementById('skinHint');
@@ -614,7 +617,7 @@ document.addEventListener('DOMContentLoaded', function () {
    window.__ABC_SKIN so js/world.js derives ABC.SKIN/MODERN/SMOOTH from the
    exact same value. Modern is the new default. */
 (function () {
-  var V = 43;                                   // cache-bust for all game scripts
+  var V = 44;                                   // cache-bust for all game scripts
   var skin = null;
   try { skin = localStorage.getItem('abcSkin'); } catch (e) {}
   if (skin !== 'modern' && skin !== 'smooth' && skin !== 'classic') skin = 'modern';

--- a/public/blockcraft/js/lang-es.js
+++ b/public/blockcraft/js/lang-es.js
@@ -91,6 +91,17 @@
     '✨ Modern': '✨ Moderno',
     '🌤️ Smooth': '🌤️ Suave',
     '🧱 Classic': '🧱 Clásico',
+    /* the one cycling "Look" button on the title screen + its hint line */
+    '🎨 Look:': '🎨 Estilo:',
+    'Modern ✨': 'Moderno ✨',
+    'Smooth': 'Suave',
+    'Classic': 'Clásico',
+    '✨ <b>Modern</b> is our newest look — sharper lighting and richer detail (still being polished!).':
+      '✨ <b>Moderno</b> es nuestro estilo más nuevo — luz más nítida y más detalle (¡todavía en mejora!).',
+    '✨ <b>Smooth</b> gives soft, rounded blocks, gentle shadows &amp; a tidy, spacious layout — a calmer, more polished world.':
+      '✨ <b>Suave</b> te da bloques redondeados, sombras suaves y todo más ordenado — un mundo más tranquilo y pulido.',
+    '🧱 <b>Classic</b> is the original blocky look — simple, fast and familiar.':
+      '🧱 <b>Clásico</b> es el look original de bloques — simple, rápido y de siempre.',
     '📥 Visit a friend\'s world': '📥 Visitar el mundo de un amigo',
     'General Disclosure': 'Aviso General',
 

--- a/public/blockcraft/js/main.js
+++ b/public/blockcraft/js/main.js
@@ -1247,8 +1247,11 @@
   ABC.nextSkin = nextSkin;
   ABC.skinDisplay = skinDisplay;
   function labelSkinBtn() {
-    const b = $('skinBtn'); if (b) b.textContent = '🎨 Look: ' + skinTitleLabel(currentSkin());
-    const h = $('skinHint'); if (h) h.innerHTML = SKIN_HINT[currentSkin()] || SKIN_HINT.modern;
+    // built from translatable pieces: this runs after the title screen's own
+    // Spanish pass, so it has to translate itself or it reverts the page to English
+    const t = (s) => (window.ABELang ? ABELang.t(s) : s);
+    const b = $('skinBtn'); if (b) b.textContent = t('🎨 Look:') + ' ' + t(skinTitleLabel(currentSkin()));
+    const h = $('skinHint'); if (h) h.innerHTML = t(SKIN_HINT[currentSkin()] || SKIN_HINT.modern);
   }
   ABC.setSkin = (skin) => {
     try { localStorage.setItem('abcSkin', (skin === 'smooth' || skin === 'classic') ? skin : 'modern'); } catch (e) {}


### PR DESCRIPTION
## 1. One skin button instead of three

The title screen carried three fixed buttons (Modern / Smooth / Classic) taking about a third of the row. `main.js` has had the cycling single-button code all along — `#skinBtn`, `labelSkinBtn()`, `toggleSkin()` — `index.html` just never used it.

Now it's one **🎨 Look: Modern ✨** button that cycles Modern → Smooth → Classic. Visible title buttons drop from 8 to 6.

A small inline stub keeps the button live during the sequential script chain, so an early tap isn't swallowed before `main.js` binds it.

**Bilingual** (per CLAUDE.md): `labelSkinBtn()` runs *after* the title screen's own Spanish pass, so it now translates itself instead of reverting the page to English. Added ES for the button, the three skin names, and all three hint lines — the hints were English-only before, because `main.js` overwrote the translated markup.

Verified in a real browser:

| | EN | ES |
|---|---|---|
| button | `🎨 Look: Modern ✨` | `🎨 Estilo: Moderno ✨` |
| hint | "…our newest look — sharper lighting…" | "…nuestro estilo más nuevo — luz más nítida…" |

## 2. The previous deploy wasn't reaching anyone

Game scripts load as `js/world.js?v=43`, and `sw.js` caches `/blockcraft/` stale-while-revalidate with `ignoreSearch: true`. With the URL unchanged, the service worker's background refresh could itself be served from the HTTP cache — so the SW cache would never take the new bytes, and #247's Modern-skin work would stay invisible indefinitely.

`V` 43 → 44 forces a real fetch, so the new code lands on the next load. This was my miss on #247.

Note this repo's SW is deliberately stale-while-revalidate for offline play, so returning players see new game code on their **second** load. I did not bump `CACHE` in `sw.js` (that would purge every game's offline cache and force a full re-download for all users) — say the word if you'd rather have first-load freshness.

`npm run smoke` and `npm run lint` pass; `scripts/bc-verify.mjs` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)